### PR TITLE
add must-gather scripts for sandboxed-containers

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,0 +1,20 @@
+FROM quay.io/openshift/origin-must-gather:latest as builder
+
+FROM centos:7
+
+ # For gathering data from nodes
+RUN yum update -y && yum install iproute tcpdump pciutils util-linux nftables rsync -y && yum clean all
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Save original gather script
+COPY --from=builder /usr/bin/gather /usr/bin/gather_original
+
+# Copy all collection scripts to /usr/bin
+COPY collection-scripts/* /usr/bin/
+
+# Copy node-gather resources to /etc
+COPY node-gather/node-gather-crd.yaml /etc/
+COPY node-gather/node-gather-ds.yaml /etc/
+
+ENTRYPOINT /usr/bin/gather

--- a/must-gather/LICENSE
+++ b/must-gather/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/must-gather/Makefile
+++ b/must-gather/Makefile
@@ -1,21 +1,21 @@
 IMAGE_REGISTRY ?= quay.io
 IMAGE_TAG ?= latest
 
-# MUST_GATHER_IMAGE needs to be passed explicitly to avoid accidentally pushing to kubevirt/must-gather
-ifndef MUST_GATHER_IMAGE
-$(error MUST_GATHER_IMAGE is not set.)
-endif
-
 build: podman-build podman-push
 
 # check
 check:
 	shellcheck collection-scripts/*
 
-podman-build:
+ensure-must-gather-image-is-set:
+ifndef MUST_GATHER_IMAGE
+	$(error MUST_GATHER_IMAGE is not set.)
+endif
+
+podman-build: ensure-must-gather-image-is-set
 	podman build --squash-all --no-cache . -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
 
-podman-push:
+podman-push: ensure-must-gather-image-is-set
 	podman push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
 
 .PHONY: build podman-build podman-push

--- a/must-gather/Makefile
+++ b/must-gather/Makefile
@@ -1,0 +1,21 @@
+IMAGE_REGISTRY ?= quay.io
+IMAGE_TAG ?= latest
+
+# MUST_GATHER_IMAGE needs to be passed explicitly to avoid accidentally pushing to kubevirt/must-gather
+ifndef MUST_GATHER_IMAGE
+$(error MUST_GATHER_IMAGE is not set.)
+endif
+
+build: podman-build podman-push
+
+# check
+check:
+	shellcheck collection-scripts/*
+
+podman-build:
+	podman build --squash-all --no-cache . -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
+
+podman-push:
+	podman push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
+
+.PHONY: build podman-build podman-push

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,35 @@
+# OpenShift sandboxed containers must-gather
+
+`must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
+that expands its capabilities to gather sandboxed containers information.
+
+### Usage
+```sh
+oc adm must-gather --image=quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-must-gather
+```
+
+The command above will create a local directory with a dump of the OpenShift sandboxed-containers state.
+Note that this command will only get data related to the sandboxed-containers part of the OpenShift cluster.
+
+You will get a dump of:
+- All namespaces (and their children objects) that belong to any sandboxed containers resources
+
+In order to get data about other parts of the cluster (not specific to sandboxed containers) you should
+run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
+
+### Development
+You can build the image locally using the Dockerfile included.
+
+A `makefile` is also provided. To use it, you must pass a repository via the command-line using the variable `MUST_GATHER_IMAGE`.
+You can also specify the registry using the variable `IMAGE_REGISTRY` (default is [quay.io](https://quay.io)) and the tag via `IMAGE_TAG` (default is `latest`).
+
+The targets for `make` are as follows:
+- `build`: builds the image with the supplied name and pushes it
+- `podman-build`: builds the image but does not push it
+- `podman-push`: pushes an already-built image
+
+For example:
+```sh
+make build MUST_GATHER_IMAGE=openshift_sandboxed_containers/openshift-sandboxed-containers-must-gather
+```
+would build the local repository as `quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-must-gather:latest` and then push it.

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -36,4 +36,7 @@ done
 # Workaround for: https://github.com/openshift/must-gather/issues/122
 /usr/bin/gather_images
 
+# Collect sandboxed-containers details
+/usr/bin/gather_sandboxed_containers_logs
+
 exit 0

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Resource list
+resources=()
+
+# sandboxed containers related namespaces
+resources+=(ns/openshift-operator-lifecycle-manager)
+resources+=(ns/openshift-marketplace)
+
+# ImageStreamTag
+resources+=(istag)
+
+# Nodes and Machines
+resources+=(nodes)
+resources+=(machines)
+
+# Run the collection of resources using must-gather
+for resource in "${resources[@]}"; do
+    echo "Inspecting resource ${resource}..."
+    /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces "${resource}" &> /dev/null
+done
+
+# Collect CRDs
+/usr/bin/gather_crds
+
+# Collect the apiservices
+/usr/bin/gather_apiservices
+
+# Collect nodes details
+/usr/bin/gather_nodes
+
+# Collect image details
+# Workaround for: https://github.com/openshift/must-gather/issues/122
+/usr/bin/gather_images
+
+exit 0

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -26,6 +26,9 @@ done
 # Collect the apiservices
 /usr/bin/gather_apiservices
 
+# Collect "audit" details
+/usr/bin/gather_audit_logs
+
 # Collect nodes details
 /usr/bin/gather_nodes
 

--- a/must-gather/collection-scripts/gather_apiservices
+++ b/must-gather/collection-scripts/gather_apiservices
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="/must-gather"
+
+# Resource list
+resources=()
+
+for i in $(/usr/bin/oc get apiservices --all-namespaces | grep kata | awk '{ print $1 }')
+do
+  resources+=("$i")
+done
+
+# we use nested loops to nicely output objects partitioned per namespace, kind
+for resource in "${resources[@]}"; do
+  apiservice_collection_path=${BASE_COLLECTION_PATH}/apiservices/
+
+  mkdir -p ${apiservice_collection_path}
+
+  /usr/bin/oc get apiservice "${resource}" -o yaml > "${apiservice_collection_path}/${resource}.yaml"
+done
+
+exit 0

--- a/must-gather/collection-scripts/gather_audit_logs
+++ b/must-gather/collection-scripts/gather_audit_logs
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Downloads the audit.log (and its rotated copies) from
+# /var/logs/{kube-apiserver,openshift-apiserver} on each
+# master node.
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+echo "INFO: Collecting one or more audit logs on ALL worker nodes in your cluster."
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+paths=(audit)
+for path in "${paths[@]}" ; do
+  output_dir="${BASE_COLLECTION_PATH}/audit_logs/$path"
+  mkdir -p "$output_dir"
+  oc adm node-logs --role=worker --path="$path" | \
+  tee "${BASE_COLLECTION_PATH}/audit_logs/$path.audit_logs_listing" | \
+  grep -v ".terminating" | \
+  grep -v ".lock" | \
+  sed "s|^|$path $output_dir |"
+done | \
+xargs --max-args=4 --max-procs=45 bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+echo "INFO: Audit logs collected."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/must-gather/collection-scripts/gather_audit_logs
+++ b/must-gather/collection-scripts/gather_audit_logs
@@ -10,6 +10,7 @@ echo "INFO: Collecting one or more audit logs on ALL worker nodes in your cluste
 # $3 - node name
 # $4 - log file name
 paths=(audit)
+# shellcheck disable=SC2016
 for path in "${paths[@]}" ; do
   output_dir="${BASE_COLLECTION_PATH}/audit_logs/$path"
   mkdir -p "$output_dir"

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Resource list
+resources=()
+
+for i in $(/usr/bin/oc get crd | grep kata | awk '{print $1}')
+do
+  resources+=("crd/$i")
+done
+
+# Run the collection of resources using must-gather
+for resource in "${resources[@]}"; do
+  /usr/bin/oc adm inspect --dest-dir must-gather "${resource}"
+done
+
+exit 0

--- a/must-gather/collection-scripts/gather_images
+++ b/must-gather/collection-scripts/gather_images
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+
+IMAGES_PATH=${BASE_COLLECTION_PATH}/cluster-scoped-resources
+NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces
+
+mkdir -p ${IMAGES_PATH}
+for name in $(oc get image -o=custom-columns=NAME:.metadata.name --no-headers)
+do
+    echo "Gathering image $name"
+    oc get image "$name" -o yaml >> "${IMAGES_PATH}/images"
+    echo '---------------' >> "${IMAGES_PATH}/images"
+done
+
+for line in $(oc get imagestreams -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name --no-headers --all-namespaces)
+do
+    IFS=$' '
+    read -r namespace name <<< "$line"
+    IFS=$'\n'
+    echo "Gathering imagestream $namespace/$name"
+    mkdir -p "${NAMESPACE_PATH}/${namespace}"
+    oc get imagestream "${name}" -n "${namespace}" -o yaml >> "${NAMESPACE_PATH}/${namespace}/imagestreams"
+    echo '---------------' >> "${NAMESPACE_PATH}/${namespace}/imagestreams"
+done
+
+for line in $(oc get imagestreamtags -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name --no-headers --all-namespaces)
+do
+    IFS=$' '
+    read -r namespace name <<< "$line"
+    IFS=$'\n'
+    echo "Gathering imagestreamtag $namespace/$name"
+    mkdir -p "${NAMESPACE_PATH}/${namespace}"
+    oc get imagestreamtag "${name}" -n "${namespace}" -o yaml >> "${NAMESPACE_PATH}/${namespace}/imagestreamtags"
+    echo '---------------' >> "${NAMESPACE_PATH}/${namespace}/imagestreamtags"
+done

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -78,7 +78,6 @@ gather_single_pod() {
     config_dirs=(etc/cni/net.d etc/kubernetes/cni/net.d)
     IFS=$' '
     for conf_dir in "${config_dirs[@]}"; do
-        oc exec "$pod" -n node-gather -- [ -d "/host/$conf_dir" ] 2>/dev/null
         if oc exec "$pod" -n node-gather -- [ -d "/host/$conf_dir" ] 2>/dev/null; then
             CNI_COFIG_PATH=${NODE_PATH}/$conf_dir
             mkdir -p "${CNI_COFIG_PATH}"

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -94,6 +94,14 @@ gather_single_pod() {
     if oc exec "$pod" -n node-gather -- [ -f /host/etc/pcidp/config.json ] 2>/dev/null; then
         oc cp "$pod:/host/etc/pcidp/config.json" "$NODE_PATH/pcidp_config.json" -n node-gather 2>/dev/null
     fi
+
+    if oc exec "$pod" -n node-gather -- [ -d "/host/run/vc" ] 2>/dev/null; then
+        echo "Collecting sandboxed-containers specific logs"
+
+        VC_PATH="$NODE_PATH/run/vc/"
+        mkdir -p "${VC_PATH}"
+        oc cp "$pod:/host/run/vc/" "${VC_PATH}" -n node-gather 2>/dev/null
+    fi
 }
 
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n node-gather)

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -82,7 +82,7 @@ gather_single_pod() {
             CNI_COFIG_PATH=${NODE_PATH}/$conf_dir
             mkdir -p "${CNI_COFIG_PATH}"
             oc cp "$pod:/host/$conf_dir ${CNI_COFIG_PATH}" -n node-gather 2>/dev/null
-    fi
+        fi
     done
     IFS=$'\n'
 

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+check_node_gather_pods_ready() {
+    line=$(oc get ds node-gather-daemonset -o=custom-columns=DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady --no-headers -n node-gather)
+
+    IFS=$' '
+    read -r desired ready <<< "$line"
+    IFS=$'\n'
+
+    if [[ "$desired" != "0" ]] && [[ "$ready" == "$desired" ]]
+    then
+       return 0
+    else
+       return 1
+    fi
+}
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+NODES_PATH=${BASE_COLLECTION_PATH}/nodes
+mkdir -p ${NODES_PATH}
+CRD_MANIFEST="/etc/node-gather-crd.yaml"
+DAEMONSET_MANIFEST="/etc/node-gather-ds.yaml"
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+POD_NAME=$(oc get pods -l app=must-gather -n "$NAMESPACE" -o'custom-columns=name:metadata.name' --no-headers)
+MUST_GATHER_IMAGE=$(oc get pod -n "$NAMESPACE" "$POD_NAME" -o jsonpath="{.spec.containers[0].image}")
+
+sed -i -e "s#MUST_GATHER_IMAGE#$MUST_GATHER_IMAGE#" $DAEMONSET_MANIFEST
+
+oc create -f $CRD_MANIFEST
+oc adm policy add-scc-to-user privileged -n node-gather -z node-gather
+oc create -f $DAEMONSET_MANIFEST
+
+COUNTER=0
+until check_node_gather_pods_ready || [ $COUNTER -eq 300 ]; do
+    if [[ $(( COUNTER % 20 )) == 0 ]]; then
+        echo "Waiting for node-gather-daemonset to be ready"
+    fi
+    (( COUNTER++ ))
+    sleep 1
+done
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName --no-headers --field-selector=status.phase!=Running -n node-gather)
+do
+    echo "Failed to collect node-gather data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
+done
+
+gather_single_pod() {
+    line="$1"
+
+    node=$(echo "$line" | awk -F ' ' '{print $1}')
+    pod=$(echo "$line" | awk -F ' ' '{print $2}')
+    NODE_PATH=${NODES_PATH}/$node
+    mkdir -p "${NODE_PATH}"
+
+    echo "$pod - Gathering node data"
+
+    oc exec "$pod" -n node-gather -- ip a 2>/dev/null >> "$NODE_PATH/ip.txt"
+    oc exec "$pod" -n node-gather -- ip -o link show type bridge 2>/dev/null >> "$NODE_PATH/bridge"
+    oc exec "$pod" -n node-gather -- bridge -j vlan show 2>/dev/null >> "$NODE_PATH/vlan"
+
+    for i in $(oc exec "$pod" -n node-gather -- nft list tables 2>/dev/null);
+    do
+        family=$(echo "$i" | awk -F ' ' '{print $2}' | sed 's/\r//')
+        table=$(echo "$i" | awk -F ' ' '{print $3}' | sed 's/\r//')
+        oc exec "$pod" -n node-gather -- nft list table "$family" "$table" 2>/dev/null > "$NODE_PATH/nft-${family}-${table}"
+    done
+
+    # shellcheck disable=SC2016
+    oc exec "$pod" -n node-gather -- /bin/bash -c 'for dev in /host/sys/bus/pci/devices/*; do if [[ -e $dev/sriov_numvfs ]]; then echo "sriov_numvfs on dev ${dev##*/}: $(cat $dev/sriov_numvfs)"; fi; done' >> "$NODE_PATH/sys_sriov_numvfs"
+    # shellcheck disable=SC2016
+    oc exec "$pod" -n node-gather -- /bin/bash -c 'for dev in /host/sys/bus/pci/devices/*; do if [[ -e $dev/sriov_totalvfs ]]; then echo "sriov_totalvfs on dev ${dev##*/}: $(cat $dev/sriov_totalvfs)"; fi; done' >> "$NODE_PATH/sys_sriov_totalvfs"
+
+    oc exec "$pod" -n node-gather -- /bin/bash -c 'if [[ -d /host/opt/cni/bin ]]; then ls -l /host/opt/cni/bin; fi' > "${NODE_PATH}/opt-cni-bin"
+    oc exec "$pod" -n node-gather -- /bin/bash -c 'if [[ -d /host/var/lib/must-gather/cni/bin ]]; then ls -l /host/var/lib/cni/bin; fi' > "${NODE_PATH}/var-lib-cni-bin"
+
+    config_dirs=(etc/cni/net.d etc/kubernetes/cni/net.d)
+    IFS=$' '
+    for conf_dir in "${config_dirs[@]}"; do
+        oc exec "$pod" -n node-gather -- [ -d "/host/$conf_dir" ] 2>/dev/null
+        if oc exec "$pod" -n node-gather -- [ -d "/host/$conf_dir" ] 2>/dev/null; then
+            CNI_COFIG_PATH=${NODE_PATH}/$conf_dir
+            mkdir -p "${CNI_COFIG_PATH}"
+            oc cp "$pod:/host/$conf_dir ${CNI_COFIG_PATH}" -n node-gather 2>/dev/null
+    fi
+    done
+    IFS=$'\n'
+
+    oc exec "$pod" -n node-gather -- ls -al /host/dev/vfio/ 2>/dev/null >> "$NODE_PATH/dev_vfio"
+    oc exec "$pod" -n node-gather -- dmesg 2>/dev/null >> "$NODE_PATH/dmesg"
+    oc exec "$pod" -n node-gather -- cat /host/proc/cmdline 2>/dev/null >> "$NODE_PATH/proc_cmdline"
+    oc exec "$pod" -n node-gather -- lspci -vv 2>/dev/null >> "$NODE_PATH/lspci"
+
+    if oc exec "$pod" -n node-gather -- [ -f /host/etc/pcidp/config.json ] 2>/dev/null; then
+        oc cp "$pod:/host/etc/pcidp/config.json" "$NODE_PATH/pcidp_config.json" -n node-gather 2>/dev/null
+    fi
+}
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n node-gather)
+do
+    gather_single_pod "$line" &
+done
+
+wait
+
+# Collect journal logs for specified units for all nodes
+NODE_UNITS=(kubelet crio)
+for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
+    NODE_PATH=${NODES_PATH}/$NODE
+    mkdir -p "${NODE_PATH}"
+    for UNIT in "${NODE_UNITS[@]}"; do
+        oc adm node-logs "$NODE" -u "$UNIT" > "${NODE_PATH}/${NODE}_logs_$UNIT" &
+    done
+done
+
+oc delete -f $DAEMONSET_MANIFEST
+oc delete -f $CRD_MANIFEST

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -70,4 +70,5 @@ mkdir -p ${LIFECYCLE_MANAGER_NS}
 
 for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
     oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+    oc describe pod "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_description"
 done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -9,3 +9,19 @@ OSC_PATH=${BASE_COLLECTION_PATH}/sandboxed-containers
 mkdir -p ${OSC_PATH}
 
 oc describe kataconfig > "${OSC_PATH}/kataconfig_description"
