### PR TITLE
Fix make test

### DIFF
--- a/config/extension-crds/containerruntimeconfig.crd.yaml
+++ b/config/extension-crds/containerruntimeconfig.crd.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: containerruntimeconfigs.machineconfiguration.openshift.io
+  labels:
+    "openshift.io/operator-managed": ""
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ContainerRuntimeConfig
+    listKind: ContainerRuntimeConfigList
+    plural: containerruntimeconfigs
+    singular: containerruntimeconfig
+    shortNames:
+    - ctrcfg
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: ContainerRuntimeConfig describes a customized Container Runtime
+          configuration.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContainerRuntimeConfigSpec defines the desired state of ContainerRuntimeConfig
+            type: object
+            required:
+            - containerRuntimeConfig
+            properties:
+              containerRuntimeConfig:
+                description: ContainerRuntimeConfiguration defines the tuneables of
+                  the container runtime. It's important to note that, since the fields
+                  of the ContainerRuntimeConfiguration are directly read by the upstream
+                  kubernetes golang client, the validation of those values is handled
+                  directly by that golang client which is outside of the controller
+                  for ContainerRuntimeConfiguration. Please ensure the valid values
+                  are used for those fields as invalid values may render cluster nodes
+                  unusable.
+                type: object
+                properties:
+                  logLevel:
+                    description: logLevel specifies the verbosity of the logs based
+                      on the level it is set to. Options are fatal, panic, error, warn,
+                      info, and debug.
+                    type: string
+                  logSizeMax:
+                    description: logSizeMax specifies the Maximum size allowed for the
+                      container log file. Negative numbers indicate that no size limit
+                      is imposed. If it is positive, it must be >= 8192 to match/exceed
+                      conmon's read buffer.
+                    type: string
+                  overlaySize:
+                    description: 'overlaySize specifies the maximum size of a container
+                      image. This flag can be used to set quota on the size of container
+                      images. (default: 10GB)'
+                    type: string
+                  pidsLimit:
+                    description: pidsLimit specifies the maximum number of processes
+                      allowed in a container
+                    type: integer
+                    format: int64
+              machineConfigPoolSelector:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                type: object
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    type: array
+                    items:
+                      description: A label selector requirement is a selector that contains
+                        values, a key, and an operator that relates the key and values.
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a
+                            set of values. Valid operators are In, NotIn, Exists and
+                            DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If the
+                            operator is Exists or DoesNotExist, the values array must
+                            be empty. This array is replaced during a strategic merge
+                            patch.
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator is
+                      "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                    additionalProperties:
+                      type: string
+          status:
+            description: ContainerRuntimeConfigStatus defines the observed state of
+              a ContainerRuntimeConfig
+            type: object
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                type: array
+                items:
+                  description: ContainerRuntimeConfigCondition defines the state of
+                    the ContainerRuntimeConfig
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      type: string
+                      format: date-time
+                      nullable: true
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+              observedGeneration:
+                description: observedGeneration represents the generation observed by
+                  the controller.
+                type: integer
+                format: int64

--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -190,6 +190,53 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 				return k8sClient.Delete(context.Background(), kataconfig)
 			}, timeout, interval).Should(Succeed())
 
+			// The controller first deletes the extension MC and then waits for the MCO to
+			// fully process the deletion. The controller achieves that by monitoring the
+			// status of the worker MCP and looking for a "Upgrading to Upgraded" transition.
+			// This is simulated on the test side by monitoring the WaitingForMcoToStart field
+			// of the KataConfig and looking for a "true to false" transition.
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become true")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(true))
+
+			By("Getting the worker MachineConfigPool successfully")
+			workerMcp := &mcfgv1.MachineConfigPool{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker"}, workerMcp)).Should(Succeed())
+
+			By("Updating worker MCP status to Updating")
+			workerMcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdating,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+
+			Expect(k8sClient.Status().Update(context.Background(), workerMcp)).Should(Succeed())
+
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become false")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(false))
+
+			By("Updating worker MCP status to Updated")
+			workerMcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdated,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+
+			Expect(k8sClient.Status().Update(context.Background(), workerMcp)).Should(Succeed())
+
 			By("Ensuring kata-oc MCP is successfully deleted")
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "kata-oc"}, mcp)
@@ -249,6 +296,52 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
 				return k8sClient.Delete(context.Background(), kataconfig)
 			}, timeout, interval).Should(Succeed())
