### PR TITLE
Fix kata node selector handling

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -558,17 +558,6 @@ func (r *KataConfigOpenShiftReconciler) checkNodeEligibility() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) getNodeSelectorAsMapNoKataOc() map[string]string {
-	nodeSelector := r.getNodeSelectorAsMap()
-	delete(nodeSelector, "node-role.kubernetes.io/kata-oc")
-	return nodeSelector
-}
-
-func (r *KataConfigOpenShiftReconciler) getNodeSelectorAsSelector() (labels.Selector, error) {
-	nodeSelector := r.getNodeSelectorAsMapNoKataOc()
-	return metav1.LabelSelectorAsSelector( &metav1.LabelSelector { MatchLabels: nodeSelector, })
-}
-
 func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
 	r.Log.Info("Getting MachineConfigPool Name")
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -405,8 +405,6 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 		Values:   []string{"kata-oc", "worker"},
 	}
 
-	mcpNodeSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"node-role.kubernetes.io/kata-oc": ""}}
-
 	mcp := &mcfgv1.MachineConfigPool{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machineconfiguration.openshift.io/v1",
@@ -428,7 +426,7 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 			MachineConfigSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{lsr},
 			},
-			NodeSelector: mcpNodeSelector,
+			NodeSelector: r.getNodeSelectorAsLabelSelector(),
 		},
 	}
 


### PR DESCRIPTION
This PR aims to fix a long-standing problem where `kataConfigPoolSelector` allows users to use `MatchExpressions` but then the controller code handling the selector cannot process the `MatchExpressions` part and ends up effectively ignoring it.

Please check out the initial commit's message for a detailed explanation of the problem and the fix.

Fixes: [KATA-1860](https://issues.redhat.com//browse/KATA-1860)
Fixes: [KATA-1966](https://issues.redhat.com//browse/KATA-1966)
Closes: [KATA-1965](https://issues.redhat.com//browse/KATA-1965)