### PR TITLE
Backport Series

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -coverprofile cover.out -args -ginkgo.v
 
 # Build manager binary
 manager: generate fmt vet

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	ignTypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-logr/logr"
@@ -80,6 +81,7 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		r.Log.Error(err, "Cannot retrieve kataConfig")
 		return ctrl.Result{}, err
 	}
 
@@ -146,6 +148,7 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 }
 
 func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {
+	r.Log.Info("Creating MachineConfig for Custom Resource")
 	kataOC, err := r.kataOcExists()
 	if err != nil {
 		return nil, err
@@ -154,7 +157,7 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 	if kataOC {
 		machinePool = "kata-oc"
 	} else if _, ok := r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels["node-role.kubernetes.io/"+machinePool]; !ok {
-		r.Log.Error(err, "no valid role for mc found")
+		r.Log.Error(err, "no valid role for MachineConfig found")
 	}
 
 	ic := ignTypes.Config{
@@ -229,7 +232,7 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 	if err != nil && k8serrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
-		r.Log.Error(err, "Could not get the kata-oc machine config pool!")
+		r.Log.Error(err, "Could not get the kata-oc MachineConfigPool")
 		return false, err
 	}
 
@@ -237,21 +240,22 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 }
 
 func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
+	r.Log.Info("Getting MachineConfigPool Name")
 	var mcpName string
 
 	kataOC, err := r.kataOcExists()
 	if kataOC && err == nil {
-		r.Log.Info("kata-oc machine config pool exists")
+		r.Log.Info("kata-oc MachineConfigPool exists")
 		return "kata-oc", nil
 	}
 
 	workerMcp := &mcfgv1.MachineConfigPool{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "worker"}, workerMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
-		r.Log.Error(err, "No worker machine config pool found!")
+		r.Log.Error(err, "No worker MachineConfigPool found!")
 		return "", err
 	} else if err != nil {
-		r.Log.Error(err, "Could not get the worker machine config pool!")
+		r.Log.Error(err, "Could not get the worker MachineConfigPool!")
 		return "", err
 	}
 
@@ -342,6 +346,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 			if updErr != nil {
 				return ctrl.Result{}, updErr
 			}
