### PR TITLE
Patch series to fix issues with monitor daemonset and CheckNodeEligibility

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -666,8 +666,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 	if r.kataConfig.Spec.CheckNodeEligibility {
 		err := r.checkNodeEligibility()
 		if err != nil {
+			// If no nodes are found, requeue to check again for eligible nodes
 			r.Log.Error(err, "Failed to check Node eligibility for running Kata containers")
-			return ctrl.Result{}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 20}, err
 		}
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
When CheckNodeEligibility is selected, operator unable to find labelled nodes and uses incorrect nodeSelector
for monitor DaemonSet

**- What I did**
Fixed the label handling when searching for eligible nodes and used the right nodeSelector

**- How to verify it**
Creating KataConfig and observing the status updates

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix issues with monitor daemonset and CheckNodeEligibility