### PR TITLE
machine-config needs a name

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -171,6 +171,14 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 			APIVersion: "machineconfiguration.openshift.io/v1",
 			Kind:       "MachineConfig",
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "50-enable-sandboxed-containers-extension",
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": machinePool,
+				"app":                                    r.kataConfig.Name,
+			},
+			Namespace: "openshift-sandboxed-containers",
+		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"sandboxed-containers"},
 			Config: runtime.RawExtension{


### PR DESCRIPTION
This was removed by accident and missed in code review for pr #81. Let's put it
back and also change the namespace name to our default one. 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

