### PR TITLE
Use raw Azure base image for peer-pods

### DIFF
--- a/hack/azure-image-job.yaml
+++ b/hack/azure-image-job.yaml
@@ -42,9 +42,9 @@ spec:
           - name: PUBLISHER
             value: "RedHat"
           - name: OFFER
-            value: "RHEL"
+            value: "rhel-raw"
           - name: SKU
-            value: "9-lvm"
+            value: "9_2"
         envFrom:
         - secretRef:
             name: peer-pods-secret


### PR DESCRIPTION
The LVM based image results in limited free space for the root filesystem. This creates issues when using peer-pods for container builds. Switching to raw images provides flexibility w.r.to root filesystem storage

Fixes: [KATA-2362](https://issues.redhat.com//browse/KATA-2362)

