### PR TITLE
Use numerical uid/gid in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ COPY --from=builder /workspace/bin/manager .
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot
 
-USER nonroot:nonroot
+USER 499:499
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Older versions of OCP are unhappy with the non-numeric ids and the controller fails to start with the following error:

container has runAsNonRoot and image has non-numeric user (nonroot),
          cannot verify user is non-root

The nonroot stuff was generated by an old operator sdk. Recent versions now put numerical ids. Do the same.

Fixes: https://issues.redhat.com/browse/KATA-1824
Fixes: rhjira#[KATA-1824](https://issues.redhat.com//browse/KATA-1824)
Signed-off-by: Greg Kurz <groug@kaod.org>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
