### PR TITLE
use generated bundle.dockerfile; remove bundle from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ api/v1/zz_generated.deepcopy.go
 config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
 config/rbac/role.yaml
 config/webhook/manifests.yaml
-#bundle

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,4 @@ api/v1/zz_generated.deepcopy.go
 config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
 config/rbac/role.yaml
 config/webhook/manifests.yaml
-bundle
+#bundle

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle-custom.Dockerfile -t $(BUNDLE_IMG) .
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
When building manually (using make targets and setting env vars) the output is a bundle that still points to the production image for the operator.  This is because the bundle-build uses the bundle-custom.Dockerfile which has the production values hard coded.

**- What I did**
Change the bundle-build target back to using the generated bundle.Dockerfile so it respects set env vars and includes the respective operator image.  Also had to remove "bundle" from .dockerignore so that the docker build can succeed.

**- How to verify it**
make bundle-build
install the operator using that bundle
Verify it is using the expected operator image for the controller pods

Closes: https://issues.redhat.com/browse/KATA-1828