+
+# operators
+operators=()
+#  logs from everything in the following operators namespaces
+#  - openshift-sandboxed-containers-operator
+operators+=(openshift-sandboxed-containers-operator)
+
+NAMESPACE_PATH=${OSC_PATH}/namespaces
+for operator in "${operators[@]}"; do
+    OPERATOR_NS=${NAMESPACE_PATH}/${operator}
+    mkdir -p ${OPERATOR_NS}
+
+    for pod in $(oc get pods -n "${operator}" -o'custom-columns=name:metadata.name' --no-headers); do
+        oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
+    done
+done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -27,3 +27,16 @@ for operator in "${operators[@]}"; do
         oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
     done
 done
+
+# mcps
+mcps=()
+#  description of the following mcps
+#  - master
+mcps+=(master)
+
+MCP_PATH=${OSC_PATH}/mcps
+mkdir -p ${MCP_PATH}
+
+for mcp in "${mcps[@]}"; do
+    oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -46,3 +46,11 @@ for mcp in "${mcps[@]}"; do
         oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
     fi	    
 done
+
+# installplans
+INSTALLPLAN_NS=${NAMESPACE_PATH}/openshift-sandboxed-containers-operator
+mkdir -p ${INSTALLPLAN_NS}
+
+for installplan in $(oc get installplans -n openshift-sandboxed-containers-operator -o'custom-columns=name:metadata.name' --no-headers); do
+    oc describe installplan ${installplan} -n openshift-sandboxed-containers-operator > "${INSTALLPLAN_NS}/${installplan}_description"
+done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -32,7 +32,9 @@ done
 mcps=()
 #  description of the following mcps
 #  - master
