### PR TITLE
add bundle.Dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=sandboxed-containers-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.2.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
To enable the OpenShift CI to build the bundle image and test
installation of an Operator we need to add the Dockerfile to build
the bundle container image.

This was generated with 'make bundle'

Signed-off-by: Jens Freimann <jfreimann@redhat.com>
