### PR TITLE
KATA-2159: add cloud-api-adaptor images as relatedImage

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,10 +76,12 @@ spec:
         env:
         - name: PEERPODS_NAMESPACE
           value: "openshift-sandboxed-containers-operator"
-        - name: KATA_MONITOR_IMAGE
+        - name: RELATED_IMAGE_KATA_MONITOR
           value: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest
         - name: SANDBOXED_CONTAINERS_EXTENSION
           value: kata-containers
+        - name: RELATED_IMAGE_CAA
+          value: quay.io/confidential-containers/cloud-api-adaptor
         imagePullPolicy: Always
         resources:
           limits:

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -344,7 +344,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 		runGroupID    = int64(1001)
 	)
 
-	kataMonitorImage := os.Getenv("KATA_MONITOR_IMAGE")
+	kataMonitorImage := os.Getenv("RELATED_IMAGE_KATA_MONITOR")
 	if len(kataMonitorImage) == 0 {
 		// kata-monitor image URL is generally impossible to verify or sanitise,
 		// with the empty value being pretty much the only exception where it's
@@ -352,7 +352,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 		// out of an infinite number of bad values, we choose not to return an
 		// error here (giving an impression that we can actually detect errors)
 		// but just log this incident and plow ahead.
-		r.Log.Info("KATA_MONITOR_IMAGE env var is unset or empty, kata-monitor pods will not run")
+		r.Log.Info("RELATED_IMAGE_KATA_MONITOR env var is unset or empty, kata-monitor pods will not run")
 	}
 
 	r.Log.Info("Creating monitor DaemonSet with image file: \"" + kataMonitorImage + "\"")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: webhookOptions,
 	}
 
-	Expect(os.Setenv("KATA_MONITOR_IMAGE", "quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest")).To(Succeed())
+	Expect(os.Setenv("RELATED_IMAGE_KATA_MONITOR", "quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest")).To(Succeed())
 
 	var err error
 	cfg, err = testEnv.Start()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.0.0-20230512144533-a9941bba4692
-	github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230512144533-a9941bba4692
+	github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230523130359-41dd75cd4399
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/confidential-containers/cloud-api-adaptor v0.5.1-0.20230504043629-580
 github.com/confidential-containers/cloud-api-adaptor v0.5.1-0.20230504043629-580abeb128aa/go.mod h1:PgjQnT5SSuSMiVM2uVKj7Qq70lMc5nVhZOPYU0lyy+s=
 github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.0.0-20230512144533-a9941bba4692 h1:c+/JR7+sxetQ+wI6XwGnrZAZA/ZgWhXQtXTbO2w0siA=
 github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.0.0-20230512144533-a9941bba4692/go.mod h1:MHjPSHrlD3SLbWqT6RteKSgZRc2fRRZahf5lfPYbHUM=
-github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230512144533-a9941bba4692 h1:Ym7kkFxPKcGEY1MadMD+BPxZOX4Migp1Sbq7kLkua2U=
-github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230512144533-a9941bba4692/go.mod h1:LH9ur4GVe4uZM9MnQIGIeBr5CdCVMQ9AtUHGPs1WoD4=
+github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230523130359-41dd75cd4399 h1:JUZZkfPXQtDtYtVZZP97daoC6cKdipEUazsOsbAv6JY=
+github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl v0.0.0-20230523130359-41dd75cd4399/go.mod h1:LH9ur4GVe4uZM9MnQIGIeBr5CdCVMQ9AtUHGPs1WoD4=
 github.com/container-orchestrated-devices/container-device-interface v0.4.0/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=


### PR DESCRIPTION
Add the cloud-api-adaptor(-webhook) image as a relatedImage to the CSV.

Fixes: rhjira#[KATA-2159](https://issues.redhat.com//browse/KATA-2159)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

add cloud-api-adaptor images as related images. By adding them to config/manager/manager.yaml they will be automatically added to the generated CSV when `make bundle` is run. 

**- What I did**
Add the caa and caa-webhook image to the manager.yaml file. This is related to and dependent on  https://github.com/confidential-containers/cloud-api-adaptor/pull/963 which changes the env variable name

**- How to verify it**
the generated CSV includes the env vars RELATED_IMAGE_CAA(_WEBHOOK). When built with OSBS and digest pinning is enabled it should replace the tag in the pull spec with the digest and by that enable the operator to work in disconnected clusters.


**- Description for the changelog**
set CAA images (caa itself and the webhook) as relatedImages in the CSV
