### PR TITLE
manifests: add back valid-subscription annotation

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/sandboxed-containers-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported


### PR DESCRIPTION
This was removed earlier but needs to be added back in order to pass validation.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

Fixes rhjira:[KATA-1876](https://issues.redhat.com//browse/KATA-1876)

Please provide the following information:
**- Description of the problem which is fixed/What is the use case**
This annotation was removed by accident. It is required to show users which subscription of OCP is required and also to pass a validation test downstream

**- What I did**
add the annotation to the CSV

**- How to verify it**
The CVP tests should pass and it should also be displayed in Operatorhub

