### PR TITLE
podvm: run image jobs from the controller automatically

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
         - name: SANDBOXED_CONTAINERS_EXTENSION
           value: kata-containers
         - name: RELATED_IMAGE_CAA
-          value: quay.io/confidential-containers/cloud-api-adaptor
+          value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:latest
         - name: RELATED_IMAGE_PEERPODS_WEBHOOK
           value: "quay.io/confidential-containers/peer-pods-webhook:latest" 
         imagePullPolicy: Always

--- a/config/peerpods/podvm/aws-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-create-job.yaml
@@ -1,0 +1,107 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aws-image-creation
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      name: aws-image-creation
+    spec:
+      volumes:
+      - name: shared-data
+        emptyDir: {}
+        volumes:
+      - name: image-id
+        emptyDir: {}
+
+      initContainers:
+      - name: payload
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: shared-data
+          mountPath: /payload
+        command: ["/bin/sh"]
+        args: ["-c", "cp /podvm-binaries.tar.gz /payload/"]
+
+      restartPolicy: Never
+      containers:
+      - name: create
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        securityContext:
+          runAsUser: 0 # needed for container mode dnf access
+        volumeMounts:
+        - name: shared-data
+          mountPath: /payload
+        - name: image-id
+          mountPath: /output
+        env:
+          - name: PODVM_DISTRO
+            value: rhel
+          - name: IMAGE_NAME
+            value: "peer-pod-ami"
+#          - name: INSTANCE_TYPE
+#            value: "t3.small" # default is t3.small, uncomment and modify if not available in your region
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          dnf install -y make git unzip
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          curl https://releases.hashicorp.com/packer/1.9.4/packer_1.9.4_linux_amd64.zip -o packer_1.9.4_linux_amd64.zip
+          echo "6cd5269c4245aa8c99e551d1b862460d63fe711c58bec618fade25f8492e80d9  packer_1.9.4_linux_amd64.zip" | sha256sum -c
+          unzip packer_1.9.4_linux_amd64.zip -d /usr/bin/
+          PATH="/usr/bin:${PATH}"
+          packer plugins install github.com/hashicorp/amazon
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_linux_amd64 -o /usr/bin/yq
+          echo "8afd786b3b8ba8053409c5e7d154403e2d4ed4cf3e93c237462dc9ef75f38c8d /usr/bin/yq" | sha256sum -c
+          chmod +x /usr/bin/yq
+          git clone https://github.com/confidential-containers/cloud-api-adaptor.git && (cd cloud-api-adaptor && git checkout 90ccfc3fa0ee56c2fc61b23ecf3731f819faf875)
+          [ "$BOOT_FIPS" == "true" ] && sed -i '/exit 0/ifips-mode-setup --enable' cloud-api-adaptor/aws/image/misc-settings.sh
+          tar xvf /payload/podvm-binaries.tar.gz -C cloud-api-adaptor/podvm/files
+          mkdir cloud-api-adaptor/podvm/files/pause_bundle # workaround to avoid pause image requirement
+          [[ ! "${VPC_ID}" ]] && [[ "${AWS_VPC_ID}" ]] && export VPC_ID=${AWS_VPC_ID}
+          [[ ! "${SUBNET_ID}" ]] && [[ "${AWS_SUBNET_ID}" ]] && export SUBNET_ID=${AWS_SUBNET_ID}
+          export MAC=$(curl -m 3 -s http://169.254.169.254/latest/meta-data/mac)
+          [[ ! "${AWS_REGION}" ]] && export AWS_REGION=$(curl -m 30 -s --show-error http://169.254.169.254/latest/meta-data/placement/region)
+          [[ ! "${AWS_REGION}" ]] && echo "AWS_REGION is missing" && exit 1
+          [[ ! "${VPC_ID}" ]] && export VPC_ID=$(curl -m 30 -s --show-error http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC}/vpc-id)
+          [[ ! "${VPC_ID}" ]] && echo "VPC_ID is missing" && exit 1
+          [[ ! "${SUBNET_ID}" ]] && export SUBNET_ID=$(curl -m 30 -s --show-error http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC}/subnet-id)
+          [[ ! "${SUBNET_ID}" ]] && echo "SUBNET_ID is missing" && exit 1
+          cd cloud-api-adaptor/aws/image
+          LIBC=gnu make BINARIES= PAUSE_BUNDLE= image && \
+          PODVM_AMI_ID=$(aws ec2 describe-images --query "Images[*].[ImageId]" --filters "Name=name,Values=${IMAGE_NAME}" --region ${AWS_REGION} --output text) && \
+          echo "PODVM_AMI_ID: \"$PODVM_AMI_ID\"" && \
+          echo ${PODVM_AMI_ID} > /output/image-id
+
+      - name: result
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        volumeMounts:
+        - name: image-id
+          mountPath: /output
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while  [ ! -f /output/image-id  ]; do sleep 5; done
+          cat /output/image-id

