### PR TITLE
Fix SCC in OSC 1.2

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -213,6 +213,9 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 								Privileged: &runPrivileged,
 								RunAsUser:  &runUserID,
 								RunAsGroup: &runGroupID,
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "osc_monitor.process",
+								},
 							},
 							Command: []string{"/usr/bin/kata-monitor", "--log-level=debug", "--runtime-endpoint=/run/crio/crio.sock"},
 							VolumeMounts: []corev1.VolumeMount{

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -32,10 +32,7 @@ func GetScc() *secv1.SecurityContextConstraints {
 			Type: secv1.RunAsUserStrategyMustRunAsNonRoot,
 		},
 		SELinuxContext: secv1.SELinuxContextStrategyOptions{
-			Type: secv1.SELinuxStrategyMustRunAs,
-			SELinuxOptions: &corev1.SELinuxOptions{
-				Type: "osc_monitor.process",
-			},
+			Type: secv1.SELinuxStrategyRunAsAny,
 		},
 		Volumes: []secv1.FSType{secv1.FSTypeAll},
 		Users:   []string{"system:serviceaccount:openshift-sandboxed-containers-operator:monitor"},


### PR DESCRIPTION
This brings the fix of PR #196 to the 1.2 release, along with an extra patch to an already created SCC.
This will simplify OCP upgrades.
