### PR TITLE
KATA-1200: use osc_monitor policy for metrics daemonset

### DIFF
--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -34,7 +34,7 @@ func GetScc() *secv1.SecurityContextConstraints {
 		SELinuxContext: secv1.SELinuxContextStrategyOptions{
 			Type: secv1.SELinuxStrategyMustRunAs,
 			SELinuxOptions: &corev1.SELinuxOptions{
-				Type: "spc_t",
+				Type: "osc_monitor.process",
 			},
 		},
 		Volumes: []secv1.FSType{secv1.FSTypeAll},


### PR DESCRIPTION
To make the daemonset that runs kata-metrics unprivileged
we change the SELinux type to a custom policy that is installed
via the kata-containers rpm.

See https://issues.redhat.com/browse/KATA-1189 for more information
on the new policy.

Fixes: https://issues.redhat.com/browse/KATA-1200
Signed-off-by: Jens Freimann <jfreimann@redhat.com>