+			r.Log.Info("Kata PODs are present. Requeue for reconciliation ")
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 		} else {
 			if r.kataConfig.Status.UnInstallationStatus.ErrorMessage != "" {
@@ -379,8 +384,8 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		err = r.Client.Delete(context.TODO(), mc)
 		if err != nil {
 			// error during removing mc, don't block the uninstall. Just log the error and move on.
-			r.Log.Info("Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
-				"mc", mc.Name, "error", err)
+			r.Log.Error(err, "Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
+				"mc", mc.Name)
 		}
 		// Sleep for MCP to reflect the changes
 		r.Log.Info("Pausing for a minute to make sure worker mcp has started syncing up")
@@ -390,6 +395,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	workerMcp := &mcfgv1.MachineConfigPool{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, workerMcp)
 	if err != nil {
+		r.Log.Error(err, "Unable to get MachineConfigPool ", "machinePool", machinePool)
 		return ctrl.Result{}, err
 	}
 	r.Log.Info("Monitoring worker mcp", "worker mcp name", workerMcp.Name, "ready machines", workerMcp.Status.ReadyMachineCount,
@@ -398,7 +404,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	r.clearUninstallStatus()
 	_, result, err2, done := r.updateStatus(machinePool)
 	if !done {
-		r.Log.Info("done returned from updateStatus")
 		return result, err2
 	}
 
@@ -410,11 +415,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	_, result, err2, done = r.updateStatus(machinePool)
 	r.clearInstallStatus()
 	if !done {
-		r.Log.Info("done returned from updateStatus")
 		return result, err2
 	}
 	err = r.Client.Status().Update(context.TODO(), r.kataConfig)
 	if err != nil {
+		r.Log.Error(err, "Unable to update KataConfig status")
 		return ctrl.Result{}, err
 	}
 
@@ -423,12 +428,14 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 
 	err = r.Client.Update(context.TODO(), r.kataConfig)
 	if err != nil {
+		r.Log.Error(err, "Unable to update KataConfig")
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.Result, error) {
+	r.Log.Info("Kata installation in progress")
 	machinePool, err := r.getMcpName()
 	if err != nil {
 		return reconcile.Result{}, err
@@ -450,27 +457,28 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 	/* create custom Machine Config Pool if configured by user */
 	if _, ok := r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels["node-role.kubernetes.io/"+machinePool]; !ok {
-		r.Log.Info("creating new Mcp")
+		r.Log.Info("Creating new MachineConfigPool")
 		mcp := r.newMCPforCR()
 
 		foundMcp := &mcfgv1.MachineConfigPool{}
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcp.Name}, foundMcp)
 		if err != nil && k8serrors.IsNotFound(err) {
-			r.Log.Info("Creating a new Machine Config Pool ", "mcp.Name", mcp.Name)
+			r.Log.Info("Creating a new MachineConfigPool ", "mcp.Name", mcp.Name)
 			err = r.Client.Create(context.TODO(), mcp)
 			if err != nil {
+				r.Log.Error(err, "Error in creating new MachineConfigPool ", "mcp.Name", mcp.Name)
 				return ctrl.Result{}, err
 			}
 			// mcp created successfully - requeue to check the status later
 			return ctrl.Result{Requeue: true, RequeueAfter: 20 * time.Second}, nil
 		} else if err != nil {
-			r.Log.Info("other error")
+			r.Log.Error(err, "Error in retreiving MachineConfigPool ", "mcp.Name", mcp.Name)
 			return ctrl.Result{}, err
 		}
 
 		// Wait till MCP is ready
 		if foundMcp.Status.MachineCount == 0 {
-			r.Log.Info("Waiting till Machine Config Pool is initialized ", "mcp.Name", mcp.Name)
+			r.Log.Info("Waiting till MachineConfigPool is initialized ", "mcp.Name", mcp.Name)
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 		}
 
@@ -483,7 +491,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 	foundMcp, doReconcile, err, done := r.updateStatus(machinePool)
 	if !done {
-		r.Log.Info("done returned from updateStatus")
 		return doReconcile, err
 	}
 
@@ -504,12 +511,13 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.kataConfig.Status.InstallationStatus.IsInProgress = "false"
 		return r.setRuntimeClass()
 	} else {
-		r.Log.Info("waiting for machine config pool to be fully updated")
+		r.Log.Info("Waiting for MachineConfigPool to be fully updated")
 		return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 	}
 }
 
 func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (ctrl.Result, error, bool) {
+	r.Log.Info("creating RHCOS extension MachineConfig")
 	mc, err := r.newMCForCR(machinePool)
 	if err != nil {
 		return ctrl.Result{}, err, true
@@ -518,7 +526,7 @@ func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (c
 	foundMcp := &mcfgv1.MachineConfigPool{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
-		r.Log.Info("MCP not found")
+		r.Log.Info("MachineConfigPool not found")
 		return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil, false
 	}
 
@@ -528,7 +536,7 @@ func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (c
 	if err != nil && (k8serrors.IsNotFound(err) || k8serrors.IsGone(err)) {
 		err = r.Client.Create(context.TODO(), mc)
 		if err != nil {
-			r.Log.Info("failed to create a new Machine Config ", "mc.Name", mc.Name)
+			r.Log.Error(err, "Failed to create a new MachineConfig ", "mc.Name", mc.Name)
 			return ctrl.Result{}, err, true
 		}
 		/* mc created successfully - it will take a moment to finalize, requeue to create runtimeclass */
@@ -633,6 +641,7 @@ func (r *KataConfigOpenShiftReconciler) getMcp() (*mcfgv1.MachineConfigPool, err
 	foundMcp := &mcfgv1.MachineConfigPool{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
 	if err != nil {
+		r.Log.Error(err, "Getting MachineConfigPool failed ", "machinePool", machinePool)
 		return nil, err
 	}
 
@@ -647,7 +656,7 @@ func (r *KataConfigOpenShiftReconciler) getNodes() (error, *corev1.NodeList) {
 	}
 
 	if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
-		r.Log.Info("get list of nodes failed")
+		r.Log.Error(err, "Getting list of nodes failed")
 		return err, &corev1.NodeList{}
 	}
 	return nil, nodes
@@ -670,7 +679,7 @@ func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv
 	foundMcp := &mcfgv1.MachineConfigPool{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
-		r.Log.Info("MCP not found")
+		r.Log.Error(err, "Unable to get MachineConfigPool ", "machinePool", machinePool)
 		return nil, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil, true
 	}
 
@@ -678,7 +687,6 @@ func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv
 	if corev1.ConditionTrue == r.kataConfig.Status.InstallationStatus.IsInProgress {
 		err, _ := r.updateInstallStatus()
 		if err != nil {
-			r.Log.Info("updateinstallstatus failed")
 			return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
 		}
 		if foundMcp.Status.DegradedMachineCount > 0 || mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions,
@@ -694,7 +702,6 @@ func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv
 	if corev1.ConditionTrue == r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress {
 		err, _ := r.updateUninstallStatus()
 		if err != nil {
-			r.Log.Info("update Uninstallstatus failed")
 			return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
 		}
 		if foundMcp.Status.DegradedMachineCount > 0 || mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions,
@@ -713,7 +720,6 @@ func (r *KataConfigOpenShiftReconciler) updateUninstallStatus() (error, bool) {
 	var err error
 	err, nodeList := r.getNodes()
 	if err != nil {
-		r.Log.Info("getNodes failed")
 		return err, false
 	}
 
@@ -732,7 +738,8 @@ func (r *KataConfigOpenShiftReconciler) updateUninstallStatus() (error, bool) {
 				err, r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList =
 					r.updateInProgressNodes(&node, r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList)
 			default:
-				r.Log.Info("error updating status, invalid machine config node state")
+				err = fmt.Errorf("Invalid machineconfig state: %v ", annotation)
+				r.Log.Error(err, "Error updating Uninstall status")
 			}
 		}
 	}
@@ -793,7 +800,6 @@ func (r *KataConfigOpenShiftReconciler) updateInstallStatus() (error, bool) {
 	var err error
 	err, nodeList := r.getNodes()
 	if err != nil {
-		r.Log.Info("getNodes failed")
 		return err, false
 	}
 
@@ -812,7 +818,8 @@ func (r *KataConfigOpenShiftReconciler) updateInstallStatus() (error, bool) {
 				err, r.kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList =
 					r.updateInProgressNodes(&node, r.kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList)
 			default:
-				r.Log.Info("error updating status, invalid machine config node state")
+				err = fmt.Errorf("Invalid machineconfig state: %v ", annotation)
+				r.Log.Error(err, "Error updating Install status")
 			}
 		}
 	}
@@ -822,7 +829,7 @@ func (r *KataConfigOpenShiftReconciler) updateInstallStatus() (error, bool) {
 func (r *KataConfigOpenShiftReconciler) updateFailedStatus(status kataconfigurationv1.KataFailedNodeStatus) (error, kataconfigurationv1.KataFailedNodeStatus) {
 	foundMcp, err := r.getMcp()
 	if err != nil {
-		r.Log.Info("couldn't get MCP information")
+		r.Log.Error(err, "couldn't get MachineConfigPool information")
 		return err, status
 	}
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -291,8 +291,13 @@ func (r *KataConfigOpenShiftReconciler) setRuntimeClass() (ctrl.Result, error) {
 		}
 
 		if r.kataConfig.Spec.KataConfigPoolSelector != nil {
+			r.Log.Info("KataConfigPoolSelector:", "r.kataConfig.Spec.KataConfigPoolSelector", r.kataConfig.Spec.KataConfigPoolSelector)
+			nodeSelector, err := metav1.LabelSelectorAsMap(r.kataConfig.Spec.KataConfigPoolSelector)
+			if err != nil {
+				r.Log.Error(err, "Unable to get nodeSelector for runtimeClass")
+			}
 			rc.Scheduling = &nodeapi.Scheduling{
-				NodeSelector: r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels,
+				NodeSelector: nodeSelector,
 			}
 		}
 		return rc

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -140,6 +140,20 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 			By("Creating and marking the second KataConfig CR with same custom node selector label correctly")
 			Expect(kataconfig2.Status.InstallationStatus.Failed.FailedNodesCount).Should(Equal(-1))
 
+			//Delete
+			By("Deleting KataConfig CR successfully")
+			kataConfigKey := types.NamespacedName{Name: kataconfig.Name}
+			Eventually(func() error {
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return k8sClient.Delete(context.Background(), kataconfig)
+			}, 5, time.Second).Should(Succeed())
+
+			By("Deleting KataConfig2 CR successfully")
+			Eventually(func() error {
+				k8sClient.Get(context.Background(), kataConfig2Key, kataconfig2)
+				return k8sClient.Delete(context.Background(), kataconfig2)
+			}, 5, time.Second).Should(Succeed())
+
 		})
 	})
 

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -2,12 +2,19 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
+	ignTypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	nodeapi "k8s.io/api/node/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -156,5 +163,229 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 
 		})
 	})
+	Context("Kata RuntimeClass Create", func() {
+		It("Should be created after successful CR creation", func() {
 
+			const (
+				name = "example-kataconfig"
+				timeout  = time.Second * 10
+				interval = time.Second * 2
+			)
+
+			// Create the Namespace
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "openshift-sandboxed-containers",
+				},
+			}
+
+			By("Creating the namespace successfully")
+			Expect(k8sClient.Create(context.Background(), ns)).Should(Succeed())
+
+			// Create Node
+			node := &corev1.Node{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Node",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker0",
+					Labels: map[string]string{"machineconfiguration.openshift.io/role": "worker",
+						"node-role.kubernetes.io/worker": ""},
+					Annotations: map[string]string{"machineconfiguration.openshift.io/state": "",
+						"machineconfiguration.openshift.io/currentConfig": "rendered-worker-00"},
+				},
+			}
+
+			By("Creating node worker0 successfully")
+			Expect(k8sClient.Create(context.Background(), node)).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] node: %v\n", node)
+
+			//Create MachineConfig
+			ic := ignTypes.Config{
+				Ignition: ignTypes.Ignition{
+					Version: "3.2.0",
+				},
+			}
+
+			icb, _ := json.Marshal(ic)
+
+			mc := &mcfgv1.MachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "machineconfiguration.openshift.io/v1",
+					Kind:       "MachineConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "00-worker",
+					Namespace: "openshift-sandboxed-containers",
+					Labels:    map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+				},
+				Spec: mcfgv1.MachineConfigSpec{
+					Extensions: []string{"sandboxed-containers"},
+					Config: runtime.RawExtension{
+						Raw: icb,
+					},
+				},
+			}
+
+			By("Creating the MachineConfig successfully")
+			Expect(k8sClient.Create(context.Background(), mc)).Should(Succeed())
+
+			mcp := &mcfgv1.MachineConfigPool{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "machineconfiguration.openshift.io/v1",
+					Kind:       "MachineConfigPool",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker",
+					Namespace: "openshift-sandboxed-containers", //This is needed otherwise MCP creation will fail
+					Labels:    map[string]string{"pools.operator.machineconfiguration.openshift.io/worker": ""},
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					MachineConfigSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "machineconfiguration.openshift.io/role", "worker"),
+					NodeSelector:          metav1.AddLabelToSelector(&metav1.LabelSelector{}, "node-role.kubernetes.io/worker", ""),
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+						ObjectReference: corev1.ObjectReference{
+							Name: "rendered-worker-00",
+						},
+					},
+				},
+			}
+
+			By("Creating the MachineConfigPool successfully")
+			Expect(k8sClient.Create(context.Background(), mcp)).Should(Succeed())
+
+			By("Getting the worker MachineConfigPool successfully")
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker"}, mcp)
+			}, timeout, interval).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] MachineConfigPool: %+v\n", mcp)
+
+			// Update MCP status
+			mcp.Status.MachineCount = 1
+			mcp.Status.ReadyMachineCount = 1
+			mcp.Status.UpdatedMachineCount = 1
+			mcp.Status.UnavailableMachineCount = 0
+			mcp.Status.DegradedMachineCount = 0
+			mcp.Status.ObservedGeneration = 2
+			mcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdated,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+
+			By("Updating MachineConfigPool status")
+			Expect(k8sClient.Status().Update(context.Background(), mcp)).Should(Succeed())
+
+			// Create KataConfig CR
+			kataConfig := &kataconfigurationv1.KataConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kataconfiguration.openshift.io/v1",
+					Kind:       "KataConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "openshift-sandboxed-containers",
+				},
+			}
+
+			By("Creating the KataConfig CR successfully")
+			Expect(k8sClient.Create(context.Background(), kataConfig)).Should(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: kataConfig.Name}, kataConfig)
+			}, timeout, interval).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] kataConfig: %+v\n", kataConfig)
+
+			// Change node state to indicate Install in progress
+			By("Updating Node status")
+			nodeRet := &corev1.Node{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker0"}, nodeRet)).Should(Succeed())
+
+			// Set Node annotations
+			nodeRet.Annotations["machineconfiguration.openshift.io/state"] = "Working"
+			node.Annotations["machineconfiguration.openshift.io/currentConfig"] = "rendered-worker-00"
+			Expect(k8sClient.Update(context.Background(), nodeRet)).Should(Succeed())
+
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] Node: %v\n", nodeRet)
+
+			// Change MCP state to indicate Install in progress
+			mcp.Status.ObservedGeneration = 3
+			mcp.Status.UnavailableMachineCount = 1
+			mcp.Status.MachineCount = 1
+			mcp.Status.ReadyMachineCount = 0
+			mcp.Status.UpdatedMachineCount = 0
+			mcp.Status.DegradedMachineCount = 0
+
+			mcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:               mcfgv1.MachineConfigPoolUpdating,
+					Status:             corev1.ConditionTrue,
+					Reason:             "",
+					Message:            "",
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+			}
+
+			By("Updating MCP status to Updating")
+			Expect(k8sClient.Status().Update(context.Background(), mcp)).Should(Succeed())
+
+			time.Sleep(interval)
+
+			By("Checking the KataConfig CR InstallationStatus")
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: kataConfig.Name}, kataConfig)).Should(Succeed())
+
+			//TBD InProgressNodesCount is not updated
+			Expect(kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList).Should(ContainElement("worker0"))
+
+			// Change node state to indicate Install complete
+			nodeRet = &corev1.Node{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker0"}, nodeRet)).Should(Succeed())
+
+			nodeRet.Annotations["machineconfiguration.openshift.io/state"] = "Done"
+			nodeRet.Annotations["machineconfiguration.openshift.io/currentConfig"] = "rendered-worker-00"
+			Expect(k8sClient.Update(context.Background(), nodeRet)).Should(Succeed())
+
+			// Change MCP state to indicate Install complete
+			mcp.Status.ObservedGeneration = 3
+			mcp.Status.UpdatedMachineCount = 1
+			mcp.Status.ReadyMachineCount = 1
+			mcp.Status.MachineCount = 1
+			mcp.Status.UnavailableMachineCount = 0
+
+			mcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:               mcfgv1.MachineConfigPoolUpdated,
+					Status:             corev1.ConditionTrue,
+					Reason:             "",
+					Message:            "",
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+			}
+
+			By("Updating MCP status to Updated")
+			Expect(k8sClient.Status().Update(context.Background(), mcp)).Should(Succeed())
+
+			time.Sleep(10 * time.Second)
+
+			By("Checking KataConfig Completed status")
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: kataConfig.Name}, kataConfig)).Should(Succeed())
+
+			Expect(kataConfig.Status.InstallationStatus.Completed.CompletedNodesCount).Should(Equal(1))
+			Expect(kataConfig.Status.InstallationStatus.Completed.CompletedNodesList).Should(ContainElement("worker0"))
+
+			By("Creating the RuntimeClass successfully")
+			rc := &nodeapi.RuntimeClass{}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "kata"}, rc)
+			}, timeout, interval).Should(Succeed())
+
+		})
+	})
 })


### PR DESCRIPTION

**Backports to release-4.8 branch**

8a56bb Set NodeSelector correctly when using MatchExpressions in KataConfigPoolSelector Fixes: #118
a02bda8 Update logging
8515520 Add unit test for node addition
bd09adf Add unit test to check for RuntimeClass creation
0d994b2 Print logs during ginkgo test execution
b532325 Cleanup resources post test