### PR TITLE
Add cleanup rules to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,3 +231,31 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+##@ Cleanup
+
+.PHONY: manifests-clean
+manifests-clean: ## Clean generated manifests
+	$(RM) -r config/crd/bases
+	$(RM) config/rbac/role.yaml
+	$(RM) config/webhook/manifests.yaml
+
+.PHONY: generate-clean
+generate-clean: ## Clean generated DeepCopy code
+	$(RM) api/v1/zz_generated.deepcopy.go
+
+.PHONY: test-clean
+test-clean: ## Clean generated test files
+	$(RM) cover.out
+
+.PHONY: bundle-clean
+bundle-clean: ## Clean generated bundle files
+	$(RM) -r bundle
+	$(RM) bundle.Dockerfile
+
+.PHONY: bin-clean
+bin-clean: ## Clean downloaded binaries
+	$(RM) -r bin
+
+.PHONY: clean
+clean: manifests-clean generate-clean test-clean bundle-clean bin-clean ## Clean all generated files


### PR DESCRIPTION
This provides a finer grained way to prune generated files from the current tree over calling `git clean`. Each target that generates files gets an associated `${target}-clean` : this provides a clear view of which target generates what. Only exceptions are downloaded binaries which all get pruned by a single `bin-clean` target for the sake of simplicity.

Signed-off-by: Greg Kurz <groug@kaod.org>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
