### PR TITLE
peerpods: remove libvirt specific fields from sample configmap and se…

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,8 @@ spec:
         env:
         - name: PEER_POD_TARGET_RUNTIMECLASS
           value: "kata-remote-cc"
+        - name: PEERPODS_NAMESPACE
+          value: "openshift-sandboxed-containers-operator"
         args:
         - --enable-leader-election
         image: controller:latest


### PR DESCRIPTION
remove any fields specifc to libvirt from the sample configmap and secret. also don't set a default for CLOUD_PROVIDER.