### PR TITLE
Create monitor daemonset post runtimeclass creation

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -127,7 +127,11 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		foundDs := &appsv1.DaemonSet{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, foundDs)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			//The DaemonSet (DS) should be ideally created after the required SeLinux policy is installed on the
+			//node. One of the ways to ensure this is to check for the existence of "kata" runtimeclass before
+			//creating the DS
+			//Alternatively we can create the DS post execution of setRuntimeClass()
+			if k8serrors.IsNotFound(err) && r.kataConfig.Status.RuntimeClass == "kata" {
 				r.Log.Info("Creating a new installation monitor daemonset", "ds.Namespace", ds.Namespace, "ds.Name", ds.Name)
 				err = r.Client.Create(context.TODO(), ds)
 				if err != nil {


### PR DESCRIPTION
Fixes: #KATA-1374

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
When creating KataConfig and observing the PODs under openshift-sandboxed-containers-operator namespace it shows huge number of restarts (20+) for monitor PODs.

**- What I did**
Updated the logic to create monitor DS post runtimeclass creation

**- How to verify it**
Create Kataconfig and observe the POD status under openshift-sandboxed-containers-operator namespace


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Create monitor daemonset post runtimeclass creation