### PR TITLE
Set NodeSelector correctly when using MatchExpressions in KataConfigPoolSelector

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	ignTypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-logr/logr"
@@ -287,8 +288,13 @@ func (r *KataConfigOpenShiftReconciler) setRuntimeClass() (ctrl.Result, error) {
 		}
 
 		if r.kataConfig.Spec.KataConfigPoolSelector != nil {
+			r.Log.Info("KataConfigPoolSelector:", "r.kataConfig.Spec.KataConfigPoolSelector", r.kataConfig.Spec.KataConfigPoolSelector)
+			nodeSelector, err := metav1.LabelSelectorAsMap(r.kataConfig.Spec.KataConfigPoolSelector)
+			if err != nil {
+				r.Log.Error(err, "Unable to get nodeSelector for runtimeClass")
+			}
 			rc.Scheduling = &nodeapi.Scheduling{
-				NodeSelector: r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels,
+				NodeSelector: nodeSelector,
 			}
 		}
 		return rc


### PR DESCRIPTION
Fixes: #118

Signed-off-by: Pradipta Banerjee <pradipta.banerjee@gmail.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Using MatchExpressions in KataConfigPoolSelector resulted in empty NodeSelector in RuntimeClass.
This is because RuntimeClass expects only MatchLabels and not MatchExpressions and Operator only
handled MatchLabels

**- What I did**
Set the NodeSelector properly irrespective of using MatchLabels or MatchExpressions in KataConfigPoolSelector

**- How to verify it**
Create KataConfig from OpenShift UI or use the following yaml
```
apiVersion: kataconfiguration.openshift.io/v1
kind: KataConfig
metadata:
  name: example-kataconfig
spec:
  kataConfigPoolSelector:
    matchExpressions:
       - key: custom-kata1
         operator: In
         values:
         - "test"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Set NodeSelector correctly when using MatchExpressions in KataConfigPoolSelector