### PR TITLE
deploy.yaml: Fix operator repo name

### DIFF
--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -510,7 +510,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers:latest
+        image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:latest
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**
the repo name of the operator is wrong

**- What I did**
use the correct name

**- How to verify it**
Deploy the operator via oc apply -f deploy/deploy.yaml and check the image field in the pod spec of the controller

**- Description for the changelog**
Fix deploy.yaml to use correct operator repository name
