### PR TITLE
controller: fix incorrect logs in createAuthJsonSecret

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1831,12 +1831,13 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 		if k8serrors.IsAlreadyExists(err) {
 			err = r.Client.Update(context.TODO(), &authJsonSecret)
 			if err != nil {
-				r.Log.Info("Error UPDATING auth-json-secret", "err", err)
+				r.Log.Info("Error updating auth-json-secret", "err", err)
 				return err
 			}
+		} else {
+			r.Log.Info("Error creating auth-json-secret", "err", err)
+			return err
 		}
-		r.Log.Info("Error creating auth-json-secret", "err", err)
-		return err
 	}
 
 	return err


### PR DESCRIPTION

```   
 controller: fix incorrect logs in createAuthJsonSecret
    
    If the client is just updated with no error, the code was always falling
    back to r.Log.Info("Error creating auth-json-secret", "err", err)
    thus printing it also when it was not necessary.
    
    Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
```