### PR TITLE
hide peerpods and peerpodconfigs internal objects

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -16,10 +16,12 @@ metadata:
     olm.skipRange: '>=1.1.0 <1.4.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git
+    operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/sandboxed-containers-operator
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported


### PR DESCRIPTION
based on:
https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs