### PR TITLE
Makefile: `make docker-push` should use podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ docker-build: test
 docker-push:
 	docker push ${IMG}
 
+# Build the docker image, using podman
+podman-build: test
+	podman build --squash-all --no-cache . -t ${IMG}
+
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ vet:
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-# Build the docker image
+# Build the docker image, using docker
 docker-build: test
 	docker build . -t ${IMG}
 
-# Push the docker image
+# Push the docker image, using docker
 docker-push:
 	docker push ${IMG}
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	podman build --squash-all --no-cache . -t ${IMG}
+	docker build . -t ${IMG}
 
 # Push the docker image
 docker-push:

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ docker-push:
 podman-build: test
 	podman build --squash-all --no-cache . -t ${IMG}
 
+# Push the docker image, using podman
+podman-push:
+	podman push ${IMG}
+
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Container image name | Description | Container repository
 # Build from source
 
 1. Install operator-sdk version 1.0 or above
-2. make docker-build docker-push IMG=quay.io/<yourusername>/sandboxed-containers-operator:<tag>
+2. make podman-build podman-push IMG=quay.io/<yourusername>/sandboxed-containers-operator:<tag>


### PR DESCRIPTION
Although the subject line may be confused, we should aim for fully using
podman or docker, consistently. :-)

In order to do so, let's go for "docker" rather than "podman" and do the
switch of `make docker-push` to do a `podman push` rather than `docker
push`.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
