### PR TITLE
Adding a PrometheusRule for kata monitor

### DIFF
--- a/config/kata-monitor/kata-monitor-prometheus-rules.yaml
+++ b/config/kata-monitor/kata-monitor-prometheus-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-sandboxed-containers-rules
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  groups:
+    - name: kata_monitor_rules
+      rules:
+      - record: cluster:kata_monitor_running_shim_count:sum
+        expr: sum(kata_monitor_running_shim_count)

--- a/config/kata-monitor/kustomization.yaml
+++ b/config/kata-monitor/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - kata-monitor-service.yaml
 - kata-monitor-servicemonitor.yaml
 - osc-dashboard.yaml
+- kata-monitor-prometheus-rules.yaml


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
We want to provide some information back through telemetry, but there is limitation on how much data can be sent.
As kata-monitor report information per node, any metric we want to expose would be multiplied by the number of nodes in the cluster, making us go above the limit in some situations.

We need to sum information up, and expose total numbers at the cluster level, and not individual per-node information.

**- What I did**
Adding a PrometheusRule to have prometheus take the number of running shim per node, make the total of it, and expose it as a new metric.
This rule can be extended in the future to add additional metrics as we need.
