### PR TITLE
KATA-1011: update Status of nodes with selected label

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -586,9 +586,23 @@ func (r *KataConfigOpenShiftReconciler) getMcp() (*mcfgv1.MachineConfigPool, err
 	return foundMcp, nil
 }
 
+func (r *KataConfigOpenShiftReconciler) poolSelectorLabels() (map[string]string) {
+	flat := map[string]string{}
+	for key, value := range r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels {
+		flat[key] = value
+	}
+
+	return flat
+}
+
 func (r *KataConfigOpenShiftReconciler) getNodes() (error, *corev1.NodeList) {
 	nodes := &corev1.NodeList{}
-	labelSelector := labels.SelectorFromSet(map[string]string{"node-role.kubernetes.io/worker": ""})
+	nodesLabels := r.poolSelectorLabels()
+	if len(nodesLabels) == 0 {
+		return nil, nodes
+	}
+
+	labelSelector := labels.SelectorFromSet(nodesLabels)
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	}


### PR DESCRIPTION
We used to select nodes labelled as workers only. This is wrong
when the user selected a custom label for nodes where the runtime
should be installed. Another case where this doesn't work is on
compact clusters because there we use the master machine config pool.

This can be fixed by using the label that is specified in the
KataConfigPoolSelector.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