+#  - worker
 mcps+=(master)
+mcps+=(worker)
 
 MCP_PATH=${OSC_PATH}/mcps
 mkdir -p ${MCP_PATH}

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -24,7 +24,7 @@ for operator in "${operators[@]}"; do
     mkdir -p ${OPERATOR_NS}
 
     for pod in $(oc get pods -n "${operator}" -o'custom-columns=name:metadata.name' --no-headers); do
-        oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
+        oc logs "${pod}" --all-containers -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
     done
 done
 
@@ -60,7 +60,7 @@ MARKETPLACE_NS=${NAMESPACE_PATH}/openshift-marketplace
 mkdir -p ${MARKETPLACE_NS}
 
 for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
-    oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+    oc logs "${pod}" --all-containers -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done
 
@@ -69,6 +69,6 @@ LIFECYCLE_MANAGER_NS=${LIFECYCLE_MANAGER_NS}/openshift-operator-lifecycle-manage
 mkdir -p ${LIFECYCLE_MANAGER_NS}
 
 for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
-    oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+    oc logs "${pod}" --all-containers -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_description"
 done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -33,12 +33,16 @@ mcps=()
 #  description of the following mcps
 #  - master
 #  - worker
+#  - kata-oc
 mcps+=(master)
 mcps+=(worker)
