### PR TITLE
Support multiple runtimeclasses in kataconfig.status.runtimeClass

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -48,8 +48,9 @@ type KataConfigSpec struct {
 
 // KataConfigStatus defines the observed state of KataConfig
 type KataConfigStatus struct {
-	// RuntimeClass is the name of the runtime class used in CRIO configuration
-	RuntimeClass string `json:"runtimeClass"`
+	// RuntimeClass is the names of the RuntimeClasses created by this controller
+	// +optional
+	RuntimeClass []string `json:"runtimeClass"`
 
 	// +optional
 	KataNodes KataNodesStatus `json:"kataNodes,omitempty"`

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -592,8 +592,8 @@ func (r *KataConfigOpenShiftReconciler) listKataPods() error {
 	}
 	for _, pod := range podList.Items {
 		if pod.Spec.RuntimeClassName != nil {
-			if *pod.Spec.RuntimeClassName == r.kataConfig.Status.RuntimeClass {
-				return fmt.Errorf("Existing pods using Kata Runtime found. Please delete the pods manually for KataConfig deletion to proceed")
+			if contains(r.kataConfig.Status.RuntimeClass, *pod.Spec.RuntimeClassName) {
+				return fmt.Errorf("Existing pods using \"%v\" RuntimeClass found. Please delete the pods manually for KataConfig deletion to proceed", *pod.Spec.RuntimeClassName)
 			}
 		}
 	}
@@ -751,12 +751,8 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 		}
 	}
 
-	if r.kataConfig.Status.RuntimeClass == "" {
-		r.kataConfig.Status.RuntimeClass = runtimeClassName
-		err = r.Client.Status().Update(context.TODO(), r.kataConfig)
-		if err != nil {
-			return err
-		}
+	if !contains(r.kataConfig.Status.RuntimeClass, runtimeClassName) {
+		r.kataConfig.Status.RuntimeClass = append(r.kataConfig.Status.RuntimeClass, runtimeClassName)
 	}
 
 	return nil


### PR DESCRIPTION
This controller can now create multiple RuntimeClasses, for plain kata
and for peer pods.  However only the original kata RuntimeClass has ever
been accounted for in KataConfig.status.runtimeClass so far.
    
This is not merely a cosmetic problem.  The controller uses
KataConfig.status.runtimeClass to find out whether there are any pods
using the kata runtime before it removes the runtime from a cluster on
uninstallation.  Since the peer pods RuntimeClass was never represented
in the field so far, running peer pods were ignored on uninstallation.
    
As for implementation, KataConfig.status.runtimeClass is now optional,
not required.  This doesn't really have to do with the core idea of this
commit, it's more to work around the fact that kubebuilder doesn't seem
to support array fields with an empty array as the default value.
    
The removal of KataConfig resource immediate Update() after modifying the
runtimeClass field is also not strictly necessary but still included since
such Update()s in the middle of reconciliation can cause problems on a
subsequent Update() ("object has been modified").

Fixes [KATA-2294](https://issues.redhat.com//browse/KATA-2294)

[EDIT, greg]
Fixes [KATA-2441](https://issues.redhat.com/browse/KATA-2441) # Partially

Signed-off-by: Pavel Mores <pmores@redhat.com>