### PR TITLE
KATA-1437: update version numbers in config, Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0
+VERSION ?= latest
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please refer to the [code](https://github.com/openshift/sandboxed-containers-ope
 ### Getting Started
 
 Please refer to the OpenShift release specific documentation for getting started with sandboxed containers. 
-- For OpenShift 4.9 please follow this [doc](https://docs.openshift.com/container-platform/4.9/sandboxed_containers/deploying-sandboxed-container-workloads.html)
+- For OpenShift 4.10 please follow this [doc](https://docs.openshift.com/container-platform/4.10/sandboxed_containers/deploying-sandboxed-container-workloads.html)
 
 Further note that starting with OpenShift 4.9, the branch naming is tied to the operator version and not the OpenShift version.
 For example `release-1.1` corresponds to the Operator release verson `1.1.x`.

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,16 +13,16 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    olm.skipRange: '>=1.1.0 <1.2.0'
+    olm.skipRange: '>=1.1.0 <1.3.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.15.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/sandboxed-containers-operator
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.2.0
+  name: sandboxed-containers-operator.v1.3.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -361,7 +361,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  version: 1.2.0
+  version: 1.3.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: sandboxed-containers-operator
   operators.operatorframework.io.bundle.channels.v1: candidate
   operators.operatorframework.io.bundle.channel.default.v1: candidate
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    olm.skipRange: '>=1.1.0 <1.2.0'
+    olm.skipRange: '>=1.1.0 <1.3.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
@@ -22,7 +22,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.2.0
+  name: sandboxed-containers-operator.v1.3.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -73,9 +73,10 @@ spec:
 
       On the Install Operator page:
 
-      - Select `stable-1.2` from the list of available Update Channel options.
+      - Select `candidate` from the list of available Update Channel options.
       This ensures that you install the latest version of OpenShift sandboxed containers
       that is compatible with your OpenShift Container Platform version.
+      Select `stable-x.y` to install already released versions.
 
       - For Installed Namespace, ensure that the Operator recommended namespace
         option is selected. This installs the Operator in the mandatory
@@ -362,7 +363,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  version: 1.2.0
+  version: 1.3.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.2.0
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.3.0
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,4 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.2.0
+  startingCSV: sandboxed-containers-operator.v1.3.0


### PR DESCRIPTION
This patch increases the version number from 1.2 to 1.3 in
the documentation, Makefile, kubebuilder config files and our example
deploy.yaml

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

