### PR TITLE
Update kataconfig CR status on scaling of nodes

### DIFF
--- a/config/extension-crds/machineconfig.crd.yaml
+++ b/config/extension-crds/machineconfig.crd.yaml
@@ -1,0 +1,341 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: machineconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: machineconfiguration.openshift.io
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: machineconfigs
+    # singular name to be used as an alias on the CLI and for display
+    singular: machineconfig
+    # kind is normally the PascalCased singular type. Your resource manifests use this.
+    kind: MachineConfig
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mc
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+  - name: v1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    additionalPrinterColumns:
+    - jsonPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
+      description: Version of the controller that generated the machineconfig. This
+        will be empty if the machineconfig is not managed by a controller.
+      name: GeneratedByController
+      type: string
+    - jsonPath: .spec.config.ignition.version
+      description: Version of the Ignition Config defined in the machineconfig.
+      name: IgnitionVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    # openAPIV3Schema has been hand modified. Do not overwrite directly with generated crd fields as we do not allow all config fields.
+    schema:
+      openAPIV3Schema:
+        description: MachineConfig defines the configuration for a machine
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigSpec is the spec for MachineConfig
+            type: object
+            properties:
+              config:
+                description: Config is a Ignition Config object.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                required:
+                - ignition
+                properties:
+                  ignition:
+                    description: Ignition section contains metadata about the configuration
+                      itself. We only permit a subsection of ignition fields for MachineConfigs.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      config:
+                        type: object
+                        properties:
+                          append:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                source:
+                                  type: string
+                                verification:
+                                  type: object
+                                  properties:
+                                    hash:
+                                      type: string
+                          replace:
+                            type: object
+                            properties:
+                              source:
+                                type: string
+                              verification:
+                                type: object
+                                properties:
+                                  hash:
+                                    type: string
+                      security:
+                        type: object
+                        properties:
+                          tls:
+                            type: object
+                            properties:
+                              certificateAuthorities:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    source:
+                                      type: string
+                                    verification:
+                                      type: object
+                                      properties:
+                                        hash:
+                                          type: string
+                      timeouts:
+                        type: object
+                        properties:
+                          httpResponseHeaders:
+                            type: integer
+                          httpTotal:
+                            type: integer
+                      version:
+                        description: Version string is the semantic version number of
+                          the spec
+                        type: string
+                  passwd:
+                    type: object
+                    properties:
+                      users:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: Name of user. Must be \"core\" user.
+                              type: string
+                            sshAuthorizedKeys:
+                              description: Public keys to be assigned to user core.
+                              type: array
+                              items:
+                                type: string
+                  storage:
+                    description: Storage describes the desired state of the system's
+                      storage devices.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      directories:
+                        description: Directories is the list of directories to be created
+                        type: array
+                        items:
+                          description: Items is list of directories to be written
+                          type: object
+                          properties:
+                            filesystem:
+                              description: Filesystem is the internal identifier of
+                                the filesystem in which to write the file. This matches
+                                the last filesystem with the given identifier.
+                              type: string
+                            group:
+                              description: Group object specifies group of the owner
+                              type: object
+                              properties:
+                                id:
+                                  description: ID is the user ID of the owner
+                                  type: integer
+                                name:
+                                  description: Name is the user name of the owner
+                                  type: string
+                            mode:
+                              description: Mode is the file's permission mode. Note
+                                that the mode must be properly specified as a decimal
+                                value (i.e. 0644 -> 420)
+                              type: integer
+                            overwrite:
+                              description: Overwrite specifies whether to delete preexisting
+                                nodes at the path
+                              type: boolean
+                            path:
+                              description: Path is the absolute path to the file
+                              type: string
+                            user:
+                              description: User object specifies the file's owner
+                              type: object
+                              properties:
+                                id:
+                                  description: ID is the user ID of the owner
+                                  type: integer
+                                name:
+                                  description: Name is the user name of the owner
+                                  type: string
+                      files:
+                        description: Files is the list of files to be created/modified
+                        type: array
+                        items:
+                          description: Items is list of files to be written
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          properties:
+                            contents:
+                              description: Contents specifies options related to the
+                                contents of the file
+                              type: object
+                              properties:
+                                compression:
+                                  description: The type of compression used on the contents
+                                    (null or gzip). Compression cannot be used with
+                                    S3.
+                                  type: string
+                                source:
+                                  description: Source is the URL of the file contents.
+                                    Supported schemes are http, https, tftp, s3, and
+                                    data. When using http, it is advisable to use the
+                                    verification option to ensure the contents haven't
+                                    been modified.
+                                  type: string
+                                verification:
+                                  description: Verification specifies options related
+                                    to the verification of the file contents
+                                  type: object
+                                  properties:
+                                    hash:
+                                      description: Hash is the hash of the config, in
+                                        the form <type>-<value> where type is sha512
+                                      type: string
+                            filesystem:
+                              description: Filesystem is the internal identifier of
+                                the filesystem in which to write the file. This matches
+                                the last filesystem with the given identifier
+                              type: string
+                            group:
+                              description: Group object specifies group of the owner
+                              type: object
+                              properties:
+                                id:
+                                  description: ID specifies group ID of the owner
+                                  type: integer
+                                name:
+                                  description: Name is the group name of the owner
+                                  type: string
+                            mode:
+                              description: Mode specifies the file's permission mode.
+                                Note that the mode must be properly specified as a decimal
+                                value (i.e. 0644 -> 420)
+                              type: integer
+                            overwrite:
+                              description: Overwrite specifies whether to delete preexisting
+                                nodes at the path
+                              type: boolean
+                            path:
+                              description: Path is the absolute path to the file
+                              type: string
+                            user:
+                              description: User object specifies the file's owner
+                              type: object
+                              properties:
+                                id:
+                                  description: ID is the user ID of the owner
+                                  type: integer
+                                name:
+                                  description: Name is the user name of the owner
+                                  type: string
+                  systemd:
+                    description: systemd describes the desired state of the systemd
+                      units
+                    type: object
+                    properties:
+                      units:
+                        description: Units is a list of units to be configured
+                        type: array
+                        items:
+                          description: Items describes unit configuration
+                          type: object
+                          properties:
+                            contents:
+                              description: Contents is the contents of the unit
+                              type: string
+                            dropins:
+                              description: Dropins is the list of drop-ins for the unit
+                              type: array
+                              items:
+                                description: Items describes unit dropin
+                                type: object
+                                properties:
+                                  contents:
+                                    description: Contents is the contents of the drop-in
+                                    type: string
+                                  name:
+                                    description: Name is the name of the drop-in. This
+                                      must be suffixed with '.conf'
+                                    type: string
+                            enabled:
+                              description: Enabled describes whether or not the service
+                                shall be enabled. When true, the service is enabled.
+                                When false, the service is disabled. When omitted, the
+                                service is unmodified. In order for this to have any
+                                effect, the unit must have an install section
+                              type: boolean
+                            mask:
+                              description: Mask describes whether or not the service
+                                shall be masked. When true, the service is masked by
+                                symlinking it to /dev/null"
+                              type: boolean
+                            name:
+                              description: Name is the name of the unit. This must be
+                                suffixed with a valid unit type (e.g. 'thing.service')
+                              type: string
+              extensions:
+                description: List of additional features that can be enabled on host
+                type: array
+                items:
+                  type: string
+                nullable: true
+              fips:
+                description: FIPS controls FIPS mode
+                type: boolean
+              kernelArguments:
+                description: KernelArguments contains a list of kernel arguments to
+                  be added
+                type: array
+                items:
+                  type: string
+                nullable: true
+              kernelType:
+                description: Contains which kernel we want to be running like default
+                  (traditional), realtime
+                type: string
+              osImageURL:
+                description: OSImageURL specifies the remote location that will be used
+                  to fetch the OS to fetch the OS.
+                type: string

