### PR TITLE
RBAC: add privileged role to the default user

### DIFF
--- a/config/rbac/katamonitor.yaml
+++ b/config/rbac/katamonitor.yaml
@@ -29,3 +29,17 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
   namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monitor-daemonset-privileged-deployment
+  namespace: openshift-sandboxed-containers-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-sandboxed-containers-operator


### PR DESCRIPTION
In order to deploy the privileged monitor daemonset we need to allow the
default user to deploy privileged pods.
This is needed as the monitor pod will need to access reserved hostpaths
in the worker nodes (/run/crio/crio.sock and /run/vc/sbs dir).

Fixes: https://issues.redhat.com/browse/KATA-1189

