### PR TITLE
controller: update ignition version

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -25,7 +25,7 @@ import (
 	"text/template"
 	"time"
 
-	ignTypes "github.com/coreos/ignition/config/v2_2/types"
+	ignTypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-logr/logr"
 	kataconfigurationv1 "github.com/openshift/kata-operator/api/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -307,27 +307,27 @@ WantedBy=multi-user.target
 	}
 
 	file := ignTypes.File{}
-	c := ignTypes.FileContents{}
+	c := file.Contents
 
 	dropinConf, err := generateDropinConfig(r.kataConfig.Status.RuntimeClass)
 	if err != nil {
 		return nil, err
 	}
 
-	c.Source = "data:text/plain;charset=utf-8;base64," + dropinConf
+	dropinFile := "data:text/plain;charset=utf-8;base64," + dropinConf
+	c.Source = &dropinFile
 	file.Contents = c
-	file.Filesystem = "root"
 	m := 420
 	file.Mode = &m
 	file.Path = "/etc/crio/crio.conf.d/50-kata.conf"
 
 	ic := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
-			Version: "2.2.0",
+			Version: "3.2.0",
 		},
 		Systemd: ignTypes.Systemd{
 			Units: []ignTypes.Unit{
-				{Name: name, Enabled: &isenabled, Contents: content},
+				{Name: name, Enabled: &isenabled, Contents: &content},
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/openshift/kata-operator
 go 1.13
 
 require (
-	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
-	github.com/coreos/ignition v0.35.0
+	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/monopole/mdrip v1.0.1


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
The controller is still using ignition v2 which is deprecated.

**- What I did**
Switch to ignition v2.9.0 and spec 3.2. This required minor changes as
data structures in ignition have changed.

**- How to verify it**
Install the operator and make sure the machine config is created and places the
crio config file correctly on the worker nodes.

**- Description for the changelog**
use ignition v3 instead of deprecated v2

Fixes: #23

Signed-off-by: Jens Freimann <jfreimann@redhat.com>