+mcps+=(kata-oc)
 
 MCP_PATH=${OSC_PATH}/mcps
 mkdir -p ${MCP_PATH}
 
 for mcp in "${mcps[@]}"; do
-    oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+    if $(oc get mcp $mcp &>/dev/null); then
+        oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+    fi	    
 done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+
+# kataconfig
+OSC_PATH=${BASE_COLLECTION_PATH}/sandboxed-containers
+mkdir -p ${OSC_PATH}
+
+oc describe kataconfig > "${OSC_PATH}/kataconfig_description"

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -63,3 +63,11 @@ for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadat
     oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done
+
+# lifecycle-manager
+LIFECYCLE_MANAGER_NS=${LIFECYCLE_MANAGER_NS}/openshift-operator-lifecycle-manager
+mkdir -p ${LIFECYCLE_MANAGER_NS}
+
+for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
+    oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -54,3 +54,11 @@ mkdir -p ${INSTALLPLAN_NS}
 for installplan in $(oc get installplans -n openshift-sandboxed-containers-operator -o'custom-columns=name:metadata.name' --no-headers); do
     oc describe installplan ${installplan} -n openshift-sandboxed-containers-operator > "${INSTALLPLAN_NS}/${installplan}_description"
 done
+
+# marketplace
+MARKETPLACE_NS=${NAMESPACE_PATH}/openshift-marketplace
+mkdir -p ${MARKETPLACE_NS}
+
+for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
+    oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+done

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -14,7 +14,9 @@ oc describe kataconfig > "${OSC_PATH}/kataconfig_description"
 operators=()
 #  logs from everything in the following operators namespaces
 #  - openshift-sandboxed-containers-operator
