### PR TITLE
controller: The CRI-O drop-in file should be provided by the RPM

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -17,12 +17,9 @@ limitations under the License.
 package controllers
 
 import (
-	"bytes"
 	"context"
-	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"k8s.io/apimachinery/pkg/labels"
 	"time"
 
@@ -158,28 +155,11 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 		r.Log.Error(err, "no valid role for mc found")
 	}
 
-	file := ignTypes.File{}
-	c := file.Contents
-
-	dropinConf, err := generateDropinConfig(r.kataConfig.Status.RuntimeClass)
-	if err != nil {
-		return nil, err
-	}
-
-	dropinFile := "data:text/plain;charset=utf-8;base64," + dropinConf
-	c.Source = &dropinFile
-
-	file.Contents = c
-	m := 420
-	file.Mode = &m
-	file.Path = "/etc/crio/crio.conf.d/50-kata.conf"
-
 	ic := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
 			Version: "3.2.0",
 		},
 	}
-	ic.Storage.Files = []ignTypes.File{file}
 
 	icb, err := json.Marshal(ic)
 	if err != nil {
@@ -191,14 +171,6 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 			APIVersion: "machineconfiguration.openshift.io/v1",
 			Kind:       "MachineConfig",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "50-enable-sandboxed-containers-extension",
-			Labels: map[string]string{
-				"machineconfiguration.openshift.io/role": machinePool,
-				"app":                                    r.kataConfig.Name,
-			},
-			Namespace: "sandboxed-containers-operator",
-		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"sandboxed-containers"},
 			Config: runtime.RawExtension{
@@ -208,37 +180,6 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 	}
 
 	return &mc, nil
-}
-
-func generateDropinConfig(handlerName string) (string, error) {
-	var err error
-	buf := new(bytes.Buffer)
-	type RuntimeConfig struct {
-		RuntimeName string
-	}
-	const b = `
-[crio.runtime]
-  manage_ns_lifecycle = true
-
-[crio.runtime.runtimes.{{.RuntimeName}}]
-  runtime_path = "/usr/bin/containerd-shim-kata-v2"
-  runtime_type = "vm"
-  runtime_root = "/run/vc"
-  privileged_without_host_devices = true
-  
-[crio.runtime.runtimes.runc]
-  runtime_path = ""
-  runtime_type = "oci"
-  runtime_root = "/run/runc"
-`
-	c := RuntimeConfig{RuntimeName: "kata"}
-	t := template.Must(template.New("test").Parse(b))
-	err = t.Execute(buf, c)
-	if err != nil {
-		return "", err
-	}
-	sEnc := b64.StdEncoding.EncodeToString([]byte(buf.String()))
-	return sEnc, err
 }
 
 func (r *KataConfigOpenShiftReconciler) addFinalizer() error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -147,20 +147,6 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 }
 
 func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {
-	isenabled := true
-	name := "kata-osbuilder-generate.service"
-	content := `
-[Unit]
-Description=Hacky service to enable kata-osbuilder-generate.service
-ConditionPathExists=/usr/lib/systemd/system/kata-osbuilder-generate.service
-[Service]
-Type=oneshot
-ExecStart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
-ExecRestart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
-[Install]
-WantedBy=multi-user.target
-`
-
 	kataOC, err := r.kataOcExists()
 	if err != nil {
 		return nil, err
@@ -191,11 +177,6 @@ WantedBy=multi-user.target
 	ic := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
 			Version: "3.2.0",
-		},
-		Systemd: ignTypes.Systemd{
-			Units: []ignTypes.Unit{
-				{Name: name, Enabled: &isenabled, Contents: &content},
-			},
 		},
 	}
 	ic.Storage.Files = []ignTypes.File{file}


### PR DESCRIPTION
Instead of having the logic of the CRI-O drop-in file in the operator,
let's just rely on it being distributed by the `kata-containers` RPM.

This is done because that file only makes sense in a system where
`kata-containers` RPM is installed, because that file is only used in a
system where `kata-containers` RPM is installed.  So, leave it for the
RPM to take care of that and let's make our lives simpler on the
operator side.
