### PR TITLE
Move SELinuxOptions to kata-monitor

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -312,6 +312,9 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 								Privileged: &runPrivileged,
 								RunAsUser:  &runUserID,
 								RunAsGroup: &runGroupID,
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "osc_monitor.process",
+								},
 							},
 							Command: []string{"/usr/bin/kata-monitor", "--listen-address=:8090", "--log-level=debug", "--runtime-endpoint=/run/crio/crio.sock"},
 							VolumeMounts: []corev1.VolumeMount{

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -32,10 +32,7 @@ func GetScc() *secv1.SecurityContextConstraints {
 			Type: secv1.RunAsUserStrategyMustRunAsNonRoot,
 		},
 		SELinuxContext: secv1.SELinuxContextStrategyOptions{
-			Type: secv1.SELinuxStrategyMustRunAs,
-			SELinuxOptions: &corev1.SELinuxOptions{
-				Type: "osc_monitor.process",
-			},
+			Type: secv1.SELinuxStrategyRunAsAny,
 		},
 		Volumes: []secv1.FSType{secv1.FSTypeAll},
 		Users:   []string{"system:serviceaccount:openshift-sandboxed-containers-operator:monitor"},


### PR DESCRIPTION
We currently deploy a custom SELinux type on worker nodes and have the
monitor PODs using it through a custom SCC. This is wrong because an
SCC can potentially be applied to any POD anywhere. This is exactly
what happens with the MCO : it exclusively runs on master nodes where
our custom SELinux type is unavailable but the SCC admission logic
legitimately applies our SCC and the MCO fails to start.

Relax the SELinux contstraint in our SCC so that it can work with
any context, and have the monitor requiring explicitely the SELinux
type it wants to use.

Fixes: KATA-1373

Suggested-by: Stanislav Laznicka <slaznick@redhat.com>
Signed-off-by: Greg Kurz <groug@kaod.org>