### PR TITLE
Improve uninstallation flow

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -781,12 +781,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}
 
-	foundMcp := &mcfgv1.MachineConfigPool{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if contains(r.kataConfig.GetFinalizers(), kataConfigFinalizer) {
 		// Get the list of pods that might be running using kata runtime
 		err := r.listKataPods()

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -774,6 +774,16 @@ func (r *KataConfigOpenShiftReconciler) getNodeSelectorAsLabelSelector() *metav1
 	return &metav1.LabelSelector{MatchLabels: r.getNodeSelectorAsMap()}
 }
 
+func (r *KataConfigOpenShiftReconciler) isMcpUpdating(mcpName string) bool {
+	mcp := &mcfgv1.MachineConfigPool{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
+	if err != nil {
+		r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcpName, "err", err)
+		return false
+	}
+	return mcfgv1.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating)
+}
+
 func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.Result, error) {
 	r.Log.Info("KataConfig deletion in progress: ")
 	machinePool, err := r.getMcpNameIfMcpExists()
@@ -1038,24 +1048,14 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 	}
 
-	isMcpUpdating := func(mcpName string) bool {
-		mcp := &mcfgv1.MachineConfigPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
-		if err != nil {
-			r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcpName, "err", err)
-			return false
-		}
-		return mcfgv1.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating)
-	}
-
-	isKataMcpUpdating := isMcpUpdating(machinePool)
+	isKataMcpUpdating := r.isMcpUpdating(machinePool)
 	r.Log.Info("MCP updating state", "MCP name", machinePool, "is updating", isKataMcpUpdating)
 	if isKataMcpUpdating {
 		r.kataConfig.Status.InstallationStatus.IsInProgress = corev1.ConditionTrue
 	}
 	isMcoUpdating := isKataMcpUpdating
 	if !isConvergedCluster {
-		isWorkerUpdating := isMcpUpdating("worker")
+		isWorkerUpdating := r.isMcpUpdating("worker")
 		r.Log.Info("MCP updating state", "MCP name", "worker", "is updating", isWorkerUpdating)
 		if isWorkerUpdating {
 			r.kataConfig.Status.InstallationStatus.IsInProgress = corev1.ConditionTrue

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -133,14 +133,12 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		// indicated by the deletion timestamp being set.
 		if r.kataConfig.GetDeletionTimestamp() != nil {
 			res, err := r.processKataConfigDeleteRequest()
-			if err != nil {
-				return res, err
-			}
+
 			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
 			if updateErr != nil {
 				return ctrl.Result{}, updateErr
 			}
-			return res, nil
+			return res, err
 		}
 
 		res, err := r.processKataConfigInstallRequest()
@@ -922,11 +920,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	_, result, err2, done := r.updateStatus(machinePool)
 	if !done {
 		return result, err2
-	}
-	err = r.Client.Status().Update(context.TODO(), r.kataConfig)
-	if err != nil {
-		r.Log.Error(err, "Unable to update KataConfig status")
-		return ctrl.Result{}, err
 	}
 
 	if isMcoUpdating {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -550,6 +550,18 @@ func (r *KataConfigOpenShiftReconciler) addFinalizer() error {
 	return nil
 }
 
+func (r *KataConfigOpenShiftReconciler) removeFinalizer() error {
+	r.Log.Info("Removing finalizer from the KataConfig")
+	controllerutil.RemoveFinalizer(r.kataConfig, kataConfigFinalizer)
+
+	err := r.Client.Update(context.TODO(), r.kataConfig)
+	if err != nil {
+		r.Log.Error(err, "Unable to update KataConfig")
+		return err
+	}
+	return nil
+}
+
 func (r *KataConfigOpenShiftReconciler) listKataPods() error {
 	podList := &corev1.PodList{}
 	listOpts := []client.ListOption{
@@ -978,12 +990,8 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	}
 
 	r.Log.Info("Uninstallation completed. Proceeding with the KataConfig deletion")
-	controllerutil.RemoveFinalizer(r.kataConfig, kataConfigFinalizer)
-
-	err = r.Client.Update(context.TODO(), r.kataConfig)
-	if err != nil {
-		r.Log.Error(err, "Unable to update KataConfig")
-		return ctrl.Result{}, err
+	if err = r.removeFinalizer(); err != nil {
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -135,7 +135,14 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 			res, err := r.processKataConfigDeleteRequest()
 
 			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
-			if updateErr != nil {
+			// The finalizer test is to get rid of the
+			// "Operation cannot be fulfilled [...] Precondition failed"
+			// error which happens when returning from a reconciliation that
+			// deleted our KataConfig by removing its finalizer.  So if the
+			// finalizer is missing the actual KataConfig object is probably
+			// already gone from the cluster, hence the error.
+			if updateErr != nil && controllerutil.ContainsFinalizer(r.kataConfig, kataConfigFinalizer) {
+				r.Log.Info("Updating KataConfig failed", "err", updateErr)
 				return ctrl.Result{}, updateErr
 			}
 			return res, err


### PR DESCRIPTION
This PR is an uninstallation couterpart of PR #291.  The core of the change is migrating uninstallation to the exact same flow logic that installation has benefited from with a side benefit of a consistent idea behind both.

Apart from the tracked issues listed below, this PR also fixes a leakage of `logLevel` ContainerRuntimeConfig resource and removes spurious error messages at the end of each uninstallation that have been confusing people routinely.

Fixes: [KATA-2139](https://issues.redhat.com//browse/KATA-2139)
Fixes: [KATA-1926](https://issues.redhat.com//browse/KATA-1926)
Fixes: [KATA-1972](https://issues.redhat.com//browse/KATA-1972)
