### PR TITLE
update CRD version to v1

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.crd.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -256,11 +256,25 @@ spec:
           - totalNodesCount
           type: object
       type: object
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Use apiextensions.k8s.io/v1 instead of v1beta1, which is not supported anymore. We need to switch to
version v1 or we can't create our own KataConfig CRD anymore. To be clear,
we're updating the version of the CustomResourceDefinition kind, not the version of kataconfig.

See https://github.com/kubernetes/kubernetes/pull/79604 
