### PR TITLE
make upstream values default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # example.com/memcached-operator-bundle:$VERSION and example.com/memcached-operator-catalog:$VERSION.
 # FIXME: This should be an upstream accessible repo.  Investigating downstream build options to allow us to do that.
-IMAGE_TAG_BASE ?= registry-proxy.engineering.redhat.com/rh-osbs/openshift-sandboxed-containers-operator
-
+IMAGE_TAG_BASE ?= quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/bundle-custom.Dockerfile
+++ b/bundle-custom.Dockerfile
@@ -27,7 +27,7 @@ chmod +x operator-sdk
 ENV PATH=$PATH:.
 
 # Unsetting VERSION here is workaround because the buildroot image sets VERSION to the golang version
-RUN unset VERSION; make bundle
+RUN unset VERSION; make bundle IMAGE_TAG_BASE=proxy.engineering.redhat.com/rh-osbs/openshift-sandboxed-containers-operator
 
 FROM scratch
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry-proxy.engineering.redhat.com/rh-osbs/openshift-sandboxed-containers-operator
+  newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
   newTag: 1.3.1


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Default values should represent upstream builds and allow custom builds with vars

Closes: [KATA-1838](https://issues.redhat.com//browse/KATA-1838)

**- What I did**
Changed image repos to quay.io so that a running make targets will generate something accessible upstream

**- How to verify it**
build with make targets by not setting any variables
build with make targets setting a custom IMAGE_TAG_BASE

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