+
+			// The controller first deletes the extension MC and then waits for the MCO to
+			// fully process the deletion. The controller achieves that by monitoring the
+			// status of the worker MCP and looking for a "Upgrading to Upgraded" transition.
+			// This is simulated on the test side by monitoring the WaitingForMcoToStart field
+			// of the KataConfig and looking for a "true to false" transition.
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become true")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(true))
+
+			By("Getting the worker MachineConfigPool successfully")
+			workerMcp := &mcfgv1.MachineConfigPool{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker"}, workerMcp)).Should(Succeed())
+
+			By("Updating worker MCP status to Updating")
+			workerMcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdating,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+
+			Expect(k8sClient.Status().Update(context.Background(), workerMcp)).Should(Succeed())
+
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become false")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(false))
+
+			By("Updating worker MCP status to Updated")
+			workerMcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdated,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+			Expect(k8sClient.Status().Update(context.Background(), workerMcp)).Should(Succeed())
 
 			By("Ensuring kata-oc MCP is successfully deleted")
 
@@ -554,6 +647,41 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 				return k8sClient.Delete(context.Background(), kataConfig)
 			}, timeout, time.Second).Should(Succeed())
 
+			// The controller first deletes the extension MC and then waits for the MCO to
+			// fully process the deletion. The controller achieves that by monitoring the
+			// status of the worker MCP and looking for a "Upgrading to Upgraded" transition.
+			// This is simulated on the test side by monitoring the WaitingForMcoToStart field
+			// of the KataConfig and looking for a "true to false" transition.
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become true")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(true))
+
+			By("Getting the worker MachineConfigPool successfully")
+			workerMcp := &mcfgv1.MachineConfigPool{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker"}, workerMcp)).Should(Succeed())
+
+			By("Updating worker MCP status to Updating")
+			workerMcp.Status.Conditions = []mcfgv1.MachineConfigPoolCondition{
+				{
+					Type:    mcfgv1.MachineConfigPoolUpdating,
+					Status:  corev1.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			}
+
+			Expect(k8sClient.Status().Update(context.Background(), workerMcp)).Should(Succeed())
+
+			By("Waiting for KataConfig CR WaitingForMcoToStart to become false")
+			Eventually(func() bool {
+				kataconfig := &kataconfigurationv1.KataConfig{}
+				k8sClient.Get(context.Background(), kataConfigKey, kataconfig)
+				return kataconfig.Status.WaitingForMcoToStart
+			}, 10, time.Second).Should(Equal(false))
+
 			By("Updating kata-oc MCP successfully")
 			kataMcp.Status.UpdatedMachineCount = 0
 			kataMcp.Status.ReadyMachineCount = 0
@@ -572,12 +700,6 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 			}
 
 			Expect(k8sClient.Status().Update(context.Background(), kataMcp)).Should(Succeed())
-
-			By("Getting the worker MachineConfigPool successfully")
-			workerMcp := &mcfgv1.MachineConfigPool{}
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "worker"}, workerMcp)
-			}, timeout, interval).Should(Succeed())
 
 			By("Updating worker MCP successfully")
 			workerMcp.Status.UpdatedMachineCount = 0

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -70,6 +70,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "config", "extension-crds", "machineconfig.crd.yaml"),
 			filepath.Join("..", "config", "extension-crds", "machineconfigpool.crd.yaml"),
 			filepath.Join("..", "config", "extension-crds", "scc.crd.yaml"),
+			filepath.Join("..", "config", "extension-crds", "containerruntimeconfig.crd.yaml"),
 		},
 		WebhookInstallOptions: webhookOptions,
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -54,7 +55,10 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true),
+		func(o *zap.Options) {
+			o.TimeEncoder = zapcore.TimeEncoderOfLayout("01/02/06 15:04:05.000")
+		}))
 
 	By("bootstrapping test environment")
 	webhookOptions := envtest.WebhookInstallOptions{


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

`make test` is failing on the devel branch.

**- What I did**

- `git clone https://github.com/openshift/sandboxed-containers-operator.git`
- `git checkout devel`
- `make test`

**- How to verify it**

`make test` should succeed.

**- Description for the changelog**

The real fixes are the second commit that adapts the tests to the new logic in the controller code introduced by #300,
and the third commit that adds the CRD of the ContainerRuntimeConfig to the test suite.

First commit is a cosmetic fix that make the timestamps human readable in the controller logs. It can only be tested in a situation where `make test` fails, e.g. before applying the other patches of this PR.

Fixes https://issues.redhat.com/browse/KATA-2167