### PR TITLE
enable changing CRI-O log level on kata workers by changing KataConfig

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -38,6 +38,10 @@ type KataConfigSpec struct {
 	// KataMonitorImage is used to specify the container image used for kata-monitor
 	// +kubebuilder:default:="quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest"
 	KataMonitorImage string `json:"kataMonitorImage"`
+
+	// Sets log level on kata-equipped nodes.  Valid values are the same as for `crio --log-level`.
+	// +kubebuilder:default:="info"
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -111,6 +111,10 @@ spec:
                 description: KataMonitorImage is used to specify the container image
                   used for kata-monitor
                 type: string
+              logLevel:
+                default: info
+                description: Sets log level on kata-equipped nodes.  Valid values are the same as for `crio --log-level`.
+                type: string
             required:
             - checkNodeEligibility
             - kataMonitorImage

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -128,6 +128,7 @@ spec:
           - machineconfiguration.openshift.io
           resources:
           - configmaps
+          - containerruntimeconfigs
           - endpoints
           - events
           - machineconfigpools

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -113,6 +113,11 @@ spec:
                 description: KataMonitorImage is used to specify the container image
                   used for kata-monitor
                 type: string
+              logLevel:
+                default: info
+                description: Sets log level on kata-equipped nodes.  Valid values
+                  are the same as for `crio --log-level`.
+                type: string
             required:
             - checkNodeEligibility
             - kataMonitorImage

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,7 @@ rules:
   - machineconfiguration.openshift.io
   resources:
   - configmaps
+  - containerruntimeconfigs
   - endpoints
   - events
   - machineconfigpools


### PR DESCRIPTION
To debug some kinds of problems with kata-enabled workers it's helpful
or even necessary to make CRI-O on the workers log in debug mode.  So
far, this was in principle achievable by a user but some knowledge of
internals of Sandboxed Containers Operator and OpenShift itself was
required.

This commit introduces a new 'logLevel' field in KataConfig.spec which
can be used to set easily a corresponding log level on nodes.
Internally, it works by creating or updating a ContainerRuntimeConfig
instance which requests MCO to set the desired log level on relevant
nodes.  The relevant nodes are all masters (more specifically, all
members of the master Machine Config Pool) in case of a converged
cluster, or nodes defined by the OSC-internal 'kata-oc' MCP otherwise.

To support this implentation, this commit gives the OSC operator a
permission to manipulate ContainerRuntimeConfig resources and labels the
'kata-oc' MCP to enable its selection in
ContainerRuntimeConfig.spec.machineConfigPoolSelector.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
