### PR TITLE
KATA-1190: always update mcp during reconcile

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -773,6 +773,17 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 			return ctrl.Result{}, err
 		}
 
+		// Update node selector in machine config pool with value from kataconfig instance
+		r.Log.Info("Updating machine config pool")
+		if foundMcp != nil {
+			*foundMcp.Spec.NodeSelector = *r.kataConfig.Spec.KataConfigPoolSelector
+			err = r.Client.Update(context.TODO(), foundMcp)
+			if err != nil {
+				r.Log.Error(err, "Error when updating MachineConfigPool")
+				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			}
+		}
+
 		// Wait till MCP is ready
 		if foundMcp.Status.MachineCount == 0 {
 			r.Log.Info("Waiting till MachineConfigPool is initialized ", "machinePool", machinePool)


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**
We don't update the node selector in the machine config pool
object when a user changes the selector in the KataConfig CR spec.

**- What I did**
What we should do is to make sure that in every reconcile 
the specified node selector matches what we set in the machine
config pool. With this fixed the users settings are applied
to the cluster.

**- How to verify it**
1. label a node with custom-kata=test
2.  create a kataconfig with a node selector kata=test (it shouldn't match the label of the node in step 1)
3. verify that the kata-oc pool is empty
4. edit the kataconfig and set the node selector to kata=test (so that it matches the label from step 1)
5. open the log and check that you see a message "Updating machine config pool"
6. check that the node selector in the spec of the kata-oc machine config pool matches with the one
    from the kataconfig
7. delete the kataconfig and verify everything is removed/uninstalled

**- Description for the changelog**
update node selector in the custom machine config pool when the node selector in the KataConfig CR is changed


Fixes: https://issues.redhat.com/browse/KATA-1190
Signed-off-by: Jens Freimann <jfreimann@redhat.com>
