### PR TITLE
fix function name spelling of clearUninstallStatus

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -724,7 +724,7 @@ func (r *KataConfigOpenShiftReconciler) updateUninstallStatus() (error, bool) {
 		return err, false
 	}
 
-	r.clearUnInstallStatus()
+	r.clearUninstallStatus()
 
 	for _, node := range nodeList.Items {
 		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
@@ -856,7 +856,7 @@ func (r *KataConfigOpenShiftReconciler) clearInstallStatus() {
 	r.kataConfig.Status.InstallationStatus.Failed.FailedNodesCount = 0
 }
 
-func (r *KataConfigOpenShiftReconciler) clearUnInstallStatus() {
+func (r *KataConfigOpenShiftReconciler) clearUninstallStatus() {
 	r.kataConfig.Status.UnInstallationStatus.Completed.CompletedNodesList = nil
 	r.kataConfig.Status.UnInstallationStatus.Completed.CompletedNodesCount = 0
 	r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList = nil


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**
We had two functions that were spelled almost the same and we removed
the wrong one. 

**- What I did**
This commit is renaming the remaining function
to make it compile again.

**- How to verify it**
make docker-build

**- Description for the changelog**
Fix compilation error introduced when we removed one of two functions that were spelled almost the same