### PR TITLE
Allow monitor pods to run on tainted nodes

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -384,6 +384,11 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "monitor",
 					NodeSelector:       nodeSelector,
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-monitor",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

No metrics for sandboxed containers running on a tainted node.

**- What I did**

Allow monitor pods to tolerate all taints.

**- How to verify it**

1. Install OSC.
2. Taint worker nodes.
3. Create KataConfig.
4. Monitor pods should be running on all nodes in the kata-oc MCP.

**- Description for the changelog**

The DaemonSet launched by the controller doesn't put tolerations on the monitor pods. This prevents the monitor pods to run on tainted nodes and break metrics for sandboxed containers.

The monitor pods must run on every node where kata is deployed, no matter any taint the user might have set. Enforce a toleration that matches all possible taints.

Fixes https://issues.redhat.com/browse/KATA-2121