### PR TITLE
Remove legacy kata config status parts

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -85,9 +85,9 @@ type KataConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=kataconfigs,scope=Cluster
-// +kubebuilder:printcolumn:name="InProgress",type=string,JSONPath=".status.installationStatus.IsInProgress",description="Status of Kata runtime installation"
-// +kubebuilder:printcolumn:name="Completed",type=integer,JSONPath=".status.installationStatus.completed.completedNodesCount",description="Number of nodes with Kata runtime installed"
-// +kubebuilder:printcolumn:name="Total",type=integer,JSONPath=".status.totalNodesCount",description="Total number of nodes"
+// +kubebuilder:printcolumn:name="InProgress",type=string,JSONPath=".status.conditions[?(@.type=='InProgress')].status",description="Status of Kata runtime installation"
+// +kubebuilder:printcolumn:name="Completed",type=integer,JSONPath=".status.kataNodes.readyNodeCount",description="Number of nodes with Kata runtime installed"
+// +kubebuilder:printcolumn:name="Total",type=integer,JSONPath=".status.kataNodes.nodeCount",description="Total number of nodes"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age of the KataConfig Custom Resource"
 type KataConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -205,6 +205,11 @@ type KataNodesStatus struct {
 	// +optional
 	NodeCount int `json:"nodeCount"`
 
+	// Number of cluster nodes that have kata installed on them and are
+	// currently ready to run kata workloads.
+	// +optional
+	ReadyNodeCount int `json:"readyNodeCount"`
+
 	// +optional
 	Installed []string `json:"installed,omitempty"`
 	// +optional

--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -51,21 +51,6 @@ type KataConfigStatus struct {
 	// RuntimeClass is the name of the runtime class used in CRIO configuration
 	RuntimeClass string `json:"runtimeClass"`
 
-	// TotalNodesCounts is the total number of worker nodes targeted by this CR
-	TotalNodesCount int `json:"totalNodesCount"`
-
-	// InstallationStatus reflects the status of the ongoing kata installation
-	// +optional
-	InstallationStatus KataInstallationStatus `json:"installationStatus,omitempty"`
-
-	// UnInstallationStatus reflects the status of the ongoing kata uninstallation
-	// +optional
-	UnInstallationStatus KataUnInstallationStatus `json:"unInstallationStatus,omitempty"`
-
-	// Upgradestatus reflects the status of the ongoing kata upgrade
-	// +optional
-	Upgradestatus KataUpgradeStatus `json:"upgradeStatus,omitempty"`
-
 	// +optional
 	KataNodes KataNodesStatus `json:"kataNodes,omitempty"`
 
@@ -110,91 +95,6 @@ type KataConfigList struct {
 
 func init() {
 	SchemeBuilder.Register(&KataConfig{}, &KataConfigList{})
-}
-
-// KataInstallationStatus reflects the status of the ongoing kata installation
-type KataInstallationStatus struct {
-	// InProgress reflects the status of nodes that are in the process of kata installation
-	InProgress KataInstallationInProgressStatus `json:"inprogress,omitempty"`
-
-	// IsInProgress reflects the current state of installing or not installing
-	IsInProgress corev1.ConditionStatus `json:"IsInProgress,omit"`
-
-	// Completed reflects the status of nodes that have completed kata installation
-	Completed KataConfigCompletedStatus `json:"completed,omitempty"`
-
-	// Failed reflects the status of nodes that have failed kata installation
-	Failed KataFailedNodeStatus `json:"failed,omitempty"`
-}
-
-// KataInstallationInProgressStatus reflects the status of nodes that are in the process of kata installation
-type KataInstallationInProgressStatus struct {
-	// InProgressNodesCount reflects the number of nodes that are in the process of kata installation
-	InProgressNodesCount int `json:"inProgressNodesCount,omitempty"`
-	// IsInProgress reflects if installation is still in progress
-	IsInProgress bool `json:"isInProgress,omitempty"`
-	// +optional
-	BinariesInstalledNodesList []string `json:"binariesInstallNodesList,omitempty"`
-}
-
-// KataConfigCompletedStatus reflects the status of nodes that have completed kata operation
-type KataConfigCompletedStatus struct {
-	// CompletedNodesCount reflects the number of nodes that have completed kata operation
-	CompletedNodesCount int `json:"completedNodesCount,omitempty"`
-
-	// CompletedNodesList reflects the list of nodes that have completed kata operation
-	// +optional
-	CompletedNodesList []string `json:"completedNodesList,omitempty"`
-}
-
-// KataFailedNodeStatus reflects the status of nodes that have failed kata operation
-type KataFailedNodeStatus struct {
-	// FailedNodesCount reflects the number of nodes that have failed kata operation
-	FailedNodesCount int    `json:"failedNodesCount,omitempty"`
-	FailedReason     string `json:"failedNodesReason,omitempty"`
-
-	// FailedNodesList reflects the list of nodes that have failed kata operation
-	// +optional
-	FailedNodesList []FailedNodeStatus `json:"failedNodesList,omitempty"`
-}
-
-// KataUnInstallationStatus reflects the status of the ongoing kata uninstallation
-type KataUnInstallationStatus struct {
-	// InProgress reflects the status of nodes that are in the process of kata uninstallation
-	InProgress KataUnInstallationInProgressStatus `json:"inProgress,omitempty"`
-
-	// Completed reflects the status of nodes that have completed kata uninstallation
-	Completed KataConfigCompletedStatus `json:"completed,omitempty"`
-
-	// Failed reflects the status of nodes that have failed kata uninstallation
-	Failed KataFailedNodeStatus `json:"failed,omitempty"`
-
-	// Stores an error message if any.  Note that this is currently meant for a single
-	// failure source when kata uninstallation is blocked by existing kata-based pods, so
-	// handling of this field in the controller code is correspondingly simple.  A review
-	// might be necessary if this field were ever to store messages coming from another
-	// source.
-	ErrorMessage string `json:"errorMessage,omitempty"`
-}
-
-// KataUnInstallationInProgressStatus reflects the status of nodes that are in the process of kata installation
-type KataUnInstallationInProgressStatus struct {
-	InProgressNodesCount int                    `json:"inProgressNodesCount,omitempty"`
-	IsInProgress         corev1.ConditionStatus `json:"status"`
-	// +optional
-	BinariesUnInstalledNodesList []string `json:"binariesUninstallNodesList,omitempty"`
-}
-
-// KataUpgradeStatus reflects the status of the ongoing kata upgrade
-type KataUpgradeStatus struct {
-}
-
-// FailedNodeStatus holds the name and the error message of the failed node
-type FailedNodeStatus struct {
-	// Name of the failed node
-	Name string `json:"name"`
-	// Error message of the failed node reported by the installation daemon
-	Error string `json:"error"`
 }
 
 type KataNodesStatus struct {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1853,6 +1853,9 @@ func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 			}
 		}
 	}
+
+	r.kataConfig.Status.KataNodes.ReadyNodeCount = len(r.kataConfig.Status.KataNodes.Installed)
+
 	return err
 }
 


### PR DESCRIPTION
This PR removes parts of `KataConfig.status` obsoleted by #330 (and #329 before it), `totalNodesCount`, `installationStatus`, `unInstallationStatus` (and the stub of `upgradeStatus`).