### PR TITLE
Improve installation steps

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -59,6 +59,11 @@ type KataConfigStatus struct {
 	// Upgradestatus reflects the status of the ongoing kata upgrade
 	// +optional
 	Upgradestatus KataUpgradeStatus `json:"upgradeStatus,omitempty"`
+
+	// Used internally to persist state between reconciliations
+	// +optional
+	// +kubebuilder:default:=false
+	WaitingForMcoToStart bool `json:"waitingForMcoToStart,omitempty"`
 }
 
 // +genclient

--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -59,8 +59,6 @@ type KataConfigStatus struct {
 	// Upgradestatus reflects the status of the ongoing kata upgrade
 	// +optional
 	Upgradestatus KataUpgradeStatus `json:"upgradeStatus,omitempty"`
-
-	BaseMcpGeneration int64 `json:"prevMcpGeneration"`
 }
 
 // +genclient

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -941,17 +941,17 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.Log.Info("SCNodeRole is: " + machinePool)
 	}
 
-	err = r.updateNodeLabels()
-	if err != nil {
-		if k8serrors.IsConflict(err) {
-			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
-		} else {
-			return ctrl.Result{Requeue: true}, nil
-		}
-	}
 
 	// Create kata-oc MCP only if it's not a converged cluster
 	if machinePool != "master" {
+		err = r.updateNodeLabels()
+		if err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			} else {
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
 
 		// Create kata-oc only if it doesn't exist
 		mcp := &mcfgv1.MachineConfigPool{}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -952,14 +952,13 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 	// Create kata-oc MCP only if it's not a converged cluster
 	if machinePool != "master" {
-		r.Log.Info("Creating new MachineConfigPool")
-		mcp := r.newMCPforCR()
 
 		// Create kata-oc only if it doesn't exist
-		foundMcp := &mcfgv1.MachineConfigPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
+		mcp := &mcfgv1.MachineConfigPool{}
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, mcp)
 		if err != nil && k8serrors.IsNotFound(err) {
 			r.Log.Info("Creating a new MachineConfigPool ", "machinePool", machinePool)
+			mcp = r.newMCPforCR()
 			err = r.Client.Create(context.TODO(), mcp)
 			if err != nil {
 				r.Log.Error(err, "Error in creating new MachineConfigPool ", "machinePool", machinePool)
@@ -973,7 +972,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 
 		// Wait till MCP is ready
-		if foundMcp.Status.MachineCount == 0 {
+		if mcp.Status.MachineCount == 0 {
 			r.Log.Info("Waiting till MachineConfigPool is initialized ", "machinePool", machinePool)
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 		}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -979,9 +979,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 	}
 
-	doReconcile, err, isMcCreated := r.createExtensionMc(machinePool)
-	if isMcCreated {
-		return doReconcile, err
+	wasMcJustCreated, err := r.createExtensionMc(machinePool)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, nil
+	} else if wasMcJustCreated {
+		return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 	}
 
 	foundMcp, doReconcile, err, done := r.updateStatus(machinePool)
@@ -1022,7 +1024,16 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 	return ctrl.Result{}, nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (ctrl.Result, error, bool) {
+// If the first return value is 'true' it means that the MC was just created
+// by this call, 'false' means that it's already existed.  As usual, the first
+// return value is only valid if the second one is nil.
+func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (bool, error) {
+
+	// In case we're returning an error we want to make it explicit that
+	// the first return value is "not care".  Unfortunately golang seems
+	// to lack syntax for creating an expression with default bool value
+	// hence this work-around.
+	var dummy bool
 
 	/* Create Machine Config object to enable sandboxed containers RHCOS extension */
 	mc := &mcfgv1.MachineConfig{}
@@ -1032,20 +1043,24 @@ func (r *KataConfigOpenShiftReconciler) createExtensionMc(machinePool string) (c
 		r.Log.Info("creating RHCOS extension MachineConfig")
 		mc, err = r.newMCForCR(machinePool)
 		if err != nil {
-			return ctrl.Result{}, err, true
+			return dummy, err
 		}
 
 		err = r.Client.Create(context.TODO(), mc)
 		if err != nil {
 			r.Log.Error(err, "Failed to create a new MachineConfig ", "mc.Name", mc.Name)
-			return ctrl.Result{}, err, true
+			return dummy, err
 		}
-		/* mc created successfully - it will take a moment to finalize, requeue to create runtimeclass */
 		r.Log.Info("MachineConfig successfully created", "mc.Name", mc.Name)
 		r.kataConfig.Status.InstallationStatus.IsInProgress = corev1.ConditionTrue
-		return ctrl.Result{Requeue: true}, nil, true
+		return true, nil
+	} else if err != nil {
+		r.Log.Info("failed to retrieve extension MachineConfig", "err", err)
+		return dummy, err
+	} else {
+		r.Log.Info("extension MachineConfig already exists")
+		return false, nil
 	}
-	return ctrl.Result{}, nil, false
 }
 
 func (r *KataConfigOpenShiftReconciler) makeReconcileRequest() reconcile.Request {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -966,7 +966,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 	// Create kata-oc MCP only if it's not a converged cluster
 	if !isConvergedCluster {
-		err = r.updateNodeLabels()
+		_, err = r.updateNodeLabels()
 		if err != nil {
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
@@ -1436,7 +1436,7 @@ func (r *KataConfigOpenShiftReconciler) getNodesWithLabels(nodeLabels map[string
 	return nil, nodes
 }
 
-func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (err error) {
+func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (labelingChanged bool, err error) {
 	workerNodeList := &corev1.NodeList{}
 	workerSelector := labels.SelectorFromSet(map[string]string{"node-role.kubernetes.io/worker": ""})
 	listOpts := []client.ListOption{
@@ -1445,13 +1445,13 @@ func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (err error) {
 
 	if err := r.Client.List(context.TODO(), workerNodeList, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes failed")
-		return err
+		return false, err
 	}
 
 	kataNodeSelector, err := r.getKataConfigNodeSelectorAsSelector()
 	if err != nil {
 		r.Log.Info("Couldn't getKataConfigNodeSelectorAsSelector()", "err", err)
-		return err
+		return false, err
 	}
 
 	for _, worker := range workerNodeList.Items {
@@ -1475,11 +1475,13 @@ func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (err error) {
 		err = r.Client.Update(context.TODO(), &worker)
 		if err != nil {
 			r.Log.Error(err, "Error when adding labels to node", "node", worker)
-			return err
+			return labelingChanged, err
 		}
+
+		labelingChanged = true
 	}
 
-	return nil
+	return labelingChanged, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) unlabelNodes(nodeSelector labels.Selector) (err error) {


### PR DESCRIPTION
This PR reworks the installation flow with two main objectives in mind: rearrange major steps (e.g. MC and MCP creation) so that they follow the most straightforward and natural succession possible, and remove arbitrary waits throughout the procedure, replacing them with a small number of better-founded ones.

A number of smaller clean-ups are also done in the initial commits of this series.

Fixes: [KATA-1969](https://issues.redhat.com//browse/KATA-1969)
Fixes: [KATA-2143](https://issues.redhat.com//browse/KATA-2143)