### PR TITLE
Fix kataconfig status handling to support installation updates

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1667,6 +1667,18 @@ func (r *KataConfigOpenShiftReconciler) getConditionReason(conditions []mcfgv1.M
 	return ""
 }
 
+func (r *KataConfigOpenShiftReconciler) getMcpByName(mcpName string) (*mcfgv1.MachineConfigPool, error) {
+
+	mcp := &mcfgv1.MachineConfigPool{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
+	if err != nil {
+		r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcp, "err", err)
+		return nil, err
+	}
+
+	return mcp, nil
+}
+
 func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv1.MachineConfigPool, ctrl.Result, error, bool) {
 	/* update KataConfig according to occurred error
 	 * We need to pull the status information from the machine config pool object

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	secv1 "github.com/openshift/api/security/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcfgconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	nodeapi "k8s.io/api/node/v1"
@@ -1677,6 +1678,78 @@ func (r *KataConfigOpenShiftReconciler) getMcpByName(mcpName string) (*mcfgv1.Ma
 	}
 
 	return mcp, nil
+}
+
+const (
+	// "Working"
+	NodeWorking = mcfgconsts.MachineConfigDaemonStateWorking
+	// "Done"
+	NodeDone = mcfgconsts.MachineConfigDaemonStateDone
+	// "Degraded"
+	NodeDegraded = mcfgconsts.MachineConfigDaemonStateDegraded
+)
+
+func (r *KataConfigOpenShiftReconciler) processTransitioningNode(node *corev1.Node) error {
+	// Don't bother checking the second return value, the annotation is there
+	// otherwise we wouldn't be here (our caller checked already).
+	mcoNodeState, _ := node.Annotations["machineconfiguration.openshift.io/state"]
+
+	// Transitioning (Working & Degraded) nodes' handling only differs in
+	// which list a node ultimately goes to so we parameterise this.
+	var putOnInstallList, putOnUninstallList func(node *corev1.Node)
+
+	if mcoNodeState == NodeWorking {
+		putOnInstallList = func(node *corev1.Node) {
+			installInProgressList := &r.kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList
+			*installInProgressList = append(*installInProgressList, node.GetName())
+		}
+		putOnUninstallList = func(node *corev1.Node) {
+			uninstallInProgressList := &r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList
+			*uninstallInProgressList = append(*uninstallInProgressList, node.GetName())
+		}
+	} else { // mcoNodeState == NodeDegraded
+		failedNodeStatus := kataconfigurationv1.FailedNodeStatus{
+			Name:  node.GetName(),
+			Error: node.Annotations["machineconfiguration.openshift.io/reason"],
+		}
+		putOnInstallList = func(node *corev1.Node) {
+			installFailedList := &r.kataConfig.Status.InstallationStatus.Failed.FailedNodesList
+			*installFailedList = append(*installFailedList, failedNodeStatus)
+		}
+		putOnUninstallList = func(node *corev1.Node) {
+			uninstallFailedList := &r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesList
+			*uninstallFailedList = append(*uninstallFailedList, failedNodeStatus)
+		}
+	}
+
+	log := r.Log.WithName("updateStatus").WithValues("node name", node.GetName(), "node state", mcoNodeState)
+
+	if corev1.ConditionTrue == r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress {
+		log.Info("putting transitioning node on uninstallation list since we're uninstalling")
+		putOnUninstallList(node)
+		return nil
+	}
+
+	isConvergedCluster, err := r.checkConvergedCluster()
+	if err != nil {
+		return err
+	}
+
+	if isConvergedCluster {
+		log.Info("putting transitioning node on installation list on converged cluster")
+		putOnInstallList(node)
+		return nil
+	}
+
+	_, nodeLabeledForKata := node.Labels["node-role.kubernetes.io/kata-oc"]
+	if nodeLabeledForKata {
+		log.Info("putting transitioning node on installation list since it's labeled")
+		putOnInstallList(node)
+	} else {
+		log.Info("putting transitioning node on uninstallation list since it's not labeled")
+		putOnUninstallList(node)
+	}
+	return nil
 }
 
 func (r *KataConfigOpenShiftReconciler) processDoneNode(node *corev1.Node) error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1679,6 +1679,69 @@ func (r *KataConfigOpenShiftReconciler) getMcpByName(mcpName string) (*mcfgv1.Ma
 	return mcp, nil
 }
 
+func (r *KataConfigOpenShiftReconciler) processDoneNode(node *corev1.Node) error {
+
+	isConvergedCluster, err := r.checkConvergedCluster()
+	if err != nil {
+		return err
+	}
+
+	targetMcpName := func() string {
+		if isConvergedCluster {
+			return "master"
+		}
+		_, nodeLabeledForKata := node.Labels["node-role.kubernetes.io/kata-oc"]
+		if nodeLabeledForKata {
+			return "kata-oc"
+		} else {
+			return "worker"
+		}
+	}()
+
+	targetMcp, err := r.getMcpByName(targetMcpName)
+	if err != nil {
+		return err
+	}
+
+	installCompletedList := &r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesList
+	uninstallCompletedList := &r.kataConfig.Status.UnInstallationStatus.Completed.CompletedNodesList
+
+	currentNodeConfig, ok := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+
+	log := r.Log.WithName("updateStatus").WithValues("node name", node.GetName(), "target pool", targetMcpName, "current config", currentNodeConfig, "target pool config", targetMcp.Spec.Configuration.Name)
+	if ok && currentNodeConfig == targetMcp.Spec.Configuration.Name {
+		// This Node is at its target configuration so it's going to
+		// go to a Completed list, either installation's or uninstallation's.
+		// To decide which we consider:
+		// - if uninstallation is in progress, any settled Node must
+		//   belong to uninstallation's Complete list as no
+		//   installations can take place while uninstalling kata from
+		//   cluster
+		// - OTOH if installation is in progress, settled Nodes will go
+		//   to installation's Completed list by default as expected
+		//   *unless* the Node's target pool is "worker" in which case
+		//   the Node shouldn't and doesn't have kata on it and thus
+		//   belongs to uninstallation's Completed list.
+		if r.kataConfig.Status.InstallationStatus.IsInProgress == corev1.ConditionTrue {
+			if targetMcpName == "worker" {
+				log.Info("putting done node on uninstallation completed list")
+				*uninstallCompletedList = append(*uninstallCompletedList, node.GetName())
+				r.kataConfig.Status.UnInstallationStatus.Completed.CompletedNodesCount = int(targetMcp.Status.UpdatedMachineCount)
+			} else {
+				log.Info("putting done node on installation completed list")
+				*installCompletedList = append(*installCompletedList, node.GetName())
+				r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesCount = int(targetMcp.Status.UpdatedMachineCount)
+			}
+		} else if r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress == corev1.ConditionTrue {
+			log.Info("putting done node on uninstallation completed list")
+			*uninstallCompletedList = append(*uninstallCompletedList, node.GetName())
+			r.kataConfig.Status.UnInstallationStatus.Completed.CompletedNodesCount = int(targetMcp.Status.UpdatedMachineCount)
+		}
+	}
+
+	return nil
+}
+
 func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv1.MachineConfigPool, ctrl.Result, error, bool) {
 	/* update KataConfig according to occurred error
 	 * We need to pull the status information from the machine config pool object


### PR DESCRIPTION
This PR aims to fix KataConfig.status updating to handle installation modifications (adding and removing kata-enabled Nodes) to the extent I believe possible without changing the KataConfig.status structure itself.

Some not so intuitive aspects of the result, apart from names dictated by the current form of KataConfig.status, include:
- *all* Done Nodes will appear on one of the Completed lists, not just the ones affected by the ongoing or most recent operation.  This is because I'm not aware of any way of telling apart Nodes that had arrived in their state earlier as opposed to as a result of the most recent operation.
- Nodes scheduled to change state (=install/uninstall kata) as part of an ongoing operation but still waiting to do so are not listed anywhere since there doesn't seem to be a good place for them in the current KataConfig.status.  They will properly appear though on an InProgress list once they actually start updating and on a Completed list once they finish updating.