+#  - openshift-machine-config-operator
 operators+=(openshift-sandboxed-containers-operator)
+operators+=(openshift-machine-config-operator)
 
 NAMESPACE_PATH=${OSC_PATH}/namespaces
 for operator in "${operators[@]}"; do

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -61,4 +61,5 @@ mkdir -p ${MARKETPLACE_NS}
 
 for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
     oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+    oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done

--- a/must-gather/node-gather/node-gather-crd.yaml
+++ b/must-gather/node-gather/node-gather-crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-gather
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-gather
+  namespace: node-gather
+

--- a/must-gather/node-gather/node-gather-ds.yaml
+++ b/must-gather/node-gather/node-gather-ds.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-gather-daemonset
+  namespace: node-gather
+  labels:
+spec:
+  selector:
+    matchLabels:
+      name: node-gather-daemonset
+  template:
+    metadata:
+      labels:
+        name: node-gather-daemonset
+    spec:
+      serviceaccount: node-gather
+      serviceAccountName: node-gather
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: node-probe
+        image: MUST_GATHER_IMAGE
+        command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: sys
+            mountPath: /host/sys
+          - name: proc
+            mountPath: /host/proc
+          - name: dev
+            mountPath: /host/dev
+          - name: etc
+            mountPath: /host/etc
+          - name: opt
+            mountPath: /host/opt
+          - name: var
+            mountPath: /host/var            
+        securityContext:
+          privileged: true
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: proc
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: dev
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: etc
+        hostPath:
+          path: /etc
+          type: Directory
+      - name: opt
+        hostPath:
+          path: /opt
+          type: Directory
+      - name: var
+        hostPath:
+          path: /var
+          type: Directory
+

--- a/must-gather/node-gather/node-gather-ds.yaml
+++ b/must-gather/node-gather/node-gather-ds.yaml
@@ -50,6 +50,8 @@ spec:
             mountPath: /host/opt
           - name: var
             mountPath: /host/var            
+          - name: run
+            mountPath: /host/run
         securityContext:
           privileged: true
       volumes:
@@ -77,4 +79,7 @@ spec:
         hostPath:
           path: /var
           type: Directory
-
+      - name: run
+        hostPath:
+          path: /run
+          type: Directory


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
While not strictly belonging to the Operator code, the team decided it's most practical
to maintain the must-gather scripts and relevant files in the same repository. 

must-gather is a tool built on top of OpenShift must-gather that expands
its capabilities to gather sandboxed containers information.

oc adm must-gather --image=quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-must-gather

The command above will create a local directory with a dump of the
OpenShift sandboxed-containers state. Note that this command will only
get data related to the sandboxed-containers part of the OpenShift
cluster.

You will get a dump of:

    All namespaces (and their children objects) that belong to any
     sandboxed containers resources




**- What I did**
Work was done by @fidencio. With the Dockerfile and the scripts he provided we can now build a must-gather
image that can be passed to the 'oc adm must-gather' command. 

**- How to verify it**
Follow the instructions in the README file

**- Description for the changelog**
Add must-gather scripts for collecting sandboxed-containers debug information



