### PR TITLE
backport release-1.2: KATA-1190: always update mcp during reconcile

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -773,6 +773,17 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 			return ctrl.Result{}, err
 		}
 
+		// Update node selector in machine config pool with value from kataconfig instance
+		r.Log.Info("Updating machine config pool")
+		if foundMcp != nil {
+			*foundMcp.Spec.NodeSelector = *r.kataConfig.Spec.KataConfigPoolSelector
+			err = r.Client.Update(context.TODO(), foundMcp)
+			if err != nil {
+				r.Log.Error(err, "Error when updating MachineConfigPool")
+				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			}
+		}
+
 		// Wait till MCP is ready
 		if foundMcp.Status.MachineCount == 0 {
 			r.Log.Info("Waiting till MachineConfigPool is initialized ", "machinePool", machinePool)

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -776,7 +776,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		// Update node selector in machine config pool with value from kataconfig instance
 		r.Log.Info("Updating machine config pool")
 		if foundMcp != nil {
-			*foundMcp.Spec.NodeSelector = *r.kataConfig.Spec.KataConfigPoolSelector
+			if foundMcp.Spec.NodeSelector != nil {
+				foundMcp.Spec.NodeSelector = r.kataConfig.Spec.KataConfigPoolSelector.DeepCopy()
+			}
 			err = r.Client.Update(context.TODO(), foundMcp)
 			if err != nil {
 				r.Log.Error(err, "Error when updating MachineConfigPool")


### PR DESCRIPTION
We don't update the node selector in the machine config pool
object when a user changes the selector in the KataConfig CR spec.
    
What we should do is to make sure in every reconcile that
the specified node selector matches what we set in the machine
config pool. With this fixed the users settings are applied
to the cluster.