--- a/config/extension-crds/machineconfigpool.crd.yaml
+++ b/config/extension-crds/machineconfigpool.crd.yaml
@@ -1,0 +1,421 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: machineconfigpools.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: machineconfiguration.openshift.io
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: machineconfigpools
+    # singular name to be used as an alias on the CLI and for display
+    singular: machineconfigpool
+    # kind is normally the PascalCased singular type. Your resource manifests use this.
+    kind: MachineConfigPool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mcp
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+  - name: v1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updated")].status
+      description: When all the machines in the pool are updated to the correct machine
+        config.
+      name: Updated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updating")].status
+      description: When at least one of machine is not either not updated or is in the
+        process of updating to the desired machine config.
+      name: Updating
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      description: When progress is blocked on updating one or more nodes, or the pool
+        configuration is failing.
+      name: Degraded
+      type: string
+    - jsonPath: .status.machineCount
+      description: Total number of machines in the machine config pool
+      name: MachineCount
+      type: number
+    - jsonPath: .status.readyMachineCount
+      description: Total number of ready machines targeted by the pool
+      name: ReadyMachineCount
+      type: number
+    - jsonPath: .status.updatedMachineCount
+      description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      name: UpdatedMachineCount
+      type: number
+    - jsonPath: .status.degradedMachineCount
+      description: Total number of machines marked degraded (or unreconcilable)
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    schema:
+      openAPIV3Schema:
+        description: MachineConfigPool describes a pool of MachineConfigs.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            type: object
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                type: object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an
+                      entire object, this string should contain a valid JSON/Go field
+                      access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen only
+                      to have some well-defined way of referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change
+                      in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is
+                      made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that were
+                      used to generate the single MachineConfig object specified in
+                      `content`.
+                    type: array
+                    items:
+                      description: ObjectReference contains enough information to let
+                        you inspect or modify the referred object.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within
+                            a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]"
+                            (container with index 2 in this pod). This syntax is chosen
+                            only to have some well-defined way of referencing a part
+                            of an object. TODO: this design is not final and this field
+                            is subject to change in the future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              machineConfigSelector:
+                description: machineConfigSelector specifies a label selector for MachineConfigs.
+                  Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                  on how label and selectors work.
+                type: object
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    type: array
+                    items:
+                      description: A label selector requirement is a selector that contains
+                        values, a key, and an operator that relates the key and values.
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a
+                            set of values. Valid operators are In, NotIn, Exists and
+                            DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If the
+                            operator is Exists or DoesNotExist, the values array must
+                            be empty. This array is replaced during a strategic merge
+                            patch.
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator is
+                      "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                    additionalProperties:
+                      type: string
+              maxUnavailable:
+                description: maxUnavailable specifies the percentage or constant number
+                  of machines that can be updating at any given time. default is 1.
+                anyOf:
+                - type: integer
+                - type: string
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                type: object
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    type: array
+                    items:
+                      description: A label selector requirement is a selector that contains
+                        values, a key, and an operator that relates the key and values.
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a
+                            set of values. Valid operators are In, NotIn, Exists and
+                            DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If the
+                            operator is Exists or DoesNotExist, the values array must
+                            be empty. This array is replaced during a strategic merge
+                            patch.
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator is
+                      "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                    additionalProperties:
+                      type: string
+              paused:
+                description: paused specifies whether or not changes to this machine
+                  config pool should be stopped. This includes generating new desiredMachineConfig
+                  and update of machines.
+                type: boolean
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            type: object
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                type: array
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                      nullable: true
+                    message:
+                      description: message is a human readable description of the details
+                        of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: reason is a brief machine readable explanation for
+                        the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                type: object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an
+                      entire object, this string should contain a valid JSON/Go field
+                      access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen only
+                      to have some well-defined way of referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change
+                      in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is
+                      made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that were
+                      used to generate the single MachineConfig object specified in
+                      `content`.
+                    type: array
+                    items:
+                      description: ObjectReference contains enough information to let
+                        you inspect or modify the referred object.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within
+                            a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]"
+                            (container with index 2 in this pod). This syntax is chosen
+                            only to have some well-defined way of referencing a part
+                            of an object. TODO: this design is not final and this field
+                            is subject to change in the future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              degradedMachineCount:
+                description: degradedMachineCount represents the total number of machines
+                  marked degraded (or unreconcilable). A node is marked degraded if
+                  applying a configuration failed..
+                type: integer
+                format: int32
+              machineCount:
+                description: machineCount represents the total number of machines in
+                  the machine config pool.
+                type: integer
+                format: int32
+              observedGeneration:
+                description: observedGeneration represents the generation observed by
+                  the controller.
+                type: integer
+                format: int64
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                type: integer
+                format: int32
+              unavailableMachineCount:
+                description: unavailableMachineCount represents the total number of
+                  unavailable (non-ready) machines targeted by the pool. A node is marked
+                  unavailable if it is in updating state or NodeReady condition is false.
+                type: integer
+                format: int32
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their config.
+                type: integer
+                format: int32

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -38,7 +38,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // blank assignment to verify that KataConfigOpenShiftReconciler implements reconcile.Reconciler
@@ -569,6 +571,26 @@ func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (c
 func (r *KataConfigOpenShiftReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kataconfigurationv1.KataConfig{}).
+		Watches(&source.Kind{Type: &mcfgv1.MachineConfigPool{}}, &handler.EnqueueRequestsFromMapFunc{
+			ToRequests: handler.ToRequestsFunc(func(kataConfigObj handler.MapObject) []reconcile.Request {
+				kataConfigList := &kataconfigurationv1.KataConfigList{}
+
+				err := r.Client.List(context.TODO(), kataConfigList)
+				if err != nil {
+					return []reconcile.Request{}
+				}
+
+				reconcileRequests := make([]reconcile.Request, len(kataConfigList.Items))
+				for _, kataconfig := range kataConfigList.Items {
+					reconcileRequests = append(reconcileRequests, reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name: kataconfig.Name,
+						},
+					})
+				}
+				return reconcileRequests
+			}),
+		}).
 		Complete(r)
 }
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -526,6 +526,14 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 	r.kataConfig.Status.TotalNodesCount = int(foundMcp.Status.MachineCount)
 
+	if mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating) &&
+		r.kataConfig.Status.InstallationStatus.IsInProgress == "false" &&
+		r.kataConfig.Status.RuntimeClass == "kata" {
+		r.Log.Info("New node being added to existing cluster")
+		r.kataConfig.Status.InstallationStatus.IsInProgress = corev1.ConditionTrue
+		return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
+	}
+
 	if mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) &&
 		foundMcp.Status.ObservedGeneration > r.kataConfig.Status.BaseMcpGeneration &&
 		foundMcp.Status.UpdatedMachineCount == foundMcp.Status.MachineCount {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Output of kataconfig CR does not update when nodes are scaled up

**- What I did**
Watch for changes to MachineConfigPool and trigger reconcile 

**- How to verify it**
Add a new node to the existing cluster. Run `oc describe kataconfig example-kataconfig` to display the status of 
the CR

**- Description for the changelog**
Update kataconfig CR status on scaling of nodes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
