### PR TITLE
Fix corner case node selector handling

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -688,10 +688,15 @@ func (r *KataConfigOpenShiftReconciler) getKataConfigNodeSelectorAsLabelSelector
 		return &metav1.LabelSelector { MatchLabels: map[string]string{ "node-role.kubernetes.io/master": "" }}
 	}
 
-	nodeSelector := r.kataConfig.Spec.KataConfigPoolSelector.DeepCopy()
+	nodeSelector := &metav1.LabelSelector{}
+	if r.kataConfig.Spec.KataConfigPoolSelector != nil {
+		nodeSelector = r.kataConfig.Spec.KataConfigPoolSelector.DeepCopy()
+	}
+
 	if r.kataConfig.Spec.CheckNodeEligibility {
 		nodeSelector = labelsutil.AddLabelToSelector(nodeSelector, "feature.node.kubernetes.io/runtime.kata", "true")
 	}
+	r.Log.Info("getKataConfigNodeSelectorAsLabelSelector()", "selector", nodeSelector)
 	return nodeSelector
 }
 


### PR DESCRIPTION
This PR fixes problems in kata node selector handling introduced by recent changes.  They include
- an empty kata node selector can be represented by nil as opposed to an empty `metav1.LabelSelector` instance
- nil and empty LabelSelector selectors are allowed but handled radically differently by apimachinery (an empty instance matches everything, nil matches nothing)
- default k8s syntax checking of `matchExpressions` doesn't catch invalid `matchExpressions.operator` values.