--- a/config/peerpods/podvm/aws-VM-image-delete-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-delete-job.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aws-image-deletion
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      name: aws-image-deletion
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: aws-image-deletion
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        securityContext:
+          runAsUser: 0 # needed for container mode dnf access
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        env:
+          - name: PODVM_DISTRO
+            value: rhel
+          - name: IMAGE_NAME
+            value: "peer-pod-ami"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          dnf install -y unzip
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          PATH="/usr/bin:${PATH}"
+          export MAC=$(curl -m 3 -s http://169.254.169.254/latest/meta-data/mac)
+          [[ ! "${AWS_REGION}" ]] && export AWS_REGION=$(curl -m 30 -s --show-error http://169.254.169.254/latest/meta-data/placement/region)
+          [[ ! "${AWS_REGION}" ]] && echo "AWS_REGION is missing" && exit 1
+          export IMAGE_NAME=${IMAGE_NAME:-peer-pod-ami}
+          PODVM_AMI_ID=$(aws ec2 describe-images --query "Images[*].[ImageId]" --filters "Name=name,Values=${IMAGE_NAME}" --region ${AWS_REGION} --output text) && \
+          echo "Deleting AMI: ${PODVM_AMI_ID}"
+          aws ec2 deregister-image --image-id ${PODVM_AMI_ID} --region ${AWS_REGION}
+          echo "Deleting AMI: ${PODVM_AMI_ID} - DONE"

--- a/config/peerpods/podvm/azure-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-create-job.yaml
@@ -1,0 +1,125 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: azure-image-creation
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      name: azure-image-creation
+    spec:
+      volumes:
+      - name: shared-data
+        emptyDir: {}
+      - name: image-id
+        emptyDir: {}
+
+      initContainers:
+      - name: payload
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: shared-data
+          mountPath: /payload
+        command: ["/bin/sh"]
+        args: ["-c", "cp /podvm-binaries.tar.gz /payload/"]
+
+      containers:
+      - name: create
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        securityContext:
+          runAsUser: 0 # needed for container mode dnf access
+        volumeMounts:
+        - name: shared-data
+          mountPath: /payload
+        - name: image-id
+          mountPath: /output
+        env:
+#          - name: VM_SIZE
+#            value: "Standard_A2_v2"
+          - name: PODVM_DISTRO
+            value: rhel
+          - name: PUBLISHER
+            value: "RedHat"
+          - name: OFFER
+            value: "rhel-raw"
+          - name: SKU
+            value: "9_2"
+          - name: IMAGE_NAME
+            value: "peer-pod-vmimage"
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          rpm --import https://packages.microsoft.com/keys/microsoft.asc
+          dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+          dnf install -y make git azure-cli unzip
+          curl https://releases.hashicorp.com/packer/1.9.4/packer_1.9.4_linux_amd64.zip -o packer_1.9.4_linux_amd64.zip
+          echo "6cd5269c4245aa8c99e551d1b862460d63fe711c58bec618fade25f8492e80d9  packer_1.9.4_linux_amd64.zip" | sha256sum -c
+          unzip packer_1.9.4_linux_amd64.zip -d /usr/bin/
+          PATH="/usr/bin:${PATH}"
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_linux_amd64 -o /usr/bin/yq # TODO: remove?
+          echo "8afd786b3b8ba8053409c5e7d154403e2d4ed4cf3e93c237462dc9ef75f38c8d /usr/bin/yq" | sha256sum -c
+          chmod +x /usr/bin/yq
+          git clone https://github.com/confidential-containers/cloud-api-adaptor.git && (cd cloud-api-adaptor && git checkout 90ccfc3fa0ee56c2fc61b23ecf3731f819faf875)
+          [ "$BOOT_FIPS" == "true" ] && sed -i '/exit 0/ifips-mode-setup --enable' cloud-api-adaptor/azure/image/misc-settings.sh
+          tar xvf /payload/podvm-binaries.tar.gz -C cloud-api-adaptor/podvm/files
+          mkdir cloud-api-adaptor/podvm/files/pause_bundle # workaround to avoid pause image requirement
+          [[ ! "${AZURE_REGION}" ]] && echo "AZURE_REGION is missing" && exit 1
+          [[ ! "${AZURE_TENANT_ID}" ]] && echo "AZURE_TENANT_ID is missing" && exit 1
+          [[ ! "${AZURE_RESOURCE_GROUP}" ]] && echo "AZURE_RESOURCE_GROUP is missing" && exit 1
+          [[ ! "${AZURE_SUBSCRIPTION_ID}" ]] && echo "AZURE_SUBSCRIPTION_ID is missing" && exit 1
+          [[ ! "${AZURE_CLIENT_SECRET}" ]] && echo "AZURE_CLIENT_SECRET is missing" && exit 1
+          [[ ! "${AZURE_CLIENT_ID}" ]] && echo "AZURE_CLIENT_ID is missing" && exit 1
+          export PKR_VAR_client_id=${AZURE_CLIENT_ID}
+          export PKR_VAR_client_secret=${AZURE_CLIENT_SECRET}
+          export PKR_VAR_subscription_id=${AZURE_SUBSCRIPTION_ID}
+          export PKR_VAR_tenant_id=${AZURE_TENANT_ID}
+          export PKR_VAR_resource_group=${AZURE_RESOURCE_GROUP}
+          export PKR_VAR_location=${AZURE_LOCATION}
+          export PKR_VAR_az_image_name=${IMAGE_NAME}
+          export PKR_VAR_vm_size=${VM_SIZE:-Standard_A2_v2}
+          export PKR_VAR_ssh_username=${SSH_USERNAME:-peerpod}
+          export PKR_VAR_publisher=${PUBLISHER}
+          export PKR_VAR_offer=${OFFER}
+          export PKR_VAR_sku=${SKU}
+          export PKR_VAR_plan_name=${PLAN_NAME}
+          export PKR_VAR_plan_product=${PLAN_PRODUCT}
+          export PKR_VAR_plan_publisher=${PLAN_PUBLISHER}
+          cd cloud-api-adaptor/azure/image
+          packer init ${PODVM_DISTRO}/
+          make BINARIES= PAUSE_BUNDLE= image && \
+          az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" && \
+          AZURE_IMAGE_ID=$(az image list --resource-group ${AZURE_RESOURCE_GROUP} --query "[].{Id: id} | [? contains(Id, '${IMAGE_NAME}')]" --output tsv) && \
+          echo ${AZURE_IMAGE_ID} >> /output/image-id
+          echo "DONE: ${AZURE_IMAGE_ID}"
+
+      - name: result
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        volumeMounts:
+        - name: image-id
+          mountPath: /output
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while  [ ! -f /output/image-id  ]; do sleep 5; done
+          cat /output/image-id
+
+      restartPolicy: Never

--- a/config/peerpods/podvm/azure-VM-image-delete-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-delete-job.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: azure-image-deletion
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      name: azure-image-deletion
+    spec:
+      containers:
+      - name: delete
+        image: registry.access.redhat.com/ubi9/ubi:9.2
+        securityContext:
+          runAsUser: 0 # needed for container mode dnf access
+        env:
+          - name: IMAGE_NAME
+            value: "peer-pod-vmimage"
+        envFrom:
+        - secretRef:
+            name: peer-pods-secret
+        - configMapRef:
+            name: peer-pods-cm
+            optional: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          rpm --import https://packages.microsoft.com/keys/microsoft.asc
+          dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+          yum install -y azure-cli
+          PATH="/usr/bin:${PATH}"
+          [[ ! "${AZURE_REGION}" ]] && echo "AZURE_REGION is missing" && exit 1
+          [[ ! "${AZURE_TENANT_ID}" ]] && echo "AZURE_TENANT_ID is missing" && exit 1
+          [[ ! "${AZURE_RESOURCE_GROUP}" ]] && echo "AZURE_RESOURCE_GROUP is missing" && exit 1
+          [[ ! "${AZURE_SUBSCRIPTION_ID}" ]] && echo "AZURE_SUBSCRIPTION_ID is missing" && exit 1
+          [[ ! "${AZURE_CLIENT_SECRET}" ]] && echo "AZURE_CLIENT_SECRET is missing" && exit 1
+          [[ ! "${AZURE_CLIENT_ID}" ]] && echo "AZURE_CLIENT_ID is missing" && exit 1
+          az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" && \
+          az image delete --image-name "${IMAGE_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" && \
+          echo "DONE"
+      restartPolicy: Never

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -1,0 +1,407 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+The image generator builds and deletes pod VM images for a cloud provider. It uses Kubernetes jobs to do this.
+Make sure
+Ensure that all job YAML files meet the following guidelines:
+1. Job files should be located at config/peerpods/
+2. all file names must follow this format: <cloud-provider>-[CVM|VM]-image-[create|delete]-job.yaml
+3. parallelism: 1
+4. completions: 1 (or none)
+5. backoffLimit: 1
+6. restartPolicy: Never
+7. job and pod names describes cloud-provider and operation
+8. Get configuration values from peer-pods-secret and peer-pods-cm volumes and predefined enviroment variables
+9. make sure create/delete jobs are based on the same configuration sources
+10. utilize precreated podvm binaries conatiner if possible
+11. all jobs must abort on image creation failure
+
+Every image creation job must obey to the following guidelines:
+1. create the podvm image and all other required cloud resouces needed for it
+2. Create a container named result that outputs the image ID (and nothing but the image ID) once the image is ready.
+3. image ID can be shared between containers using emptyDir volume
+
+Every image deletion job should preform the following:
+1. based on the exect same configurtion creation job is using
+2. deletes the image and all created resouces
+*/
+
+const (
+	peerpodsCMName          = "peer-pods-cm"
+	peerpodsCMAWSImageKey   = "PODVM_AMI_ID"
+	peerpodsCMAzureImageKey = "AZURE_IMAGE_ID"
+	fipsCMKey               = "BOOT_FIPS"
+	defaultVMType           = "VM"
+)
+
+type ImageGenerator struct {
+	client    client.Client        // controller-runtime client
+	clientset kubernetes.Interface // k8s clientset
+
+	provider     string
+	CMimageIDKey string
+	fips         bool
+}
+
+var ig *ImageGenerator = nil
+var igLogger logr.Logger = ctrl.Log.WithName("image-generator")
+
+// ImageCreate creates a podvm image for a cloud provider if not present
+func ImageCreate(c client.Client) (bool, ctrl.Result) {
+	if ig == nil { // initialize ImageGenerator if not exsits
+		var err error
+		ig, err = newImageGenerator(c)
+		if err != nil || ig == nil {
+			igLogger.Info("error initializing ImageGenerator instance", "err", err)
+			return false, ctrl.Result{Requeue: true}
+		}
+	}
+	return ig.imageJobRunner("create")
+}
+
+// ImageDelete deletes a podvm image for a cloud provider if present
+func ImageDelete(c client.Client) (bool, ctrl.Result) {
+	if ig == nil { // initialize ImageGenerator if not exsits
+		var err error
+		ig, err = newImageGenerator(c)
+		if err != nil || ig == nil {
+			igLogger.Info("error initializing ImageGenerator instance", "err", err)
+			return false, ctrl.Result{Requeue: true}
+		}
+	}
+	return ig.imageJobRunner("delete")
+}
+
+func newImageGenerator(client client.Client) (*ImageGenerator, error) {
+	var ig ImageGenerator
+	var procFIPS = "/proc/sys/crypto/fips_enabled"
+
+	ig.client = client
+	ig.provider = ""     // set by setupCloudProvider
+	ig.CMimageIDKey = "" // set by setupCloudProvider
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get in-cluster config: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s clientset: %v", err)
+	}
+	ig.clientset = clientset
+
+	content, err := os.ReadFile(procFIPS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read FIPS file: %v", err)
+	}
+
+	fips, err := strconv.Atoi(strings.Trim(string(content), "\n\t "))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert FIPS file content to int: %v", err)
+	}
+	ig.fips = fips == 1
+
+	igLogger.Info("ImageGenerator instance has been initialized successfully", "fips", ig.fips)
+	return &ig, nil
+}
+
+func (r *ImageGenerator) getCloudProviderFromInfra() string {
+	// TODO: first check if it's indeed openshift
+	infrastructure := &configv1.Infrastructure{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infrastructure)
+	if err != nil {
+		igLogger.Info("getCloudProviderInfra: Error getting Infrastructure object", "err", err)
+		return ""
+	}
+
+	if infrastructure.Status.PlatformStatus == nil {
+		igLogger.Info("getCloudProviderInfra: Infrastructure.status.platformStatus is empty")
+		return ""
+	}
+
+	igLogger.Info("Got cloud provider from infrastructure object")
+	return strings.ToLower(string(infrastructure.Status.PlatformStatus.Type))
+}
+
+func (r *ImageGenerator) setupCloudProvider(cm *corev1.ConfigMap) error {
+	var provider string
+	if r.provider != "" && r.CMimageIDKey != "" {
+		return nil
+	}
+
+	if cm.Data["CLOUD_PROVIDER"] != "" {
+		provider = cm.Data["CLOUD_PROVIDER"]
+	} else {
+		provider = r.getCloudProviderFromInfra()
+	}
+
+	switch provider {
+	case "aws":
+		r.CMimageIDKey = peerpodsCMAWSImageKey
+	case "azure":
+		r.CMimageIDKey = peerpodsCMAzureImageKey
+	default:
+		return fmt.Errorf("getCloudProvider: Unsupported cloud provider: %s", provider)
+	}
+	r.provider = provider
+
+	igLogger.Info("Cloud provider fetched successfully", "provider", r.provider, "keyID", r.CMimageIDKey)
+	return nil
+}
+
+func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, error) {
+	igLogger.Info("Create Job out of YAML file", "jobFileName", jobFileName)
+	yamlData, err := readJobYAML(jobFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := parseJobYAML(yamlData)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.client.Create(context.TODO(), job); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			igLogger.Info("Image Job already exists, get existing object", "jobFileName", jobFileName)
+			latest := &batchv1.Job{}
+			if err := r.client.Get(context.TODO(), types.NamespacedName{
+				Name:      job.Name,
+				Namespace: job.Namespace,
+			}, latest); err != nil {
+				igLogger.Info("Image Job already exists, getting existing object failed", "jobFileName", jobFileName)
+				return nil, err
+			}
+			return latest, nil
+		} else {
+			return nil, err
+		}
+	}
+	igLogger.Info("Job file has been processed successfully and Job has been created")
+	return job, nil
+}
+
+func (r *ImageGenerator) deleteJobFromFile(jobFileName string, keepPods bool) error {
+	igLogger.Info("delete job from YAML file", "jobFileName", jobFileName)
+	yamlData, err := readJobYAML(jobFileName)
+	if err != nil {
+		return err
+	}
+
+	job, err := parseJobYAML(yamlData)
+	if err != nil {
+		return err
+	}
+
+	var deletePolicy metav1.DeletionPropagation
+	if keepPods {
+		deletePolicy = metav1.DeletePropagationOrphan // this leaves the job's pods around for tracking
+	} else {
+		deletePolicy = metav1.DeletePropagationBackground // this deletes the job's pods as well
+	}
+
+	if err := r.client.Delete(context.TODO(), job, &client.DeleteOptions{PropagationPolicy: &deletePolicy}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			igLogger.Info("Image Job doesn't exist, nothing to delete", "jobFileName", jobFileName)
+		} else {
+			return err
+		}
+	}
+
+	igLogger.Info("Job file has been processed successfully and Job has been deleted", "keepPods", keepPods)
+	return nil
+}
+
+func (r *ImageGenerator) getPeerPodsCM() (*corev1.ConfigMap, error) {
+	igLogger.Info("Getting peer-pods ConfigMap")
+	peerPodsCM := &corev1.ConfigMap{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      peerpodsCMName,
+		Namespace: "openshift-sandboxed-containers-operator",
+	}, peerPodsCM)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: check in peer-pods-secret as well?
+
+	return peerPodsCM, nil
+}
+
+func (r *ImageGenerator) imageJobRunner(op string) (bool, ctrl.Result) {
+	var job *batchv1.Job
+
+	igLogger.Info("imageJobRunner", "operation", op)
+	latestCM, err := r.getPeerPodsCM()
+	if latestCM == nil || err != nil {
+		igLogger.Info("error getting peer-pods ConfigMap", "err", err)
+		return false, ctrl.Result{Requeue: true}
+	}
+
+	if err = r.setupCloudProvider(latestCM); err != nil {
+		igLogger.Info("error getting cloud provider", "err", err)
+		return false, ctrl.Result{Requeue: true}
+	}
+
+	if op == "create" && latestCM.Data[r.CMimageIDKey] != "" {
+		igLogger.Info("Image ID is already set, skipping image creation", "image-ID", latestCM.Data[r.CMimageIDKey])
+		return true, ctrl.Result{Requeue: false}
+	}
+
+	if latestCM.Data == nil {
+		latestCM.Data = make(map[string]string)
+	}
+
+	// set CM with BOOT_FIPS if system is in FIPS mode
+	if op == "create" && latestCM.Data[fipsCMKey] == "" && r.fips {
+		igLogger.Info("setting BOOT_FIPS in peer-pods ConfigMap")
+		latestCM.Data[fipsCMKey] = "true"
+		err = r.client.Update(context.TODO(), latestCM)
+		if err != nil {
+			igLogger.Info("error updating peer-pods ConfigMap with FIPS", "err", err)
+			return false, ctrl.Result{Requeue: true}
+		}
+	}
+
+	// file format: [azure|aws]-[CVM|VM]-image-[create|delete]-job.yaml
+	VMtype := defaultVMType
+	filename := r.provider + "-" + VMtype + "-image-" + op + "-job.yaml"
+	job, err = r.createJobFromFile(filename)
+	if err != nil {
+		igLogger.Info("error creating image creation job from yaml file", "err", err)
+		return false, ctrl.Result{Requeue: true}
+	}
+
+	if job.Status.Active == 0 && job.Status.Succeeded == 0 && job.Status.Failed == 0 { // job hasn't started yet
+		igLogger.Info("JobStatus: Job hasn't started yet", "job name", job.Name)
+		return false, ctrl.Result{RequeueAfter: 60 * time.Second}
+	} else if job.Status.Failed > 0 { // job failed, delete job?
+		igLogger.Info("JobStatus: Job has failed, delete job, keep pod for tracking", "job name", job.Name)
+		if err := r.deleteJobFromFile(filename, true); err != nil {
+			igLogger.Info("error deleting the job definition from yaml file", "err", err, "filename", filename)
+		}
+		return false, ctrl.Result{Requeue: true}
+	} else if job.Status.Succeeded > 0 { // job completed, continue
+		igLogger.Info("JobStatus: Job has completed successfully, fetch ImageID and add set in CM", "job name", job.Name)
+	} else if job.Status.Active > 0 { // job is still running
+		igLogger.Info("JobStatus: Job is still running", "job name", job.Name)
+		return false, ctrl.Result{RequeueAfter: 60 * time.Second}
+	} else {
+		igLogger.Info("JobStatus: Unexpected Job Status!!!", "job name", job.Name)
+		if err := r.deleteJobFromFile(filename, true); err != nil {
+			igLogger.Info("error deleting the job definition from yaml file", "err", err, "filename", filename)
+		}
+		return false, ctrl.Result{Requeue: true}
+	}
+
+	imageID := ""
+	if op == "create" {
+		logs, err := r.getImageIDFromJobLogs(job)
+		if err != nil || logs == "" {
+			igLogger.Info("falied to get ImageID from logs", "err", err)
+			if err := r.deleteJobFromFile(filename, true); err != nil {
+				igLogger.Info("error deleting the job definition from yaml file", "err", err, "filename", filename)
+			}
+			return false, ctrl.Result{Requeue: true}
+		}
+		imageID = logs
+	}
+
+	latestCM.Data[r.CMimageIDKey] = imageID
+	err = r.client.Update(context.TODO(), latestCM) // TODO: consider watching also CM from the controller
+	if err != nil {
+		igLogger.Info("error updating peer-pods ConfigMap imageID", "err", err)
+		return false, ctrl.Result{Requeue: true}
+	}
+
+	if op == "delete" {
+		igLogger.Info("image deletion job has been complated, deletes jobs and pods")
+		if err := r.deleteJobFromFile(r.provider+"-"+VMtype+"-image-create-job.yaml", false); err != nil {
+			igLogger.Info("error deleting the job create definition from yaml file", "err", err)
+			return false, ctrl.Result{Requeue: true}
+		}
+		if err := r.deleteJobFromFile(r.provider+"-"+VMtype+"-image-delete-job.yaml", false); err != nil {
+			igLogger.Info("error deleting the job delete definition from yaml file", "err", err)
+			return false, ctrl.Result{Requeue: true}
+		}
+	}
+	igLogger.Info("image ID has been "+op+"d"+" successfully for cloud provider", "provider", r.provider)
+	return true, ctrl.Result{}
+}
+
+func (r *ImageGenerator) getImageIDFromJobLogs(job *batchv1.Job) (string, error) {
+	labelSelector := labels.SelectorFromSet(map[string]string{"job-name": job.Name})
+	listOpts := []client.ListOption{
+		client.InNamespace(job.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	}
+
+	podList := &corev1.PodList{}
+	err := r.client.List(context.TODO(), podList, listOpts...)
+	if err != nil {
+		igLogger.Info("Error in getting pod list", "err", err)
+		return "", err
+	}
+
+	podLogOpts := corev1.PodLogOptions{Container: "result"}
+	req := r.clientset.CoreV1().Pods(job.Namespace).GetLogs(podList.Items[0].Name, &podLogOpts)
+	podLogs, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+	str := strings.TrimRight(buf.String(), "\r\n")
+
+	if strings.Contains(str, " ") {
+		return "", fmt.Errorf("getImageIDFromJobLogs: logs contains spaces, it's unexpected in image-ID something went wrong: %s", str)
+	}
+
+	igLogger.Info("Job's \"result\" container logs", "logs", str, "pod-name", podList.Items[0].Name)
+	return str, nil
+}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -42,7 +42,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +60,6 @@ type KataConfigOpenShiftReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 
-	clientset  kubernetes.Interface
 	kataConfig *kataconfigurationv1.KataConfig
 }
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -6,6 +6,7 @@ import (
 
 	yaml "github.com/ghodss/yaml"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -35,6 +36,24 @@ func IsOpenShift() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func parseJobYAML(yamlData []byte) (*batchv1.Job, error) {
+	job := &batchv1.Job{}
+	err := yaml.Unmarshal(yamlData, job)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func readJobYAML(jobFileName string) ([]byte, error) {
+	jobFilePath := filepath.Join(peerpodsImageJobsPathLocation, jobFileName)
+	yamlData, err := os.ReadFile(jobFilePath)
+	if err != nil {
+		return nil, err
+	}
+	return yamlData, nil
 }
 
 func parseMachineConfigYAML(yamlData []byte) (*mcfgv1.MachineConfig, error) {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 
 	peerpodcontrollers "github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl/controllers"
 	peerpodconfigcontrollers "github.com/confidential-containers/cloud-api-adaptor/peerpodconfig-ctrl/controllers"
+	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	mcfgapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io"
 	"go.uber.org/zap/zapcore"
@@ -77,6 +78,8 @@ func init() {
 	utilruntime.Must(peerpodconfig.AddToScheme(scheme))
 
 	utilruntime.Must(peerpod.AddToScheme(scheme))
+
+	utilruntime.Must(configv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
EDITED:

This PR contains several features:
1. **AWS**: if image is not specified it will generate AMI image and update the CM with it when KataConfig is created (and it will be deleted when KataConfig is deleted)
2.  **Azure**: if image is not specified it will generate Azure image and update the CM with it when KataConfig is created (and it will be deleted when KataConfig is deleted)
3. **Azure&AWS**: if cluster is installed with **fips=true** all created images will boot with kernel cmdline parameter fips=1

To test use:
```
quay.io/snir/osc-operator:v1.4.8
quay.io/snir/osc-operator-bundle:v1.4.8
quay.io/snir/osc-operator-catalog:v1.4.8
```