### PR TITLE
inform user if kata uninstallation is blocked by existing kata-based …

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -152,6 +152,13 @@ type KataUnInstallationStatus struct {
 
 	// Failed reflects the status of nodes that have failed kata uninstallation
 	Failed KataFailedNodeStatus `json:"failed,omitempty"`
+
+	// Stores an error message if any.  Note that this is currently meant for a single
+	// failure source when kata uninstallation is blocked by existing kata-based pods, so
+	// handling of this field in the controller code is correspondingly simple.  A review
+	// might be necessary if this field were ever to store messages coming from another
+	// source.
+	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
 // KataUnInstallationInProgressStatus reflects the status of nodes that are in the process of kata installation

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -226,6 +226,9 @@ spec:
                       inProgressNodesCount:
                         type: integer
                     type: object
+                  errorMessage:
+                    description: Cause of uninstallation failure
+                    type: string
                 type: object
               upgradeStatus:
                 description: Upgradestatus reflects the status of the ongoing kata

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -398,7 +398,20 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		// Get the list of pods that might be running using kata runtime
 		err := r.listKataPods()
 		if err != nil {
+			r.kataConfig.Status.UnInstallationStatus.ErrorMessage = err.Error()
+			updErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+			if updErr != nil {
+				return ctrl.Result{}, updErr
+			}
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		} else {
+			if r.kataConfig.Status.UnInstallationStatus.ErrorMessage != "" {
+				r.kataConfig.Status.UnInstallationStatus.ErrorMessage = ""
+				updErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+				if updErr != nil {
+					return ctrl.Result{}, updErr
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
…pods

If user requests uninstallation of Kata by deleting their KataConfig
instance, the request cannot be fulfilled if there still are pods that use
Kata as runtime.  So far, the controller logged a message on detecting this
condition but since the message went to the controller log it wasn't very
well visible or discoverable.

This change creates a new field in KataConfig status to communicate the
error to the user more effectively.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
