### PR TITLE
Update install.sh, use files from release-4.7 branch

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-curl https://raw.githubusercontent.com/openshift/kata-operator/master/deploy/deploy.sh | bash
-oc apply -f https://raw.githubusercontent.com/openshift/kata-operator/master/config/samples/kataconfiguration_v1_kataconfig.yaml
+curl https://raw.githubusercontent.com/openshift/kata-operator/release-4.7/deploy/deploy.sh | bash
+oc apply -f https://raw.githubusercontent.com/openshift/kata-operator/release-4.7/config/samples/kataconfiguration_v1_kataconfig.yaml
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-curl https://raw.githubusercontent.com/openshift/kata-operator/release-4.7/deploy/deploy.sh | bash
-oc apply -f https://raw.githubusercontent.com/openshift/kata-operator/release-4.7/config/samples/kataconfiguration_v1_kataconfig.yaml
+curl https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/release-4.7/deploy/deploy.sh | bash
+oc apply -f https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/release-4.7/config/samples/kataconfiguration_v1_kataconfig.yaml
 


### PR DESCRIPTION
Right now it uses files from the master branch. This is wrong, we always want to use the files from the release-4.7 branch.

