### PR TITLE
KATA-1136: Metrics prometheus setup

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../kata-monitor
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook

--- a/config/kata-monitor/kata-monitor-service.yaml
+++ b/config/kata-monitor/kata-monitor-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics
+  namespace: openshift-sandboxed-containers-operator
+  labels:
+    name: openshift-sandboxed-containers-monitor
+spec:
+  selector:
+    name: openshift-sandboxed-containers-monitor
+  ports:
+    - name: metrics
+      port: 8090
+      protocol: TCP

--- a/config/kata-monitor/kata-monitor-servicemonitor.yaml
+++ b/config/kata-monitor/kata-monitor-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-sandboxed-containers-monitor
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  namespaceSelector:
+    matchNames:
+    - openshift-sandboxed-containers-operator
+  selector:
+    matchLabels:
+      name: openshift-sandboxed-containers-monitor
+  endpoints:
+  - port: metrics

--- a/config/kata-monitor/kustomization.yaml
+++ b/config/kata-monitor/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- kata-monitor-service.yaml
+- kata-monitor-servicemonitor.yaml

--- a/config/rbac/katamonitor.yaml
+++ b/config/rbac/katamonitor.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: monitor-role
+  namespace: openshift-sandboxed-containers-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monitor-rolebinding
+  namespace: openshift-sandboxed-containers-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: monitor-role
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- katamonitor.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -142,7 +142,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 
 	if monitorImage == "" {
 		r.Log.Info("OSC_MONITOR_IMAGE is not set, using default image")
-		monitorImage = "quay.io/openshift_sandboxed_monitors/openshift-sandboxed-containers-monitor:latest"
+		monitorImage = "quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest"
 	}
 	dsName := "openshift-sandboxed-containers-monitor"
 	dsLabels := map[string]string{

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -126,7 +126,7 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 				res = ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}
 			}
 		} else if err != nil {
-			r.Log.Info("could not get monitor daemonset, try again", err)
+			r.Log.Error(err, "could not get monitor daemonset, try again")
 			res = ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}
 		}
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	"os"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -101,8 +103,123 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 			return ctrl.Result{}, updateErr
 		}
 
+		ds := r.processDaemonsetForMonitor()
+		// Set KataConfig instance as the owner and controller
+		if ds != nil {
+			r.Log.Info("daemonset is not nil")
+			if err := controllerutil.SetControllerReference(r.kataConfig, ds, r.Scheme); err != nil {
+				r.Log.Error(err, "setcontrollerreference failed")
+				return ctrl.Result{}, err
+			}
+			r.Log.Info("setcontrollerreference successful")
+		} else {
+			r.Log.Info("ds returned was nil")
+			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
+		}
+		foundDs := &appsv1.DaemonSet{}
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, foundDs)
+		if err != nil && k8serrors.IsNotFound(err) {
+			r.Log.Info("Creating a new installation monitor daemonset", "ds.Namespace", ds.Namespace, "ds.Name", ds.Name)
+			err = r.Client.Create(context.TODO(), ds)
+			if err != nil {
+				r.Log.Error(err, "error when creating monitor daemonset")
+				res = ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}
+			}
+		} else if err != nil {
+			r.Log.Info("could not get monitor daemonset, try again", err)
+			res = ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}
+		}
+
 		return res, err
 	}()
