### PR TITLE
Switch to condition for progress status reporting

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -69,6 +69,9 @@ type KataConfigStatus struct {
 	// +optional
 	KataNodes KataNodesStatus `json:"kataNodes,omitempty"`
 
+	// +optional
+	Conditions []KataConfigCondition `json:"conditions,omitempty"`
+
 	// Used internally to persist state between reconciliations
 	// +optional
 	// +kubebuilder:default:=false
@@ -210,4 +213,18 @@ type KataNodesStatus struct {
 	WaitingToUninstall []string `json:"waitingToUninstall,omitempty"`
 	// +optional
 	FailedToUninstall []string `json:"failedToUninstall,omitempty"`
+}
+
+type KataConfigConditionType string
+
+const (
+	KataConfigInProgress KataConfigConditionType = "InProgress"
+)
+
+type KataConfigCondition struct {
+	Type               KataConfigConditionType `json:"type"`
+	Status             corev1.ConditionStatus  `json:"status"`
+	LastTransitionTime metav1.Time             `json:"lastTransitionTime"`
+	Reason             string                  `json:"reason"`
+	Message            string                  `json:"message"`
 }

--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -198,6 +198,13 @@ type FailedNodeStatus struct {
 }
 
 type KataNodesStatus struct {
+	// Number of cluster nodes that have kata installed on them including
+	// those queued for installation and currently installing, though
+	// excluding nodes that have a kata installation but are queued for
+	// uninstallation or currently uninstalling.
+	// +optional
+	NodeCount int `json:"nodeCount"`
+
 	// +optional
 	Installed []string `json:"installed,omitempty"`
 	// +optional

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1828,6 +1828,8 @@ func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 		return len(nodes.Items)
 	}()
 
+	r.kataConfig.Status.KataNodes.NodeCount = r.kataConfig.Status.TotalNodesCount
+
 	for _, node := range nodeList.Items {
 		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -2016,6 +2016,23 @@ func (r *KataConfigOpenShiftReconciler) clearUninstallStatus() {
 	r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesCount = 0
 }
 
+func (r *KataConfigOpenShiftReconciler) findInProgressCondition() *kataconfigurationv1.KataConfigCondition {
+	for i := 0; i < len(r.kataConfig.Status.Conditions); i++ {
+		if r.kataConfig.Status.Conditions[i].Type == kataconfigurationv1.KataConfigInProgress {
+			return &r.kataConfig.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func (r *KataConfigOpenShiftReconciler) addInProgressCondition() *kataconfigurationv1.KataConfigCondition {
+	r.kataConfig.Status.Conditions = append(r.kataConfig.Status.Conditions, kataconfigurationv1.KataConfigCondition{Type: kataconfigurationv1.KataConfigInProgress})
+
+	r.Log.Info("InProgress Condition added")
+
+	return &r.kataConfig.Status.Conditions[len(r.kataConfig.Status.Conditions)-1]
+}
+
 func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 	var err error = nil
 


### PR DESCRIPTION
This PR adds a conventional Kubernetes Condition type and a Condition array to KataConfig.status.  The only Condition currently supported is InProgress with three possible Reasons - Installing, Updating and Uninstalling.

The final commit doesn't really fit here since it fixes an omission in #329 but I included it anyway since it's a tiny change that probably wouldn't be worth a separate PR IMHO.

With this PR I believe all is set to remove the legacy parts of KataConfig.status.  Anybody depending on them is encouraged to migrate to the new KataConfig.status structure.

As a migration guide, note that
- `installationStatus.IsInProgress == True` should correspond to `InProgress.status == True` and `InProgress.reason` either `Installing` or `Updating`
- `unInstallationStatus.inProgress.status == True` should correspond to `InProgress.status == True` and `InProgress.reason == Uninstalling`
- failure during installation or uninstallation is represented by  `InProgress.status == True` and `InProgress.reason == Failed` with an appropriate `InProgress.message`
- `totalNodesCount` should correspond to `kataNodes.nodeCount`
- installation's completed, inprogress and failed node lists should correspond to `kataNodes.installed`, `kataNodes.installing` and `kataNodes.failedToInstall` lists, respectively
- uninstallation's inprogress and failed node lists should correspond to `kataNodes.uninstalling` and `kataNodes.failedToUninstall` lists, respectively.  There's no equivalent of the completed list since it seems semantically cleaner to focus on kata-enabled nodes and there are no known users of that list to my knowledge.  Any node that is on no list in `kataNodes` is implicitly on a `notInstalled` list.

The planned removal of legacy `KataConfig.status` parts only concerns `installationStatus`, `unInstallationStatus`, `totalNodesCount` and `upgradeStatus` (which was never implemented anyway).  All other parts of `KataConfig.status` are meant to remain in place.