### PR TITLE
kata-monitor DaemonSet: add the "listen-address" arg

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -313,7 +313,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 								RunAsUser:  &runUserID,
 								RunAsGroup: &runGroupID,
 							},
-							Command: []string{"/usr/bin/kata-monitor", "--log-level=debug", "--runtime-endpoint=/run/crio/crio.sock"},
+							Command: []string{"/usr/bin/kata-monitor", "--listen-address=:8090", "--log-level=debug", "--runtime-endpoint=/run/crio/crio.sock"},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "crio-sock",


### PR DESCRIPTION
In the upstream kata-containers repo the kata-monitor binary is now
listening on the loopback address by default:
https://github.com/kata-containers/kata-containers/commit/e64c54a2ad7

Since the DaemonSet needs to expose the endpoint to Prometheus, let's
specify the "listen-address" argument.
This will cause no changes with older/current kata-monitor images but
will allow to switch seamlessy to the latest kata-monitor images
preserving the availability of the endpoint to Prometheus.
