### PR TITLE
Update description of CheckNodeEligibility option

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -29,9 +29,9 @@ type KataConfigSpec struct {
 	// +nullable
 	KataConfigPoolSelector *metav1.LabelSelector `json:"kataConfigPoolSelector"`
 
-	// CheckNodeEligibility is used to detect the node(s) readiness to run
-	// Kata containers. If set to true then, NFD operator is used to check
-	// the readiness
+	// CheckNodeEligibility is used to detect the node(s) eligibility to run Kata containers.
+	// This is currently done through the use of the Node Feature Discovery Operator (NFD).
+	// For more information on how the check works, please refer to the sandboxed containers documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
 	// +kubebuilder:default:=false
 	CheckNodeEligibility bool `json:"checkNodeEligibility"`
 

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -54,9 +54,11 @@ spec:
             properties:
               checkNodeEligibility:
                 default: false
-                description: CheckNodeEligibility is used to detect the node(s) readiness
-                  to run Kata containers. If set to true then, NFD operator is used
-                  to check the readiness
+                description: CheckNodeEligibility is used to detect the node(s) eligibility
+                  to run Kata containers. This is currently done through the use of
+                  the Node Feature Discovery Operator (NFD). For more information
+                  on how the check works, please refer to the sandboxed containers
+                  documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
                 type: boolean
               kataConfigPoolSelector:
                 description: KataConfigPoolSelector is used to filter the worker nodes

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -56,9 +56,11 @@ spec:
             properties:
               checkNodeEligibility:
                 default: false
-                description: CheckNodeEligibility is used to detect the node(s) readiness
-                  to run Kata containers. If set to true then, NFD operator is used
-                  to check the readiness
+                description: CheckNodeEligibility is used to detect the node(s) eligibility
+                  to run Kata containers. This is currently done through the use of
+                  the Node Feature Discovery Operator (NFD). For more information
+                  on how the check works, please refer to the sandboxed containers
+                  documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
                 type: boolean
               kataConfigPoolSelector:
                 description: KataConfigPoolSelector is used to filter the worker nodes


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
The current description of the "CheckNodeEligibility" option that is displayed when creating KataConfig via OpenShift UI is misleading.
**- What I did**
Updated the description to closely aligned with the implementation
**- How to verify it**
When creating the KataConfig instance, check the description of the "CheckNodeEligibility" option and you should see the following:
```
"CheckNodeEligibility is used to detect the node(s) eligibility to run Kata containers. 
This is currently done through the use of the Node Feature Discovery Operator (NFD). 
For more information on how the check works, please refer to the sandboxed containers documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html"
```
**- Description for the changelog**
Fix "CheckNodeEligibility" description.