### PR TITLE
Fix envtest tearing down

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,10 +43,14 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var k8sManager ctrl.Manager
+var (
+	cfg        *rest.Config
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	k8sManager ctrl.Manager
+	ctx        context.Context
+	cancel     context.CancelFunc
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -55,6 +60,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
 	webhookOptions := envtest.WebhookInstallOptions{
@@ -111,7 +118,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -121,6 +128,9 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	// Stop() will timeout if the context isn't cancelled beforehand.
+	// See https://github.com/kubernetes-sigs/kubebuilder/pull/2379 for details.
+	cancel()
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })


### PR DESCRIPTION
PR #307 was too optimistic. The original issue worked around by 053f8664bf29d still exists actually ; `make test` is now failing with :

  [FAILED] Unexpected error:
      <errors.aggregate | len:1, cap:1>: [
          <*errors.errorString | 0xc0005ebf80>{
              s: "timeout waiting for process kube-apiserver to stop",
          },
      ]
      timeout waiting for process kube-apiserver to stop
  occurred

This is caused by a missing cancellation of the certwatcher in the controller-runtime. The fix, as documented in [1], is to create a cancellable context, pass it to envtest and cancel it just before tearing down the test.

[1] https://github.com/kubernetes-sigs/kubebuilder/pull/2379

Fixes https://issues.redhat.com/browse/KATA-2168