### PR TITLE
Use fqdn for node names

### DIFF
--- a/images/daemon/go.mod
+++ b/images/daemon/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/kata-operator-daemon
 go 1.13
 
 require (
+	github.com/Showmax/go-fqdn v1.0.0
 	github.com/containers/image/v5 v5.5.1
 	github.com/coreos/go-semver v0.3.0
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/images/daemon/go.sum
+++ b/images/daemon/go.sum
@@ -71,6 +71,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=

--- a/images/daemon/pkg/daemon/kata_actions.go
+++ b/images/daemon/pkg/daemon/kata_actions.go
@@ -3,11 +3,11 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	kataTypes "github.com/openshift/kata-operator/api/v1"
 
+	"github.com/Showmax/go-fqdn"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -59,7 +59,7 @@ func getFailedNode(err error) (fn kataTypes.FailedNodeStatus, retErr error) {
 }
 
 func getHostName() (string, error) {
-	hostname, err := os.Hostname()
+	hostname, err := fqdn.FqdnHostname()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #68

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #68 "

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Fixes failed uninstall of Kata runtime when Kata is installed on specific nodes

**- What I did**
Used fqdn for nodename instead of host name

**- How to verify it**
Build the kata-operator-daemon and push the image to registry. Thereafter modify kata-operator to use the kata-operator-daemon image and go through the install/uninstall cycle

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use FQDN for nodename