### PR TITLE
Revert fix for Kata-1011

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -586,23 +586,9 @@ func (r *KataConfigOpenShiftReconciler) getMcp() (*mcfgv1.MachineConfigPool, err
 	return foundMcp, nil
 }
 
-func (r *KataConfigOpenShiftReconciler) poolSelectorLabels() (map[string]string) {
-	flat := map[string]string{}
-	for key, value := range r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels {
-		flat[key] = value
-	}
-
-	return flat
-}
-
 func (r *KataConfigOpenShiftReconciler) getNodes() (error, *corev1.NodeList) {
 	nodes := &corev1.NodeList{}
-	nodesLabels := r.poolSelectorLabels()
-	if len(nodesLabels) == 0 {
-		return nil, nodes
-	}
-
-	labelSelector := labels.SelectorFromSet(nodesLabels)
+	labelSelector := labels.SelectorFromSet(map[string]string{"node-role.kubernetes.io/worker": ""})
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
The fix for [KATA-1011](https://issues.redhat.com/browse/KATA-1011) breaks the status updates. No node names are shown when installing or uninstall of the kata runtime.

**- What I did**
Created two builds - with and without [KATA-1011](https://issues.redhat.com/browse/KATA-1011) fix and verified (un)install workflow

**- How to verify it**
Create kataconfig and watch the status of the CR. With [KATA-1011](https://issues.redhat.com/browse/KATA-1011) fix the node names are not populated.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Revert fix for [KATA-1011](https://issues.redhat.com/browse/KATA-1011) 