### PR TITLE
Add additional print columns to KataConfig CRD

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // KataConfigSpec defines the desired state of KataConfig
@@ -67,6 +66,10 @@ type KataConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=kataconfigs,scope=Cluster
+// +kubebuilder:printcolumn:name="InProgress",type=string,JSONPath=".status.installationStatus.IsInProgress",description="Status of Kata runtime installation"
+// +kubebuilder:printcolumn:name="Completed",type=integer,JSONPath=".status.installationStatus.completed.completedNodesCount",description="Number of nodes with Kata runtime installed"
+// +kubebuilder:printcolumn:name="Total",type=integer,JSONPath=".status.totalNodesCount",description="Total number of nodes"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age of the KataConfig Custom Resource"
 type KataConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -14,7 +14,24 @@ spec:
     singular: kataconfig
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Status of Kata runtime installation
+      jsonPath: .status.installationStatus.IsInProgress
+      name: InProgress
+      type: string
+    - description: Number of nodes with Kata runtime installed
+      jsonPath: .status.installationStatus.completed.completedNodesCount
+      name: Completed
+      type: integer
+    - description: Total number of nodes
+      jsonPath: .status.totalNodesCount
+      name: Total
+      type: integer
+    - description: Age of the KataConfig Custom Resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KataConfig is the Schema for the kataconfigs API

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -16,7 +16,24 @@ spec:
     singular: kataconfig
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Status of Kata runtime installation
+      jsonPath: .status.installationStatus.IsInProgress
+      name: InProgress
+      type: string
+    - description: Number of nodes with Kata runtime installed
+      jsonPath: .status.installationStatus.completed.completedNodesCount
+      name: Completed
+      type: integer
+    - description: Total number of nodes
+      jsonPath: .status.totalNodesCount
+      name: Total
+      type: integer
+    - description: Age of the KataConfig Custom Resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KataConfig is the Schema for the kataconfigs API


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
This series adds additional printer columns to the KataConfig CRD which is displayed in `kubectl get` or `oc get` output.
The improvements are suggested by @zanetworker 
Fixes: #[KATA-1204](https://issues.redhat.com/browse/KATA-1204)

**- What I did**
Added relevant kubebuilders markers to include the additional columns.

**- How to verify it**
Create KataConfig and run `oc get kataconfigs.kataconfiguration.openshift.io`
```
NAME                 INPROGRESS   COMPLETED   TOTAL   AGE
example-kataconfig   false        1           1       17m
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add additional print columns to KataConfig CRD
