### PR TITLE
Remove kata monitor image

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -35,10 +35,6 @@ type KataConfigSpec struct {
 	// +kubebuilder:default:=false
 	CheckNodeEligibility bool `json:"checkNodeEligibility"`
 
-	// KataMonitorImage is used to specify the container image used for kata-monitor
-	// +kubebuilder:default:="quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest"
-	KataMonitorImage string `json:"kataMonitorImage"`
-
 	// Sets log level on kata-equipped nodes.  Valid values are the same as for `crio --log-level`.
 	// +kubebuilder:default:="info"
 	LogLevel string `json:"logLevel,omitempty"`

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,11 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,9 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        env:
+        - name: KATA_MONITOR_IMAGE
+          value: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest
         imagePullPolicy: Always
         resources:
           limits:

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -277,9 +277,6 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 					Name:      name,
 					Namespace: "openshift-sandboxed-containers-operator",
 				},
-				Spec: kataconfigurationv1.KataConfigSpec{
-					KataMonitorImage: "quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest",
-				},
 			}
 
 			By("Creating the KataConfig CR successfully")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -73,6 +74,8 @@ var _ = BeforeSuite(func(done Done) {
 		},
 		WebhookInstallOptions: webhookOptions,
 	}
+
+	Expect(os.Setenv("KATA_MONITOR_IMAGE", "quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest")).To(Succeed())
 
 	var err error
 	cfg, err = testEnv.Start()


### PR DESCRIPTION
This PR removes spec.kataMonitorImage from the KataConfig CR.  kata-monitor container image URL is basically a technical implementation detail of OSC and as such has no good place in KataConfig.

The OSC controller now gets the kata-monitor image URL from an environment variable KATA_MONITOR_IMAGE instead of a KataConfig instance.  The default value is now part of the manager container template in OSC controller-manager Deployment.