### PR TITLE
Fix handling of custom MachineConfigPool

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -238,8 +238,15 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 
 func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
 	var mcpName string
+
+	kataOC, err := r.kataOcExists()
+	if kataOC && err == nil {
+		r.Log.Info("kata-oc machine config pool exists")
+		return "kata-oc", nil
+	}
+
 	workerMcp := &mcfgv1.MachineConfigPool{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "worker"}, workerMcp)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "worker"}, workerMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
 		r.Log.Error(err, "No worker machine config pool found!")
 		return "", err

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -237,7 +237,7 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 }
 
 func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
-	var role string
+	var mcpName string
 	workerMcp := &mcfgv1.MachineConfigPool{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "worker"}, workerMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
@@ -249,11 +249,11 @@ func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
 	}
 
 	if workerMcp.Status.MachineCount > 0 {
-		role = "worker"
+		mcpName = "worker"
 	} else {
-		role = "master"
+		mcpName = "master"
 	}
-	return role, nil
+	return mcpName, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) setRuntimeClass() (ctrl.Result, error) {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -513,11 +513,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 			r.Log.Info("Waiting till Machine Config Pool is initialized ", "mcp.Name", mcp.Name)
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 		}
-		if foundMcp.Status.MachineCount != foundMcp.Status.ReadyMachineCount {
-			r.Log.Info("Waiting till Machine Config Pool is ready ", "mcp.Name", mcp.Name)
 
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
-		}
 	}
 
 	doReconcile, err, isMcCreated := r.createExtensionMc(machinePool)

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -236,7 +236,7 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 	return true, nil
 }
 
-func (r *KataConfigOpenShiftReconciler) workerOrMaster() (string, error) {
+func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
 	var role string
 	workerMcp := &mcfgv1.MachineConfigPool{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "worker"}, workerMcp)
