### PR TITLE
Fix kataconfig status handling to support installation updates (port to main)

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1672,6 +1672,18 @@ func (r *KataConfigOpenShiftReconciler) getConditionReason(conditions []mcfgv1.M
 	return ""
 }
 
+func (r *KataConfigOpenShiftReconciler) getMcpByName(mcpName string) (*mcfgv1.MachineConfigPool, error) {
+
+	mcp := &mcfgv1.MachineConfigPool{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
+	if err != nil {
+		r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcp, "err", err)
+		return nil, err
+	}
+
+	return mcp, nil
+}
+
 func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv1.MachineConfigPool, ctrl.Result, error, bool) {
 	/* update KataConfig according to occurred error
 	 * We need to pull the status information from the machine config pool object

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1820,6 +1820,55 @@ func (r *KataConfigOpenShiftReconciler) processDoneNode(node *corev1.Node) error
 	return nil
 }
 
+// If multiple errors occur during execution of this function the last one
+// will be returned.
+func (r *KataConfigOpenShiftReconciler) updateStatusNew() error {
+
+	if r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress != corev1.ConditionTrue &&
+		r.kataConfig.Status.InstallationStatus.IsInProgress != corev1.ConditionTrue {
+		return nil
+	}
+
+	err, nodeList := r.getNodes()
+	if err != nil {
+		return err
+	}
+
+	r.clearInstallStatus()
+	r.clearUninstallStatus()
+
+	r.kataConfig.Status.TotalNodesCount = func() int {
+		err, nodes := r.getNodesWithLabels(r.getNodeSelectorAsMap())
+		if err != nil {
+			r.Log.Info("Error retrieving kata-oc labelled Nodes to count them", "err", err)
+			return 0
+		}
+		return len(nodes.Items)
+	}()
+
+	for _, node := range nodeList.Items {
+		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
+			switch annotation {
+			case NodeDone:
+				e := r.processDoneNode(&node)
+				if e != nil {
+					err = e
+				}
+			case NodeDegraded:
+			case NodeWorking:
+				e := r.processTransitioningNode(&node)
+				if e != nil {
+					err = e
+				}
+			default:
+				err = fmt.Errorf("Unexpected machineconfiguration.openshift.io/state: %v ", annotation)
+				r.Log.Info("Unexpected machineconfiguration.openshift.io/state", "node", node.GetName(), "state", annotation)
+			}
+		}
+	}
+	return err
+}
+
 func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv1.MachineConfigPool, ctrl.Result, error, bool) {
 	/* update KataConfig according to occurred error
 	 * We need to pull the status information from the machine config pool object

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -943,10 +943,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		r.kataConfig.Status.WaitingForMcoToStart = false
 	}
 
-	r.clearUninstallStatus()
-	_, result, err2, done := r.updateStatus(machinePool)
-	if !done {
-		return result, err2
+	err = r.updateStatusNew()
+	if err != nil {
+		r.Log.Info("Error updating KataConfig.status", "err", err)
 	}
 
 	if isMcoUpdating {
@@ -1149,12 +1148,10 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.kataConfig.Status.WaitingForMcoToStart = false
 	}
 
-	foundMcp, doReconcile, err, done := r.updateStatus(machinePool)
-	if !done {
-		return doReconcile, err
+	err = r.updateStatusNew()
+	if err != nil {
+		r.Log.Info("Error updating KataConfig.status", "err", err)
 	}
-
-	r.kataConfig.Status.TotalNodesCount = int(foundMcp.Status.MachineCount)
 
 	if !isMcoUpdating {
 		r.Log.Info("create runtime class")
@@ -1869,178 +1866,6 @@ func (r *KataConfigOpenShiftReconciler) updateStatusNew() error {
 	return err
 }
 
-func (r *KataConfigOpenShiftReconciler) updateStatus(machinePool string) (*mcfgv1.MachineConfigPool, ctrl.Result, error, bool) {
-	/* update KataConfig according to occurred error
-	 * We need to pull the status information from the machine config pool object
-	 */
-	foundMcp := &mcfgv1.MachineConfigPool{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
-	if err != nil && k8serrors.IsNotFound(err) {
-		r.Log.Error(err, "Unable to get MachineConfigPool ", "machinePool", machinePool)
-		return nil, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil, true
-	}
-
-	/* installation status */
-	if corev1.ConditionTrue == r.kataConfig.Status.InstallationStatus.IsInProgress {
-		err, _ := r.updateInstallStatus()
-		if err != nil {
-			return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
-		}
-		if foundMcp.Status.DegradedMachineCount > 0 || mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions,
-			mcfgv1.MachineConfigPoolDegraded) {
-			err, r.kataConfig.Status.InstallationStatus.Failed = r.updateFailedStatus(r.kataConfig.Status.InstallationStatus.Failed)
-			if err != nil {
-				return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
-			}
-		}
-	}
-
-	/* uninstallation status */
-	if corev1.ConditionTrue == r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress {
-		err, _ := r.updateUninstallStatus()
-		if err != nil {
-			return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
-		}
-		if foundMcp.Status.DegradedMachineCount > 0 || mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions,
-			mcfgv1.MachineConfigPoolDegraded) {
-			err, r.kataConfig.Status.UnInstallationStatus.Failed = r.updateFailedStatus(r.kataConfig.Status.UnInstallationStatus.Failed)
-			if err != nil {
-				return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err, false
-			}
-		}
-	}
-
-	return foundMcp, reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil, true
-}
-
-func (r *KataConfigOpenShiftReconciler) updateUninstallStatus() (error, bool) {
-	var err error
-	err, nodeList := r.getNodes()
-	if err != nil {
-		return err, false
-	}
-
-	r.clearUninstallStatus()
-
-	for _, node := range nodeList.Items {
-		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
-			switch annotation {
-			case "Done":
-				err, r.kataConfig.Status.UnInstallationStatus.Completed =
-					r.updateCompletedNodes(&node, r.kataConfig.Status.UnInstallationStatus.Completed)
-			case "Degraded":
-				err, r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesList =
-					r.updateFailedNodes(&node, r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesList)
-			case "Working":
-				err, r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList =
-					r.updateInProgressNodes(&node, r.kataConfig.Status.UnInstallationStatus.InProgress.BinariesUnInstalledNodesList)
-			default:
-				err = fmt.Errorf("Invalid machineconfig state: %v ", annotation)
-				r.Log.Error(err, "Error updating Uninstall status")
-			}
-		}
-	}
-	return err, true
-}
-
-func (r *KataConfigOpenShiftReconciler) updateInProgressNodes(node *corev1.Node, inProgressList []string) (error, []string) {
-	foundMcp, err := r.getMcp()
-	if err != nil {
-		return err, inProgressList
-	}
-	if mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating) {
-		inProgressList = append(inProgressList, node.GetName())
-	}
-
-	return nil, inProgressList
-}
-
-func (r *KataConfigOpenShiftReconciler) updateCompletedNodes(node *corev1.Node, completedStatus kataconfigurationv1.KataConfigCompletedStatus) (error, kataconfigurationv1.KataConfigCompletedStatus) {
-	foundMcp, err := r.getMcp()
-	if err != nil {
-		return err, completedStatus
-	}
-	currentNodeConfig, ok := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
-	if ok && foundMcp.Spec.Configuration.Name == currentNodeConfig &&
-		(r.kataConfig.Status.InstallationStatus.IsInProgress == corev1.ConditionTrue ||
-			r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress == corev1.ConditionTrue) {
-
-		completedStatus.CompletedNodesList = append(completedStatus.CompletedNodesList, node.GetName())
-		completedStatus.CompletedNodesCount = int(foundMcp.Status.UpdatedMachineCount)
-	}
-
-	return nil, completedStatus
-}
-
-func (r *KataConfigOpenShiftReconciler) updateFailedNodes(node *corev1.Node,
-	failedList []kataconfigurationv1.FailedNodeStatus) (error, []kataconfigurationv1.FailedNodeStatus) {
-
-	foundMcp, err := r.getMcp()
-	if err != nil {
-		return err, failedList
-	}
-	if mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolNodeDegraded) ||
-		mcfgv1.IsMachineConfigPoolConditionTrue(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolDegraded) {
-		failedList =
-			append(r.kataConfig.Status.InstallationStatus.Failed.FailedNodesList,
-				kataconfigurationv1.FailedNodeStatus{Name: node.GetName(),
-					Error: node.Annotations["machineconfiguration.openshift.io/reason"]})
-	}
-
-	return nil, failedList
-}
-
-func (r *KataConfigOpenShiftReconciler) updateInstallStatus() (error, bool) {
-	var err error
-	err, nodeList := r.getNodes()
-	if err != nil {
-		return err, false
-	}
-
-	r.clearInstallStatus()
-
-	for _, node := range nodeList.Items {
-		if annotation, ok := node.Annotations["machineconfiguration.openshift.io/state"]; ok {
-			switch annotation {
-			case "Done":
-				err, r.kataConfig.Status.InstallationStatus.Completed =
-					r.updateCompletedNodes(&node, r.kataConfig.Status.InstallationStatus.Completed)
-			case "Degraded":
-				err, r.kataConfig.Status.InstallationStatus.Failed.FailedNodesList =
-					r.updateFailedNodes(&node, r.kataConfig.Status.InstallationStatus.Failed.FailedNodesList)
-			case "Working":
-				err, r.kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList =
-					r.updateInProgressNodes(&node, r.kataConfig.Status.InstallationStatus.InProgress.BinariesInstalledNodesList)
-			default:
-				err = fmt.Errorf("Invalid machineconfig state: %v ", annotation)
-				r.Log.Error(err, "Error updating Install status")
-			}
-		}
-	}
-	return err, true
-}
-
-func (r *KataConfigOpenShiftReconciler) updateFailedStatus(status kataconfigurationv1.KataFailedNodeStatus) (error, kataconfigurationv1.KataFailedNodeStatus) {
-	foundMcp, err := r.getMcp()
-	if err != nil {
-		r.Log.Error(err, "couldn't get MachineConfigPool information")
-		return err, status
-	}
-
-	status = r.clearFailedStatus(status)
-
-	if foundMcp.Status.DegradedMachineCount > 0 {
-		status.FailedReason = r.getConditionReason(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolNodeDegraded)
-		return nil, status
-	} else if mcfgv1.IsMachineConfigPoolConditionPresentAndEqual(foundMcp.Status.Conditions,
-		mcfgv1.MachineConfigPoolDegraded, corev1.ConditionTrue) {
-		status.FailedReason = r.getConditionReason(foundMcp.Status.Conditions, mcfgv1.MachineConfigPoolDegraded)
-		return nil, status
-	}
-
-	return err, status
-}
-
 func (r *KataConfigOpenShiftReconciler) clearInstallStatus() {
 	r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesList = nil
 	r.kataConfig.Status.InstallationStatus.Completed.CompletedNodesCount = 0
@@ -2057,14 +1882,6 @@ func (r *KataConfigOpenShiftReconciler) clearUninstallStatus() {
 	r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesList = nil
 	r.kataConfig.Status.UnInstallationStatus.Failed.FailedReason = ""
 	r.kataConfig.Status.UnInstallationStatus.Failed.FailedNodesCount = 0
-}
-
-func (r *KataConfigOpenShiftReconciler) clearFailedStatus(status kataconfigurationv1.KataFailedNodeStatus) kataconfigurationv1.KataFailedNodeStatus {
-	status.FailedNodesList = nil
-	status.FailedReason = ""
-	status.FailedNodesCount = 0
-
-	return status
 }
 
 func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -656,23 +656,6 @@ func (r *KataConfigOpenShiftReconciler) checkNodeEligibility() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) getMcpNameIfMcpExists() (string, error) {
-	r.Log.Info("Getting MachineConfigPool Name")
-
-	kataOC, err := r.kataOcExists()
-	if kataOC && err == nil {
-		r.Log.Info("kata-oc MachineConfigPool exists")
-		return "kata-oc", nil
-	}
-	isConvergedCluster, err := r.checkConvergedCluster()
-	if err == nil && isConvergedCluster {
-		r.Log.Info("Converged Cluster. Not creating kata-oc MCP")
-		return "master", nil
-	}
-	r.Log.Info("No valid MCP found")
-	return "", err
-}
-
 func (r *KataConfigOpenShiftReconciler) getMcpName() (string, error) {
 	isConvergedCluster, err := r.checkConvergedCluster()
 	if err != nil {
@@ -943,7 +926,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		r.kataConfig.Status.WaitingForMcoToStart = false
 	}
 
-	err = r.updateStatusNew()
+	err = r.updateStatus()
 	if err != nil {
 		r.Log.Info("Error updating KataConfig.status", "err", err)
 	}
@@ -1148,7 +1131,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.kataConfig.Status.WaitingForMcoToStart = false
 	}
 
-	err = r.updateStatusNew()
+	err = r.updateStatus()
 	if err != nil {
 		r.Log.Info("Error updating KataConfig.status", "err", err)
 	}
@@ -1543,22 +1526,6 @@ func (r *KataConfigOpenShiftReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Complete(r)
 }
 
-func (r *KataConfigOpenShiftReconciler) getMcp() (*mcfgv1.MachineConfigPool, error) {
-	machinePool, err := r.getMcpNameIfMcpExists()
-	if err != nil {
-		return nil, err
-	}
-
-	foundMcp := &mcfgv1.MachineConfigPool{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, foundMcp)
-	if err != nil {
-		r.Log.Error(err, "Getting MachineConfigPool failed ", "machinePool", machinePool)
-		return nil, err
-	}
-
-	return foundMcp, nil
-}
-
 func (r *KataConfigOpenShiftReconciler) getNodes() (error, *corev1.NodeList) {
 	nodes := &corev1.NodeList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{"node-role.kubernetes.io/worker": ""})
@@ -1819,7 +1786,7 @@ func (r *KataConfigOpenShiftReconciler) processDoneNode(node *corev1.Node) error
 
 // If multiple errors occur during execution of this function the last one
 // will be returned.
-func (r *KataConfigOpenShiftReconciler) updateStatusNew() error {
+func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 
 	if r.kataConfig.Status.UnInstallationStatus.InProgress.IsInProgress != corev1.ConditionTrue &&
 		r.kataConfig.Status.InstallationStatus.IsInProgress != corev1.ConditionTrue {


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

When you try to delete kataconfig while a workload is running, you will get an error that kataconfig cannot be deleted while it is running a workload.

You should be able to delete the workload and kataconfig will remove the status and will proceed to delete kataconfig.  This is the previous 1.3.3 behavior.

Fixes: https://issues.redhat.com/browse/KATA-2240

**- What I did**

Cherry-picked all patches from #327 

**- How to verify it**

1. build OSC from this PR
2. deploy it on OCP 4.13.x
3. create kataconfig with  enablePeerPods: false
4. create a sandboxed pod workload
6. delete kataconfig
7. see the expected `Existing pods using Kata Runtime found. Please delete the pods manually for KataConfig deletion to proceed` error in the kataconfig's yaml status
8. delete the sandboxed pod workload
9. kataconfig should be deleted

