### PR TITLE
Add namespace label to align with Pod Security Admission requirements

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,8 +148,6 @@ func createScc(ctx context.Context, mgr manager.Manager) error {
 
 func labelNamespace(ctx context.Context, mgr manager.Manager) error {
 
-	//label := map[string]string{"openshift.io/cluster-monitoring": "true"}
-
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: OperatorNamespace,
@@ -163,7 +161,11 @@ func labelNamespace(ctx context.Context, mgr manager.Manager) error {
 
 	setupLog.Info("Labelling Namespace")
 	setupLog.Info("Labels: ", "Labels", ns.ObjectMeta.Labels)
-	//ns.ObjectMeta.Labels = label
+	// Add namespace label to align with newly introduced Pod Security Admission controller
 	ns.ObjectMeta.Labels["openshift.io/cluster-monitoring"] = "true"
+	ns.ObjectMeta.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+	ns.ObjectMeta.Labels["pod-security.kubernetes.io/audit"] = "privileged"
+	ns.ObjectMeta.Labels["pod-security.kubernetes.io/warn"] = "privileged"
+
 	return mgr.GetClient().Update(ctx, ns)
 }


### PR DESCRIPTION
Fixes: #[KATA-1583](https://issues.redhat.com//browse/KATA-1583)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
OpenShift 4.11 is going to enable pod security admission (https://kubernetes.io/docs/concepts/security/pod-security-admission/) using the “restricted” profile by default (https://kubernetes.io/docs/concepts/security/pod-security-standards/) 
Since we require privileged support for kata-monitor, we need to label the namespace accordingly

**- What I did**
Added required labels to the `openshift-sandboxed-containers-operator` ns

**- How to verify it**
Create a Kata Pod and check controller logs for `pod-security.kubernetes.io/audit-violations`.
There shouldn't be any audit-violations when kata-monitor pods gets created


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add namespace label to align with Pod Security Admission requirements