### PR TITLE
Add security contexts to the operator

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,11 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: manager
         args:
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -52,4 +56,9 @@ spec:
           requests:
             cpu: 100m
             memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
OCP 4.12 is now enforcing the "restricted" Pod Security Admission (PSA) policy by default for every pod. This includes the pods that belong to the operator, i.e. the controller manager and the monitors. As a consequence, subscribing to OSC currently fails with the following error:

      message: 'pods "controller-manager-6dff96dbb8-m2twk" is forbidden: violates
        PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container
        "manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted
        capabilities (container "manager" must set securityContext.capabilities.drop=["ALL"]),
        runAsNonRoot != true (pod or container "manager" must set securityContext.runAsNonRoot=true),
        seccompProfile (pod or container "manager" must set securityContext.seccompProfile.type
        to "RuntimeDefault" or "Localhost")'

The controller manager has two containers, the manager itself and the kube-rbac-proxy sidecar. None of these two require elevated privileges. The operator manifest should thus have appropriate security contexts that explicitly comply with the "restricted" policy as explained here [1].

The monitors do require some privileges though. This is already addressed with the current code base : the controller adds the appropriate labels to the OSC namespace. This tells the PSA that it should accept "privileged" pods to be started in the OSC namespace.

[1] https://sdk.operatorframework.io/docs/best-practices/pod-security-standards/#what-does-that-mean

Fixes: https://issues.redhat.com/browse/KATA-1754
Signed-off-by: Greg Kurz <groug@kaod.org>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
