### PR TITLE
Makefile: Target bundle-build requires bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build
-bundle-build: ## Build the bundle image.
+bundle-build: bundle ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

If one calls make bundle-build without a make bundle beforehand, it will error out:

```
$ make bundle-build
docker build -f bundle.Dockerfile -t openshift-sandboxed-containers-operator-bundle:v1.3.2 .
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat sandboxed-containers-operator/bundle.Dockerfile: no such file or directory

```

**- What I did**

Added `bundle` as dependency of `bundle-build`

**- How to verify it**

Run `make bundle-build` without calling `make bundle` beforehand.

**- Description for the changelog**
Makefile: Target bundle-build requires bundle
