### PR TITLE
Clean up and renames 4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 4.8.0
+VERSION ?= 1.0.0
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'
@@ -12,7 +12,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/isolatedcontainers/sandboxed-containers-operator:4.8.0
+IMG ?= quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ An operator to perform lifecycle management (install/upgrade/uninstall) of [Kata
 
 
    ```
-   git clone https://github.com/openshift/sandboxed-containers-operator 
+   git clone https://github.com/openshift/sandboxed-containers-operator
    git checkout -b master --track origin/master
    ```
 3. Install the sandboxed containers operator on the cluster,
 
    ```
-   make install && make deploy IMG=quay.io/isolatedcontainers/sandboxed-containers-operator:4.8
+   make install && make deploy IMG=quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:latest
    ```
-4. To begin the installation of the kata runtime on the cluster,
+4. To begin the installation of the kata runtime on the cluster
 
    ```
    oc create -f config/samples/kataconfiguration_v1_kataconfig.yaml
@@ -105,7 +105,7 @@ oc delete kataconfig example-kataconfig
 ### Openshift
 1. During the installation you can watch the values of the kataconfig CR. Do `watch oc describe kataconfig example-kataconfig`.
 2. To check if the nodes in the machine config pool are going through a config update watch the machine config pool resource. For this do `watch oc get mcp kata-oc`
-3. Check the logs of the sandboxed containers operator controller pod to see detailled messages about what the steps it is executing. To find out the name of the controller pod, `oc get pods -n sandboxed-containers-operator-system | grep sandboxed-containers-operator-controller-manager` and then monitor the logs of the container `manager` in that pod. 
+3. Check the logs of the sandboxed containers operator controller pod to see detailled messages about what steps it is executing. To find out the name of the controller pod, `oc get pods -n openshift-sandboxed-containers-operator | grep controller-manager` and then monitor the logs of the container `manager` in that pod.
 
 ## Components
 
@@ -114,7 +114,7 @@ The sandboxed containers operator uses three containers:
 
 Container image name | Description | Container repository
 ---------------| ----------- | ----------
- _sandboxed-containers-operator_ |  It contains the controller part of the operator that watches and manages the kataconfig custom resource. It runs as a cluster scoped container. The operator itself is build with operator-sdk. | https://quay.io/isolatedcontainers/sandboxed-containers-operator
+ _openshift-sandboxed-containers-operator_ |  It contains the controller part of the operator that watches and manages the kataconfig custom resource. It runs as a cluster scoped container. The operator itself is build with operator-sdk. | https://quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
 
 # Build from source
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,11 @@
 # Adds namespace to all resources.
-namespace: sandboxed-containers-operator-system
+namespace: openshift-sandboxed-containers-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: sandboxed-containers-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/isolatedcontainers/sandboxed-containers-operator
-  newTag: 4.8.0
+  newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: "openshift-sandboxed-containers-operator"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/config/samples/catalogsource.yaml
+++ b/config/samples/catalogsource.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/isolatedcontainers/sandboxed-containers-operator-catalog:latest
+  image: quay.io/openshift_sandboxed-containers/openshift-sandboxed-containers-catalog:latest
   displayName: Kata container Operators
   publisher: Red Hat
   updateStrategy:

--- a/config/samples/configmap_payload.yaml
+++ b/config/samples/configmap_payload.yaml
@@ -1,8 +1,0 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: payload-config
-  namespace: sandboxed-containers-operator-system
-data:
-  # change to your custom payload repository:tag value
-  daemon.payload: quay.io/user/repository:test

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -177,7 +177,7 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 				"machineconfiguration.openshift.io/role": machinePool,
 				"app":                                    r.kataConfig.Name,
 			},
-			Namespace: "openshift-sandboxed-containers",
+			Namespace: "openshift-sandboxed-containers-operator",
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			Extensions: []string{"sandboxed-containers"},

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-oc apply -f https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/master/deploy/deploy.yaml
+oc apply -f https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/release-4.8/deploy/deploy.yaml

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -146,6 +146,8 @@ spec:
                         - name
                         type: object
                       type: array
+                    failedNodesReason:
+                      type: string
                   type: object
                 inProgress:
                   description: InProgress reflects the status of nodes that are in
@@ -159,11 +161,18 @@ spec:
                       description: InProgressNodesCount reflects the number of nodes
                         that are in the process of kata installation
                       type: integer
+                    isInProgress:
+                      description: IsInProgress reflects if installation is still
+                        in progress
+                      type: boolean
                   type: object
               type: object
             kataImage:
               description: KataImage is the image used for delivering kata binaries
               type: string
+            prevMcpGeneration:
+              format: int64
+              type: integer
             runtimeClass:
               description: RuntimeClass is the name of the runtime class used in CRIO
                 configuration
@@ -218,6 +227,8 @@ spec:
                         - name
                         type: object
                       type: array
+                    failedNodesReason:
+                      type: string
                   type: object
                 inProgress:
                   description: InProgress reflects the status of nodes that are in
@@ -230,12 +241,15 @@ spec:
                     inProgressNodesCount:
                       type: integer
                   type: object
+                isInProgress:
+                  type: boolean
               type: object
             upgradeStatus:
-              description: upgradeStatus reflects the status of the ongoing kata upgrade
+              description: Upgradestatus reflects the status of the ongoing kata upgrade
               type: object
           required:
           - kataImage
+          - prevMcpGeneration
           - runtimeClass
           - totalNodesCount
           type: object

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: sandboxed-containers-operator-system
+  name: openshift-sandboxed-containers-operator
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -255,8 +255,8 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: sandboxed-containers-operator-leader-election-role
-  namespace: sandboxed-containers-operator-system
+  name: openshift-sandboxed-containers-leader-election-role
+  namespace: openshift-sandboxed-containers-operator
 rules:
 - apiGroups:
   - ""
@@ -290,7 +290,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: sandboxed-containers-operator-manager-role
+  name: openshift-sandboxed-containers-manager-role
 rules:
 - apiGroups:
   - ""
@@ -393,7 +393,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sandboxed-containers-operator-proxy-role
+  name: openshift-sandboxed-containers-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -411,7 +411,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: sandboxed-containers-operator-metrics-reader
+  name: openshift-sandboxed-containers-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -421,50 +421,50 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sandboxed-containers-operator-leader-election-rolebinding
-  namespace: sandboxed-containers-operator-system
+  name: openshift-sandboxed-containers-leader-election-rolebinding
+  namespace: openshift-sandboxed-containers-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: sandboxed-containers-operator-leader-election-role
+  name: openshift-sandboxed-containers-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: sandboxed-containers-operator-system
+  namespace: openshift-sandboxed-containers-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sandboxed-containers-operator-manager-rolebinding
+  name: openshift-sandboxed-containers-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sandboxed-containers-operator-manager-role
+  name: openshift-sandboxed-containers-manager-role
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: sandboxed-containers-operator-system
+  namespace: openshift-sandboxed-containers-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sandboxed-containers-operator-proxy-rolebinding
+  name: openshift-sandboxed-containers-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sandboxed-containers-operator-proxy-role
+  name: openshift-sandboxed-containers-proxy-role
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: sandboxed-containers-operator-system
+  namespace: openshift-sandboxed-containers-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: sandboxed-containers-operator-controller-manager-metrics-svc
-  namespace: sandboxed-containers-operator-system
+  name: openshift-sandboxed-containers-controller-manager-metrics-svc
+  namespace: openshift-sandboxed-containers-operator
 spec:
   ports:
   - name: https
@@ -478,8 +478,8 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-  name: sandboxed-containers-operator-controller-manager
-  namespace: sandboxed-containers-operator-system
+  name: openshift-sandboxed-containers-controller-manager
+  namespace: openshift-sandboxed-containers-operator
 spec:
   replicas: 1
   selector:
@@ -492,21 +492,11 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:e10d1d982dd653db74ca87a1d1ad017bc5ef1aeb651bdea089debf16485b080b
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/isolatedcontainers/sandboxed-containers-operator:4.8
+        image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers:latest
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
- Description of the problem which is fixed/What is the use case

    use new namespace name and refer to new quay.io repository
    We should adhere to the naming convention in OpenShift and use
    the default namespace openshift-sandboxed-containers. The same goes for
    the quay.io user/repository we use. Use the new
    quay.io/openshift_sandboxed_containers instead of
    quay.io/isolatedcontainres.

    delete example configmap for payload. We don't have a payload any more.

- What I did

This cleans up README and example files to use the namespace
openshift-sandboxed-containers instead of sandboxed-containers-operator-system.

- How to verify it

Follow the README descripton to install/uninstall and make sure all steps work.

- Description for the changelog
Use new namespace openshift-sandboxed-containers and refer to new quay.io organisation quay.io/openshift_sandboxed_containers
@jensfr
