### PR TITLE
Fix 1.2-style MCP

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -938,6 +938,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 		foundMcp.Spec.NodeSelector.MatchLabels["node-role.kubernetes.io/worker"] = ""
 		foundMcp.Spec.NodeSelector.MatchLabels["node-role.kubernetes.io/kata-oc"] = ""
+		foundMcp.ObjectMeta.Labels = map[string]string{"pools.operator.machineconfiguration.openshift.io/kata-oc": ""}
 
 		err = r.Client.Update(context.TODO(), foundMcp)
 		if err != nil {


### PR DESCRIPTION
Add the "pools.operator.machineconfiguration.openshift.io/kata-oc" label
to an existing pre-1.3 MCP. This is needed to control the crio log level
through KataConfig.spec.logLevel.

Fixes: [KATA-1653](https://issues.redhat.com//browse/KATA-1653)

Signed-off-by: Greg Kurz <groug@kaod.org>
