### PR TITLE
add kata-operator-payload dockerfiles

### DIFF
--- a/images/payload/CentOS-8-Virt-SIG-Advanced-Virtualization.repo
+++ b/images/payload/CentOS-8-Virt-SIG-Advanced-Virtualization.repo
@@ -1,0 +1,5 @@
+[centos-8-sig-virt-advanced-virtualization]
+name=CentOS 8 - SIG Virt - Advanced Virtualization
+baseurl=http://mirror.centos.org/$contentdir/$releasever/virt/$basearch/advanced-virtualization
+gpgcheck=0
+enabled=1

--- a/images/payload/CentOS-8-Virt-SIG-Kata-Containers.repo
+++ b/images/payload/CentOS-8-Virt-SIG-Kata-Containers.repo
@@ -1,0 +1,5 @@
+[centos-8-sig-virt-kata-containers]
+name=CentOS 8 - SIG Virt - Kata Containers
+baseurl=http://mirror.centos.org/$contentdir/$releasever/virt/$basearch/kata-containers
+gpgcheck=0
+enabled=1

--- a/images/payload/Dockerfile
+++ b/images/payload/Dockerfile
@@ -1,0 +1,49 @@
+FROM centos:8.2.2004 as katapackages
+
+ADD CentOS-8-Virt-SIG-Advanced-Virtualization.repo /etc/yum.repos.d/CentOS-8-Virt-SIG-Advanced-Virtualization.repo
+ADD CentOS-8-Virt-SIG-Kata-Containers.repo /etc/yum.repos.d/CentOS-8-Virt-SIG-Kata-Containers.repo
+
+WORKDIR /usr/src/kata-containers
+
+#Call `dnf install` early like this, otherwise the successful transaction would
+#cleanup the packages downloaded, down in this file.
+RUN dnf install -y createrepo
+RUN mkdir packages
+
+RUN dnf module disable -y virt:rhel
+
+RUN dnf install -y --downloadonly --downloaddir=/usr/src/kata-containers/packages \
+    qemu-kvm
+
+#Needed as these packages are installed by default on CentOS:8.2.2004, while
+#they're **not** #present on a RHCOS installation 
+RUN dnf reinstall -y --downloadonly --downloaddir=/usr/src/kata-containers/packages \
+    snappy \
+    lzo
+
+RUN dnf install -y --downloadonly --downloaddir=/usr/src/kata-containers/packages \
+    kata-runtime \
+    kata-osbuilder
+
+#We don't need kata-shim installed on OpenShift
+RUN rm /usr/src/kata-containers/packages/kata-shim*.rpm
+
+RUN ls -lR /usr/src/kata-containers/
+RUN createrepo /usr/src/kata-containers/packages
+
+COPY . .
+
+############################
+# STEP 2 build a small image
+############################
+FROM scratch
+
+WORKDIR /
+# Copy our static executable.
+
+COPY --from=katapackages /usr/src/kata-containers/packages  packages/
+
+COPY packages.repo .
+COPY kata-cleanup.sh .
+
+

--- a/images/payload/Dockerfile.custom
+++ b/images/payload/Dockerfile.custom
@@ -1,0 +1,29 @@
+FROM centos:8.2.2004 as katapackages
+
+ADD CentOS-8-Virt-SIG-Advanced-Virtualization.repo /etc/yum.repos.d/CentOS-8-Virt-SIG-Advanced-Virtualization.repo
+ADD CentOS-8-Virt-SIG-Kata-Containers.repo /etc/yum.repos.d/CentOS-8-Virt-SIG-Kata-Containers.repo
+WORKDIR /usr/src/kata-containers
+ADD packages/ packages
+
+#Call `dnf install` early like this, otherwise the successful transaction would
+#cleanup the packages downloaded, down in this file.
+RUN dnf install -y createrepo
+
+RUN ls -lR /usr/src/kata-containers/
+RUN createrepo /usr/src/kata-containers/packages
+
+COPY . .
+
+############################
+# STEP 2 build a small image
+############################
+FROM scratch
+
+WORKDIR /
+
+COPY --from=katapackages /usr/src/kata-containers/packages  packages/
+
+COPY packages.repo .
+COPY kata-cleanup.sh .
+
+

--- a/images/payload/README.md
+++ b/images/payload/README.md
@@ -1,0 +1,5 @@
+# kata-operator-payload
+
+A container image used by kata-operator to install Kata and dependencies (like QEMU...) on worker nodes.
+During podman build the rpms are downloaded and a local repo is created. The resulting container image includes the rpms.
+The kata-operat-daemon pulls down this image unpacks it and installs it on the node where it is running. 

--- a/images/payload/README.md
+++ b/images/payload/README.md
@@ -1,5 +1,5 @@
 # kata-operator-payload
 
 A container image used by kata-operator to install Kata and dependencies (like QEMU...) on worker nodes.
-During podman build the rpms are downloaded and a local repo is created. The resulting container image includes the rpms.
+During container build (e.g., podman, docker, etc), the RPMs are downloaded and a local repo is created. The resulting container image includes the RPMs.
 The kata-operat-daemon pulls down this image unpacks it and installs it on the node where it is running. 

--- a/images/payload/hack/deploy.sh
+++ b/images/payload/hack/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -xe
+
+IMAGE_NAME="quay.io/isolatedcontainers/kata-operator-payload"
+
+if "${TRAVIS_BRANCH}" == "master"; then
+	TAG="latest"
+else
+	TAG="$(echo ${TRAVIS_BRANCH} | awk '{print $2}' FS='-')"
+fi
+
+docker login \
+	--username="${QUAY_USERNAME}" \
+	--password="${QUAY_PASSWORD}" \
+	quay.io
+
+docker buildx build \
+	--push \
+	--platform="linux/amd64,linux/ppc64le,linux/s390x" \
+	--tag "${IMAGE_NAME}:${TAG}" \
+	.

--- a/images/payload/hack/docker-client.json
+++ b/images/payload/hack/docker-client.json
@@ -1,0 +1,3 @@
+{
+    "experimental": "enabled"
+}

--- a/images/payload/hack/docker-daemon.json
+++ b/images/payload/hack/docker-daemon.json
@@ -1,0 +1,3 @@
+{
+    "experimental": true
+}

--- a/images/payload/hack/prepare.sh
+++ b/images/payload/hack/prepare.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -xe
+
+# Install the latest version of Docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
+# Enable experimental features for the Docker client
+mkdir -p ~/.docker
+cp hack/docker-client.json ~/.docker/config.json
+
+# Enable experimental features for the Docker daemon
+sudo cp hack/docker-daemon.json /etc/docker/daemon.json
+sudo systemctl restart docker
+
+# Install the buildx Docker plugin
+DOCKER_BUILDKIT=1 docker build --platform=local -o . git://github.com/docker/buildx
+mkdir -p ~/.docker/cli-plugins
+mv buildx ~/.docker/cli-plugins/docker-buildx
+
+# Set up the cross-architecture build environment
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --use
+docker buildx inspect --bootstrap

--- a/images/payload/kata-cleanup.sh
+++ b/images/payload/kata-cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+DIR="${1:-/opt/kata-install}"
+cd $DIR
+
+
+echo "====================================================="
+echo "Uninstall all kata-packages"
+echo "====================================================="
+rpm-ostree uninstall --idempotent --all
+if rpm-ostree override reset -a; then
+	echo "rpm-ostree override reset -a failed"
+fi
+
+echo "====================================================="
+echo "removing files in install directory"
+echo "====================================================="
+rm -rf /usr/local/kata* /opt/kata-*
+
+echo "====================================================="
+echo "reboot node"
+echo "====================================================="
+systemctl reboot

--- a/images/payload/packages.repo
+++ b/images/payload/packages.repo
@@ -1,0 +1,7 @@
+[packages]
+name=Local kata packages and dependencies repository
+baseurl=file:///opt/kata-install/packages
+enabled=1
+gpgcheck=0
+protect=1
+


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
It builds a container image with the kata-* and QEMU (plus
dependencies) RPMs in it. The kata-operator-daemon when running
on the worker nodes downloads this image and then installs
the RPMs it contains.

**- What I did**
This is a 1:1 copy from the release-4.6 branch
(commit 4765c70)

**- How to verify it**
The dockerfile can be used to build the container with podman build.
The build should finish succesfully. The payload image can be tested by
using the payload configmap to make the operator use it. 
