### PR TITLE
add PEERPODS_NAMESPACE variable to controller-manager deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,8 @@ spec:
         env:
         - name: PEER_POD_TARGET_RUNTIMECLASS
           value: "kata-remote-cc"
+        - name: PEERPODS_NAMESPACE
+          value: "openshift-sandboxed-containers-operator"
         args:
         - --enable-leader-election
         image: controller:latest


### PR DESCRIPTION
It is used by the peer-pod-controller, so let's set it in the controller-manager deployment. 