### PR TITLE
Pod Overhead: increase memory to 350Mi

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -549,7 +549,7 @@ func (r *KataConfigOpenShiftReconciler) setRuntimeClass() (ctrl.Result, error) {
 			Overhead: &nodeapi.Overhead{
 				PodFixed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("250m"),
-					corev1.ResourceMemory: resource.MustParse("160Mi"),
+					corev1.ResourceMemory: resource.MustParse("350Mi"),
 				},
 			},
 		}


### PR DESCRIPTION
Current Pod overhead memory is set to 160Mi.
Creating a simple Pod with and without the kata runtimeClass will show an accounted memory difference of 300Mi in the OpenShift console. As the memory usage due to the VM operations is dynamic and may easily increase (e.g., for fs caching) a sane value for the Pod overhead memory should be a bit more than that:  let's set it to 350Mi.

