### PR TITLE
New way of showing kata nodes in kataconfig status

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -66,6 +66,9 @@ type KataConfigStatus struct {
 	// +optional
 	Upgradestatus KataUpgradeStatus `json:"upgradeStatus,omitempty"`
 
+	// +optional
+	KataNodes KataNodesStatus `json:"kataNodes,omitempty"`
+
 	// Used internally to persist state between reconciliations
 	// +optional
 	// +kubebuilder:default:=false
@@ -189,4 +192,22 @@ type FailedNodeStatus struct {
 	Name string `json:"name"`
 	// Error message of the failed node reported by the installation daemon
 	Error string `json:"error"`
+}
+
+type KataNodesStatus struct {
+	// +optional
+	Installed []string `json:"installed,omitempty"`
+	// +optional
+	Installing []string `json:"installing,omitempty"`
+	// +optional
+	WaitingToInstall []string `json:"waitingToInstall,omitempty"`
+	// +optional
+	FailedToInstall []string `json:"failedToInstall,omitempty"`
+
+	// +optional
+	Uninstalling []string `json:"uninstalling,omitempty"`
+	// +optional
+	WaitingToUninstall []string `json:"waitingToUninstall,omitempty"`
+	// +optional
+	FailedToUninstall []string `json:"failedToUninstall,omitempty"`
 }

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1983,6 +1983,17 @@ func (r *KataConfigOpenShiftReconciler) putNodeOnStatusList(node *corev1.Node) e
 	return nil
 }
 
+func (r *KataConfigOpenShiftReconciler) clearNodeStatusLists() {
+	r.kataConfig.Status.KataNodes.Installed = nil
+	r.kataConfig.Status.KataNodes.Installing = nil
+	r.kataConfig.Status.KataNodes.WaitingToInstall = nil
+	r.kataConfig.Status.KataNodes.FailedToInstall = nil
+
+	r.kataConfig.Status.KataNodes.Uninstalling = nil
+	r.kataConfig.Status.KataNodes.WaitingToUninstall = nil
+	r.kataConfig.Status.KataNodes.FailedToUninstall = nil
+}
+
 func (r *KataConfigOpenShiftReconciler) clearInstallStatus() {
 	r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesList = nil
 	r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesCount = 0

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -503,6 +503,20 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 	return mcp
 }
 
+func getExtensionName() string {
+	// RHCOS uses "sandboxed-containers" as thats resolved/translated in the machine-config-operator to "kata-containers"
+	// FCOS however does not get any translation in the machine-config-operator so we need to
+	// send in "kata-containers".
+	// Both are later send to rpm-ostree for installation.
+	//
+	// As RHCOS is rather special variant, use "kata-containers" by default, which also applies to FCOS
+	extension := os.Getenv("SANDBOXED_CONTAINERS_EXTENSION")
+	if len(extension) == 0 {
+		extension = "kata-containers"
+	}
+	return extension
+}
+
 func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {
 	r.Log.Info("Creating MachineConfig for Custom Resource")
 
@@ -517,16 +531,7 @@ func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.
 		return nil, err
 	}
 
-	// RHCOS uses "sandboxed-containers" as thats resolved/translated in the machine-config-operator to "kata-containers"
-	// FCOS however does not get any translation in the machine-config-operator so we need to
-	// send in "kata-containers".
-	// Both are later send to rpm-ostree for installation.
-	//
-	// As RHCOS is rather special variant, use "kata-containers" by default, which also applies to FCOS
-	extension := os.Getenv("SANDBOXED_CONTAINERS_EXTENSION")
-	if len(extension) == 0 {
-		extension = "kata-containers"
-	}
+	extension := getExtensionName()
 
 	mc := mcfgv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1957,20 +1957,27 @@ func (r *KataConfigOpenShiftReconciler) putNodeOnStatusList(node *corev1.Node) e
 
 	if isNodeInstalled(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is Installed", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.Installed = append(r.kataConfig.Status.KataNodes.Installed, node.GetName())
 	} else if isNodeNotInstalled(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is NotInstalled", "node", node.GetName())
 	} else if isNodeInstalling(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is Installing", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.Installing = append(r.kataConfig.Status.KataNodes.Installing, node.GetName())
 	} else if isNodeUninstalling(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is Uninstalling", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.Uninstalling = append(r.kataConfig.Status.KataNodes.Uninstalling, node.GetName())
 	} else if isNodeWaitingToInstall(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is WaitingToInstall", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.WaitingToInstall = append(r.kataConfig.Status.KataNodes.WaitingToInstall, node.GetName())
 	} else if isNodeWaitingToUninstall(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is WaitingToUninstall", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.WaitingToUninstall = append(r.kataConfig.Status.KataNodes.WaitingToUninstall, node.GetName())
 	} else if isNodeFailedToInstall(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is FailedToInstall", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.FailedToInstall = append(r.kataConfig.Status.KataNodes.FailedToInstall, node.GetName())
 	} else if isNodeFailedToUninstall(nodeMcoState, nodeCurrMc, nodeTargetMc, isKataEnabledOnNode) {
 		r.Log.Info("node is FailedToUninstall", "node", node.GetName())
+		r.kataConfig.Status.KataNodes.FailedToUninstall = append(r.kataConfig.Status.KataNodes.FailedToUninstall, node.GetName())
 	}
 
 	return nil

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1805,6 +1805,7 @@ func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 
 	r.clearInstallStatus()
 	r.clearUninstallStatus()
+	r.clearNodeStatusLists()
 
 	r.kataConfig.Status.TotalNodesCount = func() int {
 		err, nodes := r.getNodesWithLabels(r.getNodeSelectorAsMap())
@@ -1817,6 +1818,9 @@ func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 
 	for _, node := range nodeList.Items {
 		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
+
+			r.putNodeOnStatusList(&node)
+
 			switch annotation {
 			case NodeDone:
 				e := r.processDoneNode(&node)


### PR DESCRIPTION
This PR adds a new section to `KataConfig.status`  called `kataNodes` which lists cluster nodes grouped by the status of kata installation on them which can be one of installed, installing, waiting to install, failed to install, not installed, uninstalling, waiting to uninstall and failed to uninstall.

By way of example, when applying a KataConfig that selects both nodes of a two-worker cluster, the newly added section might show

```
  kataNodes:
    waitingToInstall:
    - worker-0
    - worker-1
```
for a brief period of time, then something like
```
  kataNodes:
    installing:
    - worker-1
    waitingToInstall:
    - worker-0
```
Once `worker-1` is installed the other worker starts installing
```
  kataNodes:
    installed:
    - worker-1
    installing:
    - worker-0
```
and finally
```
  kataNodes:
    installed:
    - worker-0
    - worker-1
```
The new addition runs alongside the existing status reporting for now.