+}
+
+func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.DaemonSet {
+	var (
+		runPrivileged = true
+		monitorImage  = os.Getenv("OSC_MONITOR_IMAGE")
+	)
+
+	if monitorImage == "" {
+		r.Log.Info("OSC_MONITOR_IMAGE is not set, using default image")
+		monitorImage = "quay.io/openshift_sandboxed_monitors/openshift-sandboxed-containers-monitor:latest"
+	}
+	dsName := "openshift-sandboxed-containers-monitor"
+	dsLabels := map[string]string{
+		"name": dsName,
+	}
+
+	var nodeSelector map[string]string
+	if r.kataConfig.Spec.KataConfigPoolSelector != nil {
+		nodeSelector = r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels
+	} else {
+		nodeSelector = map[string]string{
+			"node-role.kubernetes.io/worker": "",
+		}
+	}
+
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: "openshift-sandboxed-containers-operator",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: dsLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: dsLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "default",
+					NodeSelector:       nodeSelector,
+					Containers: []corev1.Container{
+						{
+							Name:            "kata-monitor",
+							Image:           monitorImage,
+							ImagePullPolicy: "Always",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &runPrivileged,
+							},
+							Command: []string{"/usr/bin/kata-monitor", "--log-level=debug", "--runtime-endpoint=/run/crio/crio.sock"},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "crio-sock",
+									MountPath: "/run/crio/",
+								},
+								{
+									Name:      "sbs",
+									MountPath: "/run/vc/sbs/",
+								}},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "crio-sock",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/run/crio/",
+								},
+							},
+						},
+						{
+							Name: "sbs",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/run/vc/sbs/",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func (r *KataConfigOpenShiftReconciler) newMCPforCR() (*mcfgv1.MachineConfigPool, error) {
@@ -508,6 +625,19 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	if err != nil {
 		r.Log.Error(err, "Unable to update KataConfig status")
 		return ctrl.Result{}, err
+	}
+
+	ds := r.processDaemonsetForMonitor()
+	if ds == nil {
+		r.Log.Error(err, "error deleting monitor Daemonset")
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	}
+	err = r.Client.Delete(context.TODO(), ds)
+	if err != nil && k8serrors.IsNotFound(err) {
+		r.Log.Info("monitor daemonset was already deleted")
+	} else if err != nil {
+		r.Log.Error(err, "error when deleting monitor Daemonset, try again")
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 15}, err
 	}
 
 	r.Log.Info("Uninstallation completed. Proceeding with the KataConfig deletion")

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
 	if err = (&kataconfigurationv1.KataConfig{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KataConfig")
 		os.Exit(1)


### PR DESCRIPTION


**- Description**
Implements [KATA-1136](https://issues.redhat.com/browse/KATA-1136)

This pull request is meant to make the Operator install everything needed to have kata metrics visible in Prometheus.
This includes:
- a Daemonset, running the kata-monitor binary, to generate kata metrics from each node
- a Service, to expose the kata metrics
- a ServiceMonitor, allowing Prometheus to find the service
- several RBAC rules, allowing prometheus to access all the above
- a label added to our namespace (openshift-sandboxed-containers-operator), so that Prometheus actually looks for the ServiceMonitor in our namespace
- an additional RBAC (to be defined), allowing the operator to create the DaemonSet with privileged status (required to access the socket from shimV2 on the node)

**- What I did**
- cherry-picked Jens' work for the DaemonSet (see #131) - we may want to finish reviewing that separately, or make the review here, as is easier
- added YAML files for Service/ServiceMonitor/RBAC (as we created them when prototyping)
- modified the YAML files (names and labels) to match the name and labels used on the DaemonSet

**- What is missing**
- additional rights must be given to the operator to be allowed to create the DaemonSet. As a workaround, after deployment, and before you create the kataconfig, you can run:
`oc adm policy add-scc-to-user privileged -z default -n openshift-sandboxed-containers-operator`
- a label need to be added to the namespace for Prometheus to actually start scraping data. This can be done after successful creation of the kataconfig:
`oc label namespaces openshift-sandboxed-containers-operator openshift.io/cluster-monitoring=true`


**- How to verify it**
- deploy the operator
  - I have a yaml file that can be used to deploy all this, using development builds for the images.
  - this PR can of course be checked out and built locally, for deployment from your own repositories

At this point, there is no difference from previous versions of the operator. You can check that the controller-manager pod is running properly, using the development image and not the official one.

[WIP] run `oc adm policy add-scc-to-user privileged -z default -n openshift-sandboxed-containers-operator`

- create the kataconfig
`oc apply -f https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/master/config/samples/kataconfiguration_v1_kataconfig.yaml
`
At this point, you can check that additional elements have been installed in the openshift-sandboxed-containers-operator namespace:
  - a DamonSet, named "openshift-sandboxed-containers-monitor", running on all worker nodes, with the development image from fgiudici's repository on quay.io
  - a Service, as below
```Name:              metrics
Namespace:         openshift-sandboxed-containers-operator
Labels:            name=openshift-sandboxed-containers-monitor
Annotations:       <none>
Selector:          name=openshift-sandboxed-containers-monitor
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                172.30.93.177
IPs:               172.30.93.177
Port:              metrics  8090/TCP
TargetPort:        8090/TCP
Endpoints:         10.132.2.4:8090,10.132.4.4:8090,10.133.2.3:8090 + 3 more...
Session Affinity:  None
Events:            <none>
```
  - a ServiceMonitor, as below
```Name:         openshift-sandboxed-containers-monitor
Namespace:    openshift-sandboxed-containers-operator
Labels:       <none>
Annotations:  <none>
API Version:  monitoring.coreos.com/v1
Kind:         ServiceMonitor
Metadata:
  Creation Timestamp:  2021-11-04T17:19:46Z
  Generation:          1
  Managed Fields:
    API Version:  monitoring.coreos.com/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:endpoints:
        f:namespaceSelector:
          .:
          f:matchNames:
        f:selector:
          .:
          f:matchLabels:
            .:
            f:name:
    Manager:         kubectl-client-side-apply
    Operation:       Update
    Time:            2021-11-04T17:19:46Z
  Resource Version:  1233875
  UID:               aa518ee6-3a1e-4641-8aad-e8a4470209b5
Spec:
  Endpoints:
    Port:  metrics
  Namespace Selector:
    Match Names:
      openshift-sandboxed-containers-operator
  Selector:
    Match Labels:
      Name:  openshift-sandboxed-containers-monitor
Events:      <none>
```

[WIP] If all of that is verified, you can add the label that will make Prometheus get this information
`oc label namespaces openshift-sandboxed-containers-operator openshift.io/cluster-monitoring=true`

- Now you can go to the Web console
  - in the "Observe/Dashboard" section, use the "Prometheus/Overview" dashboard, and look at the "TargetSync" graph
    The list of targets scraped by prometheus appears there.
    You will see a new target appear the next time Prometheus gathers data (look for "serviceMonitor/openshift-sandboxed-containers-operator/openshift-sandboxed-containers-monitor/0")
    (NOTE: this can take some time, as Prometheus is polling for data every once in a while. The graph actually helps you guess when your data should be appearing, depending on when you created the label compared to where there is "scrape activity" shown on the graph)
  - when the target appears, you can go to the "Observe/Metrics" section, and enter "kata" in the search box. This should give you the list of available metrics with "kata" in their name. If they show up, it means the metrics is being gathered by Prometheus.


MORE:
- run a pod under kata (see sample "example-fedora" for instance), to actually generate metrics from kata
- run custom queries from the "metrics" page to verify metrics are consistent with the pods being run


**- Description for the changelog**
Enable sandboxed-containers vm- and pod- specific metrics gathering from Prometheus
