### PR TITLE
Include generation of generated files in build process of controller …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,17 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY Makefile Makefile
+COPY hack/ hack/
+RUN go mod vendor
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=mod -o manager main.go
+RUN make build
 
 # Use OpenShift base image
 FROM registry.ci.openshift.org/ocp/4.10:base
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot


### PR DESCRIPTION
…image

Since PR #211, generated files are no longer part of this repo.  However, the build process of the main artifact, controller container image, hasn't been adapted to the absence of generated files and currently fails.

This change adds generation of generated files to the build process.  It does so by replacing the bare `go build` command with a `build` Makefile target invocation.  The 'build' target takes care of both file generation (as a prerequisite) and building itself.

Several small adjustments are necessary to support running the 'build' target during the controller image build process.  Apart from Makefile, also hack/ needs to exist in the builder image as it contains input for the file generator.  A COPY command had to be adjusted as `make build` leaves the resulting binary in ./bin instead of ./ .

Finally, 'go mod vendor' is used to avoid an "inconsistent vendoring" error.  Apparently, 'controller-gen' which runs as part of file generation invokes 'go' internally without passing it the '-mod=mod' flag which effectively disables vendoring.  'go mod vendor' is then a way to bring vendoring into agreement with go.mod.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