@@ -315,7 +315,7 @@ func (r *KataConfigOpenShiftReconciler) setRuntimeClass() (ctrl.Result, error) {
 
 func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.Result, error) {
 	r.Log.Info("KataConfig deletion in progress: ")
-	machinePool, err := r.workerOrMaster()
+	machinePool, err := r.getMcpName()
 	if err != nil {
 		return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}
@@ -462,7 +462,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 }
 
 func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.Result, error) {
-	machinePool, err := r.workerOrMaster()
+	machinePool, err := r.getMcpName()
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -662,7 +662,7 @@ func (r *KataConfigOpenShiftReconciler) isOldestCR() (bool, error) {
 }
 
 func (r *KataConfigOpenShiftReconciler) getMcp() (*mcfgv1.MachineConfigPool, error) {
-	machinePool, err := r.workerOrMaster()
+	machinePool, err := r.getMcpName()
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -362,92 +362,52 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 
 	r.Log.Info("Making sure parent MCP is synced properly, SCNodeRole=" + machinePool)
 	r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress = corev1.ConditionTrue
-	if _, ok := r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels["node-role.kubernetes.io/"+machinePool]; ok {
-		mc, err := r.newMCForCR(machinePool)
+	mc, err := r.newMCForCR(machinePool)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	var isMcDeleted bool
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, mc)
+	if err != nil && k8serrors.IsNotFound(err) {
+		isMcDeleted = true
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !isMcDeleted {
+		err = r.Client.Delete(context.TODO(), mc)
 		if err != nil {
-			return ctrl.Result{}, err
+			// error during removing mc, don't block the uninstall. Just log the error and move on.
+			r.Log.Info("Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
+				"mc", mc.Name, "error", err)
 		}
-		var isMcDeleted bool
+		// Sleep for MCP to reflect the changes
+		r.Log.Info("Pausing for a minute to make sure worker mcp has started syncing up")
+		time.Sleep(60 * time.Second)
+	}
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, mc)
-		if err != nil && k8serrors.IsNotFound(err) {
-			isMcDeleted = true
-		} else if err != nil {
-			return ctrl.Result{}, err
-		}
+	workreMcp := &mcfgv1.MachineConfigPool{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, workreMcp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	r.Log.Info("Monitoring worker mcp", "worker mcp name", workreMcp.Name, "ready machines", workreMcp.Status.ReadyMachineCount,
+		"total machines", workreMcp.Status.MachineCount)
+	r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress = corev1.ConditionTrue
+	r.clearUninstallStatus()
+	_, result, err2, done := r.updateStatus(machinePool)
+	if !done {
+		r.Log.Info("done returned from updateStatus")
+		return result, err2
+	}
 
-		if !isMcDeleted {
-			err = r.Client.Delete(context.TODO(), mc)
-			if err != nil {
-				// error during removing mc, don't block the uninstall. Just log the error and move on.
-				r.Log.Info("Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
-					"mc", mc.Name, "error", err)
-			}
-			// Sleep for MCP to reflect the changes
-			r.Log.Info("Pausing for a minute to make sure worker mcp has started syncing up")
-			time.Sleep(60 * time.Second)
-		}
-
-		workreMcp := &mcfgv1.MachineConfigPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, workreMcp)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		r.Log.Info("Monitoring worker mcp", "worker mcp name", workreMcp.Name, "ready machines", workreMcp.Status.ReadyMachineCount,
-			"total machines", workreMcp.Status.MachineCount)
-		r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress = corev1.ConditionTrue
-		r.clearUninstallStatus()
-		_, result, err2, done := r.updateStatus(machinePool)
-		if !done {
-			r.Log.Info("done returned from updateStatus")
-			return result, err2
-		}
-
-		if workreMcp.Status.ReadyMachineCount != workreMcp.Status.MachineCount {
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
-		}
-	} else {
-		if len(r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList) > 0 {
-			r.Log.Info("Pausing for a minute to make sure parent mcp has started syncing up")
-			time.Sleep(60 * time.Second)
-
-			parentMcp := &mcfgv1.MachineConfigPool{}
-
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, parentMcp)
-			if err != nil && k8serrors.IsNotFound(err) {
-				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, fmt.Errorf("Not able to find parent pool %s", parentMcp.GetName())
-			} else if err != nil {
-				return ctrl.Result{}, err
-			}
-
-			r.Log.Info("Monitoring parent mcp", "parent mcp name", parentMcp.Name, "ready machines", parentMcp.Status.ReadyMachineCount,
-				"total machines", parentMcp.Status.MachineCount)
-			if parentMcp.Status.ReadyMachineCount != parentMcp.Status.MachineCount {
-				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
-			}
-
-			mcp := r.newMCPforCR()
-			err = r.Client.Delete(context.TODO(), mcp)
-			if err != nil {
-				// error during removing mcp, don't block the uninstall. Just log the error and move on.
-				r.Log.Info("Error found deleting mcp. If the mcp exists after installation it can be safely deleted manually.",
-					"mcp", mcp.Name, "error", err)
-			}
-
-			mc, err := r.newMCForCR(machinePool)
-			err = r.Client.Delete(context.TODO(), mc)
-			if err != nil {
-				// error during removing mc, don't block the uninstall. Just log the error and move on.
-				r.Log.Info("Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
-					"mc", mc.Name, "error", err)
-			}
-		} else {
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
-		}
+	if workreMcp.Status.ReadyMachineCount != workreMcp.Status.MachineCount {
+		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 	}
 
 	r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress = corev1.ConditionFalse
-	_, result, err2, done := r.updateStatus(machinePool)
+	_, result, err2, done = r.updateStatus(machinePool)
 	r.clearInstallStatus()
 	if !done {
 		r.Log.Info("done returned from updateStatus")

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -387,13 +387,13 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		time.Sleep(60 * time.Second)
 	}
 
-	workreMcp := &mcfgv1.MachineConfigPool{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, workreMcp)
+	workerMcp := &mcfgv1.MachineConfigPool{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, workerMcp)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	r.Log.Info("Monitoring worker mcp", "worker mcp name", workreMcp.Name, "ready machines", workreMcp.Status.ReadyMachineCount,
-		"total machines", workreMcp.Status.MachineCount)
+	r.Log.Info("Monitoring worker mcp", "worker mcp name", workerMcp.Name, "ready machines", workerMcp.Status.ReadyMachineCount,
+		"total machines", workerMcp.Status.MachineCount)
 	r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress = corev1.ConditionTrue
 	r.clearUninstallStatus()
 	_, result, err2, done := r.updateStatus(machinePool)
@@ -402,7 +402,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		return result, err2
 	}
 
-	if workreMcp.Status.ReadyMachineCount != workreMcp.Status.MachineCount {
+	if workerMcp.Status.ReadyMachineCount != workerMcp.Status.MachineCount {
 		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Fix handling of custom MachineConfigPool
Closes: #107 

**- What I did**
Made changes to the code to handle `kata-oc` MCP which is the custom MCP created by the operator.

**- How to verify it**

Create a custom_kataconfig.yaml with the following content
```
apiVersion: kataconfiguration.openshift.io/v1
kind: KataConfig
metadata:
 name: custom-kataconfig
spec:
 kataConfigPoolSelector:
 matchLabels:
 custom-kata1: test
```

Label the worker nodes (eg worker0, worker1 in my setup)

$ oc label node worker0.ocp4.example.com custom-kata1=test
$ oc create -f custom_kataconfig.yaml
Once install succeeds, label the other worker
$ oc label node worker1.ocp4.example.com custom-kata1=test

Kataconfig CR should show updated status with new node info

Delete the CR 

$ oc delete kataconfig custom-kataconfig

The kataconfig CR should successfully get deleted.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix handling of custom MachineConfigPool
