### PR TITLE
set version to 1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.3.4
+VERSION ?= 1.4.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    olm.skipRange: '>=1.1.0 <1.3.2'
+    olm.skipRange: '>=1.1.0 <1.4.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git
@@ -23,7 +23,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.3.2
+  name: sandboxed-containers-operator.v1.4.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -363,7 +363,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  version: 1.3.2
+  version: 1.4.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
In preparation for the next release, set version in Makefile and the CSV to 1.4.0. Not having to touch the CSV manually is still a todo that we're working on, at the moment it is still required though.