### PR TITLE
Use 4.8 operator image in deploy.yaml

### DIFF
--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -506,7 +506,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/isolatedcontainers/kata-operator:4.7
+        image: quay.io/isolatedcontainers/kata-operator:4.8
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
This will eventually become the release-4.8 branch, let's start using the 4.8 operator image by default.

