### PR TITLE
controller: The CRI-O drop-in file should be provided by the RPM

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -17,12 +17,9 @@ limitations under the License.
 package controllers
 
 import (
-	"bytes"
 	"context"
-	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"k8s.io/apimachinery/pkg/labels"
 	"time"
 
@@ -172,22 +169,6 @@ WantedBy=multi-user.target
 		r.Log.Error(err, "no valid role for mc found")
 	}
 
-	file := ignTypes.File{}
-	c := file.Contents
-
-	dropinConf, err := generateDropinConfig(r.kataConfig.Status.RuntimeClass)
-	if err != nil {
-		return nil, err
-	}
-
-	dropinFile := "data:text/plain;charset=utf-8;base64," + dropinConf
-	c.Source = &dropinFile
-
-	file.Contents = c
-	m := 420
-	file.Mode = &m
-	file.Path = "/etc/crio/crio.conf.d/50-kata.conf"
-
 	ic := ignTypes.Config{
 		Ignition: ignTypes.Ignition{
 			Version: "3.2.0",
@@ -198,7 +179,6 @@ WantedBy=multi-user.target
 			},
 		},
 	}
-	ic.Storage.Files = []ignTypes.File{file}
 
 	icb, err := json.Marshal(ic)
 	if err != nil {
@@ -210,14 +190,6 @@ WantedBy=multi-user.target
 			APIVersion: "machineconfiguration.openshift.io/v1",
 			Kind:       "MachineConfig",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "50-enable-sandboxed-containers-extension",
-			Labels: map[string]string{
-				"machineconfiguration.openshift.io/role": machinePool,
-				"app":                                    r.kataConfig.Name,
-			},
-			Namespace: "sandboxed-containers-operator",
-		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"sandboxed-containers"},
 			Config: runtime.RawExtension{
@@ -227,37 +199,6 @@ WantedBy=multi-user.target
 	}
 
 	return &mc, nil
-}
-
-func generateDropinConfig(handlerName string) (string, error) {
-	var err error
-	buf := new(bytes.Buffer)
-	type RuntimeConfig struct {
-		RuntimeName string
-	}
-	const b = `
-[crio.runtime]
-  manage_ns_lifecycle = true
-
-[crio.runtime.runtimes.{{.RuntimeName}}]
-  runtime_path = "/usr/bin/containerd-shim-kata-v2"
-  runtime_type = "vm"
-  runtime_root = "/run/vc"
-  privileged_without_host_devices = true
-  
-[crio.runtime.runtimes.runc]
-  runtime_path = ""
-  runtime_type = "oci"
-  runtime_root = "/run/runc"
-`
-	c := RuntimeConfig{RuntimeName: "kata"}
-	t := template.Must(template.New("test").Parse(b))
-	err = t.Execute(buf, c)
-	if err != nil {
-		return "", err
-	}
-	sEnc := b64.StdEncoding.EncodeToString([]byte(buf.String()))
-	return sEnc, err
 }
 
 func (r *KataConfigOpenShiftReconciler) addFinalizer() error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -190,6 +190,14 @@ WantedBy=multi-user.target
 			APIVersion: "machineconfiguration.openshift.io/v1",
 			Kind:       "MachineConfig",
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "50-enable-sandboxed-containers-extension",
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": machinePool,
+				"app":                                    r.kataConfig.Name,
+			},
+			Namespace: "openshift-sandboxed-containers",
+		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"sandboxed-containers"},
 			Config: runtime.RawExtension{


### PR DESCRIPTION
Instead of having the logic of the CRI-O drop-in file in the operator,
let's just rely on it being distributed by the `kata-containers` RPM.

This is done because that file only makes sense in a system where
`kata-containers` RPM is installed, because that file is only used in a
system where `kata-containers` RPM is installed.  So, leave it for the
RPM to take care of that and let's make our lives simpler on the
operator side.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>


