### PR TITLE
controller: checkNodeEligibility vs peerpods: noop

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -576,6 +576,11 @@ func (r *KataConfigOpenShiftReconciler) checkConvergedCluster() (bool, error) {
 func (r *KataConfigOpenShiftReconciler) checkNodeEligibility() error {
 	r.Log.Info("Check Node Eligibility to run Kata containers")
 	// Check if node eligibility label exists
+
+	if r.kataConfig.Spec.EnablePeerPods {
+		r.Log.Info("enablePeerPods is true. Skipping since they are mutually exclusive.")
+		return nil
+	}
 	err, nodes := r.getNodesWithLabels(map[string]string{"feature.node.kubernetes.io/runtime.kata": "true"})
 	if err != nil {
 		r.Log.Error(err, "Error in getting list of nodes with label: feature.node.kubernetes.io/runtime.kata")

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -631,6 +631,19 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 			By("Creating the KataConfig CR successfully")
 			Expect(k8sClient.Create(context.Background(), kataConfig)).Should(Succeed())
 
+			// Delete
+			By("Deleting KataConfig CR successfully")
+			kataConfigKey := types.NamespacedName{Name: kataConfig.Name}
+			Eventually(func() error {
+				k8sClient.Get(context.Background(), kataConfigKey, kataConfig)
+				return k8sClient.Delete(context.Background(), kataConfig)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting to delete KataConfig CR successfully")
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), kataConfigKey, kataConfig)
+			}, timeout, interval).ShouldNot(Succeed())
+
 		})
 	})
 })

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -646,4 +646,39 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 
 		})
 	})
+	Context("Custom KataConfig with CheckNodeEligibility and PeerPods enabled", func() {
+		It("Should ignore CheckNodeEligibility when PeerPods is enabled", func() {
+
+			kataConfig := &kataconfigurationv1.KataConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kataconfiguration.openshift.io/v1",
+					Kind:       "KataConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name + "-with-peerpods",
+				},
+				Spec: kataconfigurationv1.KataConfigSpec{
+					CheckNodeEligibility: true,
+					EnablePeerPods:       true,
+				},
+			}
+
+			By("Creating the KataConfig CR successfully")
+			Expect(k8sClient.Create(context.Background(), kataConfig)).Should(Succeed())
+
+			// Delete
+			By("Deleting KataConfig CR successfully")
+			kataConfigKey := types.NamespacedName{Name: kataConfig.Name}
+			Eventually(func() error {
+				k8sClient.Get(context.Background(), kataConfigKey, kataConfig)
+				return k8sClient.Delete(context.Background(), kataConfig)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting to delete KataConfig CR successfully")
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), kataConfigKey, kataConfig)
+			}, timeout, interval).ShouldNot(Succeed())
+
+		})
+	})
 })


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

When PeerPods is enabled checkNodeEligibility should not take into consideration since PeerPods doesn’t require KVM/qemu.

**- What I did**

I'm checking if enablePeerPods is enabled during checkNodeEligibility().

**- How to verify it**

Enable both checkNodeEligibility and enablePeerPods in you kata-config and check controller logs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Configuration: Ignoring checkNodeEligibility when peer pods is enabled.