### PR TITLE
 KATA-1340: allow re-install on all workers

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -883,11 +883,18 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 
 		// Update node selector in machine config pool with value from kataconfig instance
-		r.Log.Info("Updating machine config pool")
+		r.Log.Info("Updating machine config pool name ", "found Mcp name", foundMcp.Name)
 		if foundMcp != nil {
-			if foundMcp.Spec.NodeSelector != nil {
-				foundMcp.Spec.NodeSelector = r.kataConfig.Spec.KataConfigPoolSelector.DeepCopy()
+			foundMcp.Spec.NodeSelector.MatchLabels = make(map[string]string)
+			if r.kataConfig.Spec.KataConfigPoolSelector != nil {
+				for key, value := range r.kataConfig.Spec.KataConfigPoolSelector.MatchLabels {
+					foundMcp.Spec.NodeSelector.MatchLabels[key] = value
+				}
+				foundMcp.Spec.NodeSelector.MatchExpressions = r.kataConfig.Spec.KataConfigPoolSelector.MatchExpressions
 			}
+			foundMcp.Spec.NodeSelector.MatchLabels["node-role.kubernetes.io/worker"] = ""
+			foundMcp.Spec.NodeSelector.MatchLabels["node-role.kubernetes.io/kata-oc"] = ""
+
 			err = r.Client.Update(context.TODO(), foundMcp)
 			if err != nil {
 				r.Log.Error(err, "Error when updating MachineConfigPool")


### PR DESCRIPTION
When we first install with KataConfigPoolSelector set on specific nodes
and later on remove that selector from kataconfig, re-installation on
all worker nodes is never going to happen.

The reason is that the kata-oc machine config pool is never updated
correctly, the old matchLabel key-value pair is never removed.

This patch fixes the problem by adding all matchLabel entries when
kataConfigPoolSelector is non-empty in every reconcile run.  When the
selector is deleted from kataconfig we create a new kata-oc machine
config pool with only our default matchLabels for the worker and kata-oc
role set. The kata-oc entry is required because we always create this
role even when we install on all worker nodes.

The deletetion-and-reinstall also works when a matchExpression is used
in kataconfig instead of matchLabels. This is because machine config
pools nodeSelector always works with matchLabels only.

Fixes: https://issues.redhat.com/browse/KATA-1340
Signed-off-by: Jens Freimann <jfreimann@redhat.com>