### PR TITLE
Upgrade to operator-sdk v1.24

### DIFF
--- a/bundle-custom.Dockerfile
+++ b/bundle-custom.Dockerfile
@@ -18,7 +18,7 @@ RUN go mod vendor
 # Install operator-sdk
 RUN export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac) \
 OS=$(uname | awk '{print tolower($0)}') \
-OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0; \
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.24.0; \
 curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}; \
 mv operator-sdk_${OS}_${ARCH} operator-sdk; \
 chmod +x operator-sdk

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,9 +2,9 @@
 
 ## Prerequisites
 - Golang - 1.18.x
-- Operator SDK version - 1.23.0
+- Operator SDK version - 1.24.0
 ```
-curl -O https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0/operator-sdk_linux_amd64
+curl -O https://github.com/operator-framework/operator-sdk/releases/download/v1.24.0/operator-sdk_linux_amd64
 install -m 755 operator-sdk_linux_amd64 ${SOME_DIR_IN_YOUR_PATH}/operator-sdk
 ```
 - podman, podman-docker or docker


### PR DESCRIPTION
Following steps from https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.24.0/

No change required for go-based operators.
Just modified the bundle-custom.Dockerfile and developer's doc to reference the newer SDK.
