### PR TITLE
Remove scc on uninstall

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func runManager() int {
 			setupLog.Error(err, "unable to create SCC")
 			return 1
 		}
+		defer deleteScc(context.TODO(), mgr)
 
 		setupLog.Info("created SCC")
 
@@ -150,6 +151,13 @@ func createScc(ctx context.Context, mgr manager.Manager) error {
 	}
 
 	return err
+}
+
+func deleteScc(ctx context.Context, mgr manager.Manager) error {
+
+	scc := controllers.GetScc()
+	setupLog.Info("Deleting SCC")
+	return mgr.GetClient().Delete(ctx, scc, &client.DeleteOptions{})
 }
 
 func labelNamespace(ctx context.Context, mgr manager.Manager) error {


### PR DESCRIPTION
Let's make sure that the controller removes the SCC it has created when it exits.
This ensures that the SCC doesn't stay around when OSC is uninstalled or when
installation fails.

Fixes: https://issues.redhat.com/browse/KATA-156
