### PR TITLE
Fix some error paths in the controller

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -632,7 +632,11 @@ func (r *KataConfigOpenShiftReconciler) createScc() error {
 
 	foundScc := &secv1.SecurityContextConstraints{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: scc.Name}, foundScc)
-	if err != nil && k8serrors.IsNotFound(err) {
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+
 		r.Log.Info("Creating a new Scc", "scc.Name", scc.Name)
 		err = r.Client.Create(context.TODO(), scc)
 		if err != nil {
@@ -641,7 +645,6 @@ func (r *KataConfigOpenShiftReconciler) createScc() error {
 	}
 
 	return nil
-
 }
 
 func (r *KataConfigOpenShiftReconciler) createRuntimeClass() error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -688,7 +688,11 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass() error {
 
 	foundRc := &nodeapi.RuntimeClass{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: rc.Name}, foundRc)
-	if err != nil && k8serrors.IsNotFound(err) {
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+
 		r.Log.Info("Creating a new RuntimeClass", "rc.Name", rc.Name)
 		err = r.Client.Create(context.TODO(), rc)
 		if err != nil {


### PR DESCRIPTION
The recently introduced `createScc()` is missing an error path. Same issue exists in `createRuntimeClass()`. Fix both.

Signed-off-by: Greg Kurz <groug@kaod.org>
