### PR TITLE
Update example-fedora.yaml

### DIFF
--- a/deploy/example-fedora.yaml
+++ b/deploy/example-fedora.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: example-fedora
-      image: fedora:30
+      image: registry.fedoraproject.org/fedora:latest
       ports:
         - containerPort: 8080
       command: ["python3"]


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

The Fedora example is problematic to test with.  As is fairly common, I hit image pull limits from the default registry.

The three things to update in the one line in the file:
- use a fully qualified container name.  This avoids the typosquatting issue when multiple public registries are in the search path.
- switch to specifically use the fedora registry for the fedora image
- switch to the latest image tag to avoid bit rot from referencing old images


I noticed this example file is only present in release-4.6 branch (not master or release-4.7).


**- What I did**

Updated the image definition.

**- How to verify it**

"oc apply" the yaml and confirm the pod launches


**- Description for the changelog**

Update fedora-example.yaml to use fully qualified container name.

