### PR TITLE
Optionally use public images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Use OpenShift golang builder image
+# These images needs to be synced with the images in the Makefile.
 ARG BUILDER_IMAGE=${BUILDER_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11}
 ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.ci.openshift.org/ocp/4.11:base}
 FROM ${BUILDER_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Use OpenShift golang builder image
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+ARG BUILDER_IMAGE=${BUILDER_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11}
+ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.ci.openshift.org/ocp/4.11:base}
+FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /workspace
 
@@ -20,7 +22,7 @@ RUN go mod vendor
 RUN GOFLAGS="" make build
 
 # Use OpenShift base image
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM ${TARGET_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# These images needs to be synced with the default values in the Dockerfile.
 BUILDER_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11
 TARGET_IMAGE  ?= registry.ci.openshift.org/ocp/4.11:base
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,6 +25,17 @@ In summary:
 - log in from the command line with the provided command
 - use "oc registry login" to save the token locally
 
+### Using public images
+
+If you cannot login to registry.ci.openshift.org, a temporary solution is to use 
+public images during build and test. At the time of writing, the following public images
+does the trick.
+
+```shell
+export BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:golang-1.18
+export TARGET_IMAGE=registry.ci.openshift.org/origin/4.10:base
+make docker-build
+```
 
 ## Set Environment Variables
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,7 +27,7 @@ In summary:
 
 ### Using public images
 
-If you cannot login to registry.ci.openshift.org, a temporary solution is to use 
+If you cannot login to registry.ci.openshift.org, a temporary solution is to use
 public images during build and test. At the time of writing, the following public images
 does the trick.
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Current build assumes the developer is a RH employee and uses images not publicly available.

Closes #268 

**- What I did**
- Updated Dockerfile to take images as arguments
- Updated current make target to include (the same) images as arguments when building docker images.
- Added documentation about building docker images from public images.

**- How to verify it**
Build with existing make targets:
```
make docker-build
make docker-buildx
```

Build with public images:
```
export BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:golang-1.18
export TARGET_IMAGE=registry.ci.openshift.org/origin/4.10:base
make docker-build
make docker-buildx
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added support for overriding images in Makefile.