### PR TITLE
Fixes for 1.4.1

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -384,6 +384,11 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.Dae
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "monitor",
 					NodeSelector:       nodeSelector,
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-monitor",


### PR DESCRIPTION
This applies selected fixes from the devel branch to main for the 1.4.1 release :

- 7f004df4303e Allow monitor pods to run on tainted nodes ([KATA-2121](https://issues.redhat.com/browse/KATA-2121))



