### PR TITLE
KATA-1444: remove nodeSelector from controller deployment

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -284,8 +284,6 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
-              nodeSelector:
-                node-role.kubernetes.io/master: ""
               terminationGracePeriodSeconds: 10
               tolerations:
               - effect: NoSchedule

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Currently we restrict the operator to run on master nodes only.
However, there is no technical reason for this setting. It
creates a problem when a cluster-admin sets the defaultNodeScheduler
field to schedule everything to workers. In that case our controller
could not be placed anywhere by the scheduler and would get stuck
in 'Pending' state.

By removing the nodeSelector field from our controller manifest we let
the scheduler place the controller pod also on worker nodes so that we
don't get into the above described situation anymore.

I tested this on clusters with
 - three control-plane and three worker nodes
 - a converged cluster where control-plane and worker nodes are on the
   same machines
 - a single-node cluster

and did not run into problems. The test procedure included deploying a
cluster, creating a kataconfig CR, running a workload with kata runtime
class, deleting the kataconfig CR and destroying the cluster.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

