### PR TITLE
set version to 1.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.3.1
+VERSION ?= 1.3.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    olm.skipRange: '>=1.1.0 <1.3.0'
+    olm.skipRange: '>=1.1.0 <1.3.2'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git
@@ -22,7 +22,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.3.0
+  name: sandboxed-containers-operator.v1.3.2
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -362,7 +362,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  version: 1.3.0
+  version: 1.3.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
This sets VERSION in the Makefile to 1.3.2.
It also updates the csv version and skipRange in config/manifests/base because we don't generate that part of the CSV yet and have to update it manually.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>
