### PR TITLE
add bundle data

### DIFF
--- a/bundle/manifests/kata-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kata-operator.clusterserviceversion.yaml
@@ -1,0 +1,246 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kataconfiguration.openshift.io/v1",
+          "kind": "KataConfig",
+          "metadata": {
+            "name": "example-kataconfig"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    operators.operatorframework.io/builder: operator-sdk-v1.2.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
+  name: sandboxed-containers-operator.v1.0.0
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: KataConfig
+      name: kataconfigs.kataconfiguration.openshift.io
+      description: The kataconfig CR represent a installation of Kata in a cluster and its current state.
+      version: v1
+  displayName: Sandboxed Containers Operator
+  description: An operator to perform lifecycle management (install/upgrade/uninstall) of Sandboxed Containers Runtime on Openshift as well as Kubernetes cluster
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - machineconfiguration.openshift.io
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - machineconfigpools
+          - machineconfigs
+          - nodes
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - manager-role
+          resources:
+          - daemonsets/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+        - apiGroups:
+          - kataconfiguration.openshift.io
+          resources:
+          - kataconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kataconfiguration.openshift.io
+          resources:
+          - kataconfigs
+          - kataconfigs/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kataconfiguration.openshift.io
+          resources:
+          - kataconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: default
+      deployments:
+      - name: sandboxed-containers-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-addr=127.0.0.1:8080
+                - --enable-leader-election
+                command:
+                - /manager
+                image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-sandboxed-containers-operator:1.0.0-5
+                imagePullPolicy: Always
+                name: manager
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 50Mi
+                  requests:
+                    cpu: 100m
+                    memory: 40Mi
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoExecute
+                key: node.kubernetes.io/unreachable
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoExecute
+                key: node.kubernetes.io/not-ready
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoSchedule
+                key: node.kubernetes.io/memory-pressure
+                operator: Exists
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: default
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - kernel-isolated containers
+  links:
+  - name: Sandboxed Containers Operator
+    url: https://www.github.com/openshift/sandboxed-containers-operator
+  maintainers:
+  - email: jfreimann@redhat.com'
+    name: '''Jens Freimann'
+  maturity: alpha
+  provider:
+    name: Red Hat
+    url: https://www.github.com/openshift/sandboxed-containers-operator
+  version: 1.0.0 

--- a/bundle/manifests/sandboxed-containers-operator.crd.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.crd.yaml
@@ -1,0 +1,269 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: kataconfigs.kataconfiguration.openshift.io
+spec:
+  group: kataconfiguration.openshift.io
+  names:
+    kind: KataConfig
+    listKind: KataConfigList
+    plural: kataconfigs
+    singular: kataconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KataConfig is the Schema for the kataconfigs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KataConfigSpec defines the desired state of KataConfig
+          nullable: true
+          properties:
+            config:
+              description: KataInstallConfig is a placeholder struct
+              properties:
+                sourceImage:
+                  description: SourceImage is the name of the kata-deploy image
+                  type: string
+              required:
+              - sourceImage
+              type: object
+            kataConfigPoolSelector:
+              description: KataConfigPoolSelector is used to filer the worker nodes
+                if not specified, all worker nodes are selected
+              nullable: true
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          type: object
+        status:
+          description: KataConfigStatus defines the observed state of KataConfig
+          properties:
+            installationStatus:
+              description: InstallationStatus reflects the status of the ongoing kata
+                installation
+              properties:
+                IsInProgress:
+                  description: IsInProgress reflects the current state of installing
+                    or not installing
+                  type: string
+                completed:
+                  description: Completed reflects the status of nodes that have completed
+                    kata installation
+                  properties:
+                    completedNodesCount:
+                      description: CompletedNodesCount reflects the number of nodes
+                        that have completed kata operation
+                      type: integer
+                    completedNodesList:
+                      description: CompletedNodesList reflects the list of nodes that
+                        have completed kata operation
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                failed:
+                  description: Failed reflects the status of nodes that have failed
+                    kata installation
+                  properties:
+                    failedNodesCount:
+                      description: FailedNodesCount reflects the number of nodes that
+                        have failed kata operation
+                      type: integer
+                    failedNodesList:
+                      description: FailedNodesList reflects the list of nodes that
+                        have failed kata operation
+                      items:
+                        description: FailedNodeStatus holds the name and the error
+                          message of the failed node
+                        properties:
+                          error:
+                            description: Error message of the failed node reported
+                              by the installation daemon
+                            type: string
+                          name:
+                            description: Name of the failed node
+                            type: string
+                        required:
+                        - error
+                        - name
+                        type: object
+                      type: array
+                    failedNodesReason:
+                      type: string
+                  type: object
+                inprogress:
+                  description: InProgress reflects the status of nodes that are in
+                    the process of kata installation
+                  properties:
+                    binariesInstallNodesList:
+                      items:
+                        type: string
+                      type: array
+                    inProgressNodesCount:
+                      description: InProgressNodesCount reflects the number of nodes
+                        that are in the process of kata installation
+                      type: integer
+                    isInProgress:
+                      description: IsInProgress reflects if installation is still
+                        in progress
+                      type: boolean
+                  type: object
+              required:
+              - IsInProgress
+              type: object
+            kataImage:
+              description: KataImage is the image used for delivering kata binaries
+              type: string
+            prevMcpGeneration:
+              format: int64
+              type: integer
+            runtimeClass:
+              description: RuntimeClass is the name of the runtime class used in CRIO
+                configuration
+              type: string
+            totalNodesCount:
+              description: TotalNodesCounts is the total number of worker nodes targeted
+                by this CR
+              type: integer
+            unInstallationStatus:
+              description: UnInstallationStatus reflects the status of the ongoing
+                kata uninstallation
+              properties:
+                completed:
+                  description: Completed reflects the status of nodes that have completed
+                    kata uninstallation
+                  properties:
+                    completedNodesCount:
+                      description: CompletedNodesCount reflects the number of nodes
+                        that have completed kata operation
+                      type: integer
+                    completedNodesList:
+                      description: CompletedNodesList reflects the list of nodes that
+                        have completed kata operation
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                failed:
+                  description: Failed reflects the status of nodes that have failed
+                    kata uninstallation
+                  properties:
+                    failedNodesCount:
+                      description: FailedNodesCount reflects the number of nodes that
+                        have failed kata operation
+                      type: integer
+                    failedNodesList:
+                      description: FailedNodesList reflects the list of nodes that
+                        have failed kata operation
+                      items:
+                        description: FailedNodeStatus holds the name and the error
+                          message of the failed node
+                        properties:
+                          error:
+                            description: Error message of the failed node reported
+                              by the installation daemon
+                            type: string
+                          name:
+                            description: Name of the failed node
+                            type: string
+                        required:
+                        - error
+                        - name
+                        type: object
+                      type: array
+                    failedNodesReason:
+                      type: string
+                  type: object
+                inProgress:
+                  description: InProgress reflects the status of nodes that are in
+                    the process of kata uninstallation
+                  properties:
+                    binariesUninstallNodesList:
+                      items:
+                        type: string
+                      type: array
+                    inProgressNodesCount:
+                      type: integer
+                    status:
+                      type: string
+                  required:
+                  - status
+                  type: object
+              type: object
+            upgradeStatus:
+              description: Upgradestatus reflects the status of the ongoing kata upgrade
+              type: object
+          required:
+          - kataImage
+          - prevMcpGeneration
+          - runtimeClass
+          - totalNodesCount
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: '1.0'
+  operators.operatorframework.io.bundle.channels.v1: '1.0'
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kata-operator
+  operators.operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
Openshift CI is able to build the operator bundle and index image and
test installation via OLM. For that it needs the files like the
clusterserviceversion, the crd and other metadata.

This patch adds these files which are a copy of the downstream product
version.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>


