### PR TITLE
bundle: add peerpodconfig crd file

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -7,6 +7,10 @@ plugins:
 projectName: sandboxed-containers-operator
 repo: github.com/openshift/sandboxed-containers-operator
 resources:
+- group: confidentialcontainers
+  version: v1alpha1
+  kind: PeerPodConfig
+  path: github.com/confidential-containers/cloud-api-adaptor/peer-pod-controller/api/v1alpha1
 - controller: true
   domain: kataconfiguration.openshift.io
   group: kataconfiguration

--- a/config/manifests/extension-crds/confidentialcontainers.org_peerpodconfigs.yaml
+++ b/config/manifests/extension-crds/confidentialcontainers.org_peerpodconfigs.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: peerpodconfigs.confidentialcontainers.org
+spec:
+  group: confidentialcontainers.org
+  names:
+    kind: PeerPodConfig
+    listKind: PeerPodConfigList
+    plural: peerpodconfigs
+    singular: peerpodconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PeerPodConfig is the Schema for the peerpodconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            example:
+              type: string
+              x-kubernetes-preserve-unknown-fields: true
+            description: PeerPodConfigSpec defines the desired state of PeerPodConfig
+            properties:
+              cloudSecretName:
+                default: peer-pods-secret
+                description: CloudSecretName is the name of the secret that holds
+                  the credentials for the cloud provider
+                type: string
+              configMapName:
+                default: peer-pods-cm
+                description: ConfigMapName is the name of the configmap that holds
+                  cloud provider specific environment Variables
+                type: string
+              instanceType:
+                description: InstanceType describes the name of the instance type
+                  of the chosen cloud provider
+                type: string
+              labelSelector:
+                description: LabelSelector selects the nodes to which the caa pods,
+                  the RuntimeClass and the MachineConfigs we use to deploy the full
+                  peer pod solution.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              limit:
+                description: Limit is the max number of peer pods. This is exposed
+                  as expended resource on nodes
+                type: string
+            required:
+            - cloudSecretName
+            - configMapName
+            type: object
+          status:
+            description: PeerPodConfigStatus defines the observed state of PeerPodConfig
+            properties:
+              setupCompleted:
+                description: SetupCompleted is set to true when all components have
+                  been deployed/created
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/manifests/extension-crds/kustomization.yaml
+++ b/config/manifests/extension-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- confidentialcontainers.org_peerpodconfigs.yaml

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
+- extension-crds/
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.


### PR DESCRIPTION
We need the PeerPodConfig CRD file in the bundle so that it is deployed with the Operator.

**- What I did**
add the peerpodconfig crd to the PROJECTS file, so that it's included as an owned resource in the CSV and add
the full CRD yaml file to config/manifests/extension-crds/

**- How to verify it**
Deploy the operator and check the controller log, if there is no error message saying that it can't find
the peerpodconfig CRD, then the problem is fixed.

Fixes: rhjira#[KATA-2098](https://issues.redhat.com//browse/KATA-2098)
