### PR TITLE
Encode log timestamps as RFC3339

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 
 	secv1 "github.com/openshift/api/security/v1"
 	mcfgapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +64,12 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func SetTimeEncoderToRfc3339() zap.Opts {
+	return func(o *zap.Options) {
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
+	}
+}
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -72,7 +79,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), SetTimeEncoderToRfc3339()))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
Timestamps are currently displayed as number of seconds since the Epoch using scientific notation, i.e. 1.6759526089944808e+09.

This is definitely not human friendly. Newer versions of the zap package now render timestamps according to RFC3339, i.e. 2023-02-09T14:38:20Z.

We're not ready to bump the controller-runtime package that brings us zap. Let's configure zap to explicitly use RFC3339.

Signed-off-by: Greg Kurz <groug@kaod.org>

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
