### PR TITLE
KATA-1289: use deepcopy to update node selector

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -776,7 +776,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		// Update node selector in machine config pool with value from kataconfig instance
 		r.Log.Info("Updating machine config pool")
 		if foundMcp != nil {
-			*foundMcp.Spec.NodeSelector = *r.kataConfig.Spec.KataConfigPoolSelector
+			if foundMcp.Spec.NodeSelector != nil {
+				foundMcp.Spec.NodeSelector = r.kataConfig.Spec.KataConfigPoolSelector.DeepCopy()
+			}
 			err = r.Client.Update(context.TODO(), foundMcp)
 			if err != nil {
 				r.Log.Error(err, "Error when updating MachineConfigPool")


### PR DESCRIPTION
For a kataconfig where spec.kataConfigPoolSelector is nil we would run into this error.
A check before assigning something to it prevents the segfault. 

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x173baaf]

goroutine 613 [running]:
github.com/openshift/sandboxed-containers-operator/controllers.(*KataConfigOpenShiftReconciler).processKataConfigInstallRequest(0xc00063c200, 0x13ac965, 0xc000010860, 0x1d8d5c8, 0xc000044138)
	/home/jfreiman/go/src/github.com/openshift/kata-operator/controllers/openshift_controller.go:779 +0x6cf
github.com/openshift/sandboxed-containers-operator/controllers.(*KataConfigOpenShiftReconciler).Reconcile.func1(0xc00063c200, 0x1d8d5c8, 0xc000044138, 0x0, 0x0)
	/home/jfreiman/go/src/github.com/openshift/kata-operator/controllers/openshift_controller.go:107 +0x1c5
github.com/openshift/sandboxed-containers-operator/controllers.(*KataConfigOpenShiftReconciler).Reconcile(0xc00063c200, 0x1d8d638, 0xc00088ede0, 0x0, 0x0, 0xc00047bef0, 0x12, 0xc00088ede0, 0xc00088ed50, 0xc0006d7db0, ...)
	/home/jfreiman/go/src/github.com/openshift/kata-operator/controllers/openshift_controller.go:163 +0x2ed
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc0002f8000, 0x1d8d638, 0xc00088ed50, 0x0, 0x0, 0xc00047bef0, 0x12, 0xc00088ed00, 0x0, 0x0, ...)
	/home/jfreiman/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:114 +0x247
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002f8000, 0x1d8d590, 0xc000766040, 0x197aea0, 0xc00070ef40)
	/home/jfreiman/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:311 +0x305
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002f8000, 0x1d8d590, 0xc000766040, 0x1c17b00)
	/home/jfreiman/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc0007fe0e0, 0xc0002f8000, 0x1d8d590, 0xc000766040)
	/home/jfreiman/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:227 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/home/jfreiman/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:223 +0x425
FAIL	github.com/openshift/sandboxed-containers-operator/controllers	13.535s
FAIL
make: *** [Makefile:93: test] Error 1

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

 