### PR TITLE
Bump outdated versions of OSC components

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: 1.3.1
+  newTag: 1.4.0

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.3.0
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.4.0
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,4 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.3.0
+  startingCSV: sandboxed-containers-operator.v1.4.0


### PR DESCRIPTION
Despite 1.4.0 was released about a month ago, there are still some mentions of 1.3.x in the tree :

$ git grep -e '1\.3\.[0123]' -- ':!go.*'
config/manager/kustomization.yaml:  newTag: 1.3.1
config/samples/deploy.yaml: image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.3.0 config/samples/deploy.yaml:  startingCSV: sandboxed-containers-operator.v1.3.0

This is essentially because we don't do automated upstream builds.

Let's bump the versions to latest public release : 1.4.0.

Fixes https://issues.redhat.com/browse/KATA-2245