### PR TITLE
added pre-req for kataconfig deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ oc apply -f config/samples/example-fedora.yaml
 ## Uninstall
 
 ### Openshift
+Prior to deletion of your kataconfig, it is expected that all existing pods that use kata runtime have been removed.
+The `oc delete` operation will fail if there are pods in the cluster that are still referencing the kata runtime.
+
+
 ```
 oc delete kataconfig <KataConfig_CR_Name>
 ```


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**
The current uninstall kata-runtime is missing the requirement that all existing pod in the cluster that use kata must be removed.

**- What I did**
added instruction about the pods removal requirement

**- Description for the changelog**

The current uninstall kata-runtime is missing the requirement that all existing pod in the cluster that use kata must be removed.