### PR TITLE
controller: fix wrong amout of cpu request in RuntimeClass

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1017,7 +1017,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		foundMcp.Status.UpdatedMachineCount == foundMcp.Status.MachineCount {
 		r.Log.Info("create runtime class")
 		r.kataConfig.Status.InstallationStatus.IsInProgress = "false"
-		err := r.createRuntimeClass("kata", "250M", "350Mi")
+		err := r.createRuntimeClass("kata", "0.25", "350Mi")
 		if err != nil {
 			// Give sometime for the error to go away before reconciling again
 			return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
@@ -1731,7 +1731,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPods() error {
 		return err
 	}
 
-	err = r.createRuntimeClass("kata-remote-cc", "250M", "350Mi")
+	err = r.createRuntimeClass("kata-remote-cc", "0.25", "350Mi")
 
 	return err
 }


### PR DESCRIPTION
In commit 7dae22183ecfa781c5fb50e4017a337d577bac78 and df06ae971b52df90e336457cd489788a9463f6b4 I turned '250m' into '250M'. This means a pod will request 250 full CPUs instead of a quarter CPU.

Fixes: rhjira#[KATA-2069](https://issues.redhat.com//browse/KATA-2069)

