### PR TITLE
draft: integrate peer pod support

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -42,6 +42,11 @@ type KataConfigSpec struct {
 	// Sets log level on kata-equipped nodes.  Valid values are the same as for `crio --log-level`.
 	// +kubebuilder:default:="info"
 	LogLevel string `json:"logLevel,omitempty"`
+
+	// EnablePeerPods is used to transparently create pods on a remote system.
+	// For more information on how this works, please refer to the sandboxed containers documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
+	// +kubebuilder:default:=false
+	EnablePeerPods bool `json:"enablePeerPods"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -2,10 +2,21 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: openshift-sandboxed-containers-operator/serving-cert
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: kataconfigs.kataconfiguration.openshift.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: kataconfiguration.openshift.io
   names:
     kind: KataConfig

--- a/config/crd/bases/confidentialcontainers.org_peerpodconfigs.yaml
+++ b/config/crd/bases/confidentialcontainers.org_peerpodconfigs.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: peerpodconfigs.confidentialcontainers.org
+spec:
+  group: confidentialcontainers.org
+  names:
+    kind: PeerPodConfig
+    listKind: PeerPodConfigList
+    plural: peerpodconfigs
+    singular: peerpodconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PeerPodConfig is the Schema for the peerpodconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PeerPodConfigSpec defines the desired state of PeerPodConfig
+            properties:
+              cloudSecretName:
+                description: CloudSecretName is the name of the secret that holds
+                  the credentials for the cloud provider
+                type: string
+              instanceType:
+                description: InstanceType describes the name of the instance type
+                  of the chosen cloud provider
+                type: string
+              limit:
+                description: Limit is the max number of peer pods. This is exposed
+                  as expended resource on nodes
+                type: string
+            required:
+            - cloudSecretName
+            type: object
+          status:
+            description: PeerPodConfigStatus defines the observed state of PeerPodConfig
+            properties:
+              setupCompleted:
+                description: SetupCompleted is set to true when all components have
+                  been deployed/created
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -62,6 +62,12 @@ spec:
                   on how the check works, please refer to the sandboxed containers
                   documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
                 type: boolean
+              enablePeerPods:
+                default: false
+                description: EnablePeerPods is used to transparently create pods on
+                  a remote system. For more information on how this works, please
+                  refer to the sandboxed containers documentation - https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html
+                type: boolean
               kataConfigPoolSelector:
                 description: KataConfigPoolSelector is used to filter the worker nodes
                   if not specified, all worker nodes are selected
@@ -120,6 +126,7 @@ spec:
                 type: string
             required:
             - checkNodeEligibility
+            - enablePeerPods
             - kataMonitorImage
             type: object
           status:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_kataconfigs.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+- patches/webhook_in_kataconfigs.yaml
+  # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_kataconfigs.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+- patches/cainjection_in_kataconfigs.yaml
+  # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,6 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/kataconfiguration.openshift.io_kataconfigs.yaml
+- bases/confidentialcontainers.org_peerpodconfigs.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ bases:
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -37,34 +37,34 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,6 +40,9 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+        - name: PEER_POD_TARGET_RUNTIMECLASS
+          value: "kata-remote-cc"
         args:
         - --enable-leader-election
         image: controller:latest

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -177,9 +177,12 @@ spec:
           - get
         - apiGroups:
           - kataconfiguration.openshift.io
+          - peerpodconfiguration.confidentialcontainers.org
           resources:
           - kataconfigs
           - kataconfigs/finalizers
+          - peerpodconfigs
+          - peerpodconfigs/finalizers
           verbs:
           - create
           - delete
@@ -189,9 +192,11 @@ spec:
           - update
           - watch
         - apiGroups:
+          - peerpodconfiguration.confidentialcontainers.org
           - kataconfiguration.openshift.io
           resources:
           - kataconfigs/status
+          - peerpodconfigs/status
           verbs:
           - get
           - patch

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -347,13 +347,13 @@ spec:
         serviceAccountName: default
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - sandboxed-containers

--- a/config/rbac/kataconfig_editor_role.yaml
+++ b/config/rbac/kataconfig_editor_role.yaml
@@ -6,8 +6,10 @@ metadata:
 rules:
 - apiGroups:
   - kataconfiguration.openshift.io
+  - peerpodconfiguration.confidentialcontainers.org
   resources:
   - kataconfigs
+  - peerpodconfigs
   verbs:
   - create
   - delete
@@ -18,7 +20,9 @@ rules:
   - watch
 - apiGroups:
   - kataconfiguration.openshift.io
+  - peerpodconfiguration.confidentialcontainers.org
   resources:
   - kataconfigs/status
+  - peerpodconfigs/status
   verbs:
   - get

--- a/config/rbac/kataconfig_viewer_role.yaml
+++ b/config/rbac/kataconfig_viewer_role.yaml
@@ -6,15 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - kataconfiguration.openshift.io
+  - peerpodconfiguration.confidentialcontainers.org
   resources:
   - kataconfigs
+  - peerpodconfigs
   verbs:
   - get
   - list
   - watch
 - apiGroups:
+  - peerpodconfiguration.confidentialcontainers.org
   - kataconfiguration.openshift.io
   resources:
   - kataconfigs/status
+  - peerpodconfigs/status
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,32 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - peerpodconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - peerpodconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - peerpodconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - clusterversions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,12 @@ rules:
   - update
 - apiGroups:
   - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   - machineconfiguration.openshift.io
   resources:
   - configmaps

--- a/config/samples/_v1alpha1_peerpodconfig.yaml
+++ b/config/samples/_v1alpha1_peerpodconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: confidentialcontainers.org/v1alpha1
+kind: PeerPodConfig
+metadata:
+  name: peerpodconfig-sample
+spec:
+  # TODO(user): Add fields here

--- a/config/samples/example-fedora.yaml
+++ b/config/samples/example-fedora.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   containers:
     - name: example-fedora
-      image: fedora:30
+      image: fedora:36
       ports:
         - containerPort: 8080
       command: ["python3"]
       args: [ "-m", "http.server", "8080"]
-  runtimeClassName: kata
+  runtimeClassName: kata-remote-cc

--- a/config/samples/kataconfiguration_v1_kataconfig.yaml
+++ b/config/samples/kataconfiguration_v1_kataconfig.yaml
@@ -2,7 +2,9 @@ apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: example-kataconfig
-#spec:
+spec:
+  kataMonitorImage: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-monitor:1.3.0
+  enablePeerPods: true
 #  kataConfigPoolSelector:
 #    matchLabels:
 #       custom-kata1: test 

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,5 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - kataconfiguration_v1_kataconfig.yaml
+- _v1alpha1_peerpodconfig.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,6 +1,34 @@
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -66,6 +66,7 @@ const (
 	container_runtime_config_name = "kata-crio-config"
 )
 
+//+kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,admissionReviewVersions=v1,sideEffects=none
 // +kubebuilder:rbac:groups=kataconfiguration.openshift.io,resources=kataconfigs;kataconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kataconfiguration.openshift.io,resources=kataconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
@@ -1378,7 +1379,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPods() error {
 			Name:      "peerpodconfig-example",
 			Namespace: "openshift-sandboxed-containers-operator",
 		},
-		Spec: v1alpha1.PeerPodConfigSpec{CloudSecretName: "peer-pods-secret"},
+		Spec: v1alpha1.PeerPodConfigSpec{CloudSecretName: "peer-pods-secret", Limit: "20"},
 	}
 
 	err := r.Client.Create(context.TODO(), &peerpodconf)

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/jensfr/peer-pod-controller/api/v1alpha1"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,9 +75,10 @@ const (
 // +kubebuilder:rbac:groups="";machineconfiguration.openshift.io,resources=nodes;machineconfigs;machineconfigpools;containerruntimeconfigs;pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use;get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update
-//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=patch
+// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/finalizers,verbs=update
 
 func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("kataconfig", req.NamespacedName)
@@ -884,6 +886,15 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 	}
 
+	// peer pod enablement
+	if r.kataConfig.Spec.EnablePeerPods {
+		err := r.enablePeerPods()
+		if err != nil {
+			r.Log.Error(err, "Peer pod enabling failed")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// If converged cluster, then MCP == master, otherwise "kata-oc" if it exists
 	machinePool, err := r.getMcpName()
 	if err != nil {
@@ -1357,4 +1368,22 @@ func (r *KataConfigOpenShiftReconciler) clearFailedStatus(status kataconfigurati
 	status.FailedNodesCount = 0
 
 	return status
+}
+
+func (r *KataConfigOpenShiftReconciler) enablePeerPods() error {
+
+	peerpodconf := v1alpha1.PeerPodConfig{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "peerpodconfig-example",
+			Namespace: "openshift-sandboxed-containers-operator",
+		},
+		Spec: v1alpha1.PeerPodConfigSpec{CloudSecretName: "peer-pods-secret"},
+	}
+
+	err := r.Client.Create(context.TODO(), &peerpodconf)
+	if k8serrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
 }

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -74,6 +74,9 @@ const (
 // +kubebuilder:rbac:groups="";machineconfiguration.openshift.io,resources=nodes;machineconfigs;machineconfigpools;containerruntimeconfigs;pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use;get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update
+//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/finalizers,verbs=update
 
 func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("kataconfig", req.NamespacedName)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v1.2.0
-	github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v1.2.0
+	github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v1.2.0
-	github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9
+	github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v1.2.0
-	github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456
+	github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/go-logr/logr v1.2.0
-	github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894
+	github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210924154557-a4f696157341

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,6 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36 h1:08nY0H3SqZ8hKRDh/13FMlfy3vxw0qSxSJGsLDT9Vn8=
-github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894 h1:1Vl2iCxRR1sdhJaFpX0LRPVo+UsSDSg93vdwq4BhKXc=
-github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
+github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9 h1:EJWWHyh49UjjFZ5U6tmHTYIy1i16reaoAccUk/wOoEk=
+github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456 h1:4ThOM256tSFXaFo14TXP8UNogSKJlCBZQPhApIHSemA=
-github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456/go.mod h1:bLST89ML/t/7wdndqs02R8NPBfOs7PhdXeglNQ0nqaA=
+github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894 h1:1Vl2iCxRR1sdhJaFpX0LRPVo+UsSDSg93vdwq4BhKXc=
+github.com/jensfr/peer-pod-controller v0.0.0-20220812074413-b5d63706b894/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456 h1:4ThOM256tSFXaFo14TXP8UNogSKJlCBZQPhApIHSemA=
+github.com/jensfr/peer-pod-controller v0.0.0-20220728144400-a37a625ca456/go.mod h1:bLST89ML/t/7wdndqs02R8NPBfOs7PhdXeglNQ0nqaA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9 h1:EJWWHyh49UjjFZ5U6tmHTYIy1i16reaoAccUk/wOoEk=
-github.com/jensfr/peer-pod-controller v0.0.0-20220822120912-e81b3dc9c6d9/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
+github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36 h1:08nY0H3SqZ8hKRDh/13FMlfy3vxw0qSxSJGsLDT9Vn8=
+github.com/jensfr/peer-pod-controller v0.0.0-20221018073419-d942d913da36/go.mod h1:81McN/A3lE8fBKLlociJcepYW2bdIlOtk7Mr4AmfT10=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1128,6 +1128,7 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	peerpodcontrollers "github.com/jensfr/peer-pod-controller/controllers"
 	"os"
 
 	secv1 "github.com/openshift/api/security/v1"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	peerpodconfig "github.com/jensfr/peer-pod-controller/api/v1alpha1"
 	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
 	"github.com/openshift/sandboxed-containers-operator/controllers"
 	// +kubebuilder:scaffold:imports
@@ -60,6 +62,8 @@ func init() {
 	utilruntime.Must(mcfgapi.Install(scheme))
 
 	utilruntime.Must(kataconfigurationv1.AddToScheme(scheme))
+
+	utilruntime.Must(peerpodconfig.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -114,6 +118,15 @@ func main() {
 			Scheme: mgr.GetScheme(),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create KataConfig controller for OpenShift cluster", "controller", "KataConfig")
+			os.Exit(1)
+		}
+
+		if err = (&peerpodcontrollers.PeerPodConfigReconciler{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("RemotePodConfig"),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create RemotePodConfig controller for OpenShift cluster", "controller", "RemotePodConfig")
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
This implements support to run peer pods. To separate as much as possible of the peer pod specific
code we create a new controller that is started when `enablePeerPods` is set to true in the kataconfig CR.
The source code is kept in a separate repository (github.com/jensfr/peer-pods-controller for now) which we import.

If enabled, the new controller will deploy
all resources necessary, this includes


- the cloud-api-adaptor
- a kata runtime binary build from the Kata CCv0 branch
- a new runtime class for peer pods
- a machine config for a crio configuration drop-in file to add the runtime class handler 
- a machine config for a  kata configu drop-in file to add peer pod specific configuration
- a webhook to add peer pod specific annotations to pods usinge the new runtime class

Changes to the osc operator are:

- The service account needs extended rbac to patch node/status. This is required to advertise
the extended (peer pod) resources.
- a MutatingWebhookConfiguraton is added to config/webhook/manifest.yaml
- the Webhook is registered in main(), if possible this will be moved inside the enablePeerPods check in the controller
- add the enablePeerPods option to the KataConfig CRD 
- add rbac rule to let the osc controller patch node/status (necessary because we run the peer pod controller in the process)
- add rbac rules to let the osc controller create/delete/update/patch PeerPodConfig CR's


This is a draft version, it is not yet possible to run the entire peer pod stack because some support is missing:
 - crio support for peer pods
 - the new kata shim binary is not yet deployed (currently planning the work)
 - we don't have kata 2.5 yet in the extension. We need config file drop-in support to be able to use machine configs
 - the new runtimeclass is not created automatically