### PR TITLE
KATA-918: Create NFD as a soft dependency for Sandboxed Containers Operator

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -29,6 +29,12 @@ type KataConfigSpec struct {
 	// +optional
 	// +nullable
 	KataConfigPoolSelector *metav1.LabelSelector `json:"kataConfigPoolSelector"`
+
+	// CheckNodeEligibility is used to detect the node(s) readiness to run
+	// Kata containers. If set to true then, NFD operator is used to check
+	// the readiness
+	// +kubebuilder:default:=false
+	CheckNodeEligibility bool `json:"checkNodeEligibility"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=sandboxed-containers-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=preview-1.0
 LABEL operators.operatorframework.io.bundle.channel.default.v1=preview-1.0
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.12.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -35,6 +35,12 @@ spec:
             description: KataConfigSpec defines the desired state of KataConfig
             nullable: true
             properties:
+              checkNodeEligibility:
+                default: false
+                description: CheckNodeEligibility is used to detect the node(s) readiness
+                  to run Kata containers. If set to true then, NFD operator is used
+                  to check the readiness
+                type: boolean
               kataConfigPoolSelector:
                 description: KataConfigPoolSelector is used to filter the worker nodes
                   if not specified, all worker nodes are selected
@@ -81,6 +87,8 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - checkNodeEligibility
             type: object
           status:
             description: KataConfigStatus defines the observed state of KataConfig

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -14,10 +14,10 @@ metadata:
       ]
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.12.0
+    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/sandboxed-containers-operator
-  name: sandboxed-containers-operator.v1.0.1
+  name: sandboxed-containers-operator.v1.2.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -302,7 +302,7 @@ spec:
   provider:
     name: Red Hat
   replaces: sandboxed-containers-operator.v1.0.0
-  version: 1.0.1
+  version: 1.2.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: sandboxed-containers-operator
   operators.operatorframework.io.bundle.channels.v1: preview-1.0
   operators.operatorframework.io.bundle.channel.default.v1: preview-1.0
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.12.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -37,6 +37,12 @@ spec:
             description: KataConfigSpec defines the desired state of KataConfig
             nullable: true
             properties:
+              checkNodeEligibility:
+                default: false
+                description: CheckNodeEligibility is used to detect the node(s) readiness
+                  to run Kata containers. If set to true then, NFD operator is used
+                  to check the readiness
+                type: boolean
               kataConfigPoolSelector:
                 description: KataConfigPoolSelector is used to filter the worker nodes
                   if not specified, all worker nodes are selected
@@ -83,6 +89,8 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - checkNodeEligibility
             type: object
           status:
             description: KataConfigStatus defines the observed state of KataConfig

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -592,4 +592,25 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 
 		})
 	})
+	Context("Custom KataConfig with CheckNodeEligibility create", func() {
+		It("Should support KataConfig with CheckNodeEligibility set", func() {
+
+			kataConfig := &kataconfigurationv1.KataConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kataconfiguration.openshift.io/v1",
+					Kind:       "KataConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: kataconfigurationv1.KataConfigSpec{
+					CheckNodeEligibility: true,
+				},
+			}
+
+			By("Creating the KataConfig CR successfully")
+			Expect(k8sClient.Create(context.Background(), kataConfig)).Should(Succeed())
+
+		})
+	})
 })


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Fixes: [KATA-918](https://issues.redhat.com/browse/KATA-918)

We have seen cases where users successfully deploy sandboxed-containers operator on cluster nodes but encounter errors when creating Kata containers due to missing capabilities. For example kata containers don’t work on AWS EC2 instances.

**- What I did**
Created a new role `kata-oc` (node-role.kubernetes.io/kata-oc) to handle nodes with Kata runtime. Also a new config variable `checkNodeEligibility` is added to KataConfig. If `checkNodeEligibility` is selected, then the operator will look for the node label `feature.node.kubernetes.io/runtime.kata` on the nodes which have the requisite support to run kata containers. 
When `NodeFeatureDiscovery` operator is available in the cluster, then the same can be used to label the nodes. Otherwise it's left to the cluster admin to label the nodes which are capable to run Kata containers.

**- How to verify it**

If NFD is installed, then create a NodeFeatureDiscovery object using the following yaml

```apiVersion: nfd.openshift.io/v1
kind: NodeFeatureDiscovery
metadata:
  name: nfd-master-server
  namespace: openshift-operators
spec:
  operand:
    image: 'registry.redhat.io/openshift4/ose-node-feature-discovery:v4.7.0'
    imagePullPolicy: Always
    namespace: node-feature-discovery-operator
  workerConfig:
    configData: |
      sources:
        custom:
          - name: "runtime.kata"
            matchOn:
              - cpuId: ["SSE4.1", "VMX"]
                loadedKMod: ["kvm", "kvm_intel"]
              - cpuId: ["SSE4.1", "SVM"]
                loadedKMod: ["kvm", "kvm_amd"]

```

If NFD is not available, then label the nodes which you think are capable of running Kata containers
```
oc label node <node-name> feature.node.kubernetes.io/runtime.kata=true
```

Deploy the operator and when creating KataConfig, select "checkNodeEligibility"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Provide support for checking node suitability to run Kata containers using NFD operator