### PR TITLE
controller: The service should be enabled by the OS

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -147,20 +147,6 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 }
 
 func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {
-	isenabled := true
-	name := "kata-osbuilder-generate.service"
-	content := `
-[Unit]
-Description=Hacky service to enable kata-osbuilder-generate.service
-ConditionPathExists=/usr/lib/systemd/system/kata-osbuilder-generate.service
-[Service]
-Type=oneshot
-ExecStart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
-ExecRestart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
-[Install]
-WantedBy=multi-user.target
-`
-
 	kataOC, err := r.kataOcExists()
 	if err != nil {
 		return nil, err
@@ -191,11 +177,6 @@ WantedBy=multi-user.target
 	ic := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
 			Version: "3.2.0",
-		},
-		Systemd: ignTypes.Systemd{
-			Units: []ignTypes.Unit{
-				{Name: name, Enabled: &isenabled, Contents: &content},
-			},
 		},
 	}
 	ic.Storage.Files = []ignTypes.File{file}


### PR DESCRIPTION
`kata-osbuilder-generate.service` should be part of the RHCOS preset,
making it "enabled" by default whenever it's present / installed.

With that in mind, we can remove this logic from the operator and rely
on the OS to do the right thing for us.

Please, for more information about the work done on RHCOS side, refer
to: https://bugzilla.redhat.com/show_bug.cgi?id=1941342

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
