### PR TITLE
Peer-pods: switch runtime class name to 'kata-remote' instead of 'kata…

### DIFF
--- a/config/peerpods/mc-50-crio-config.yaml
+++ b/config/peerpods/mc-50-crio-config.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: peerpodconfig-openshift
     machineconfiguration.openshift.io/role: kata-oc
-  name: 50-kata-remote-cc
+  name: 50-kata-remote
 spec:
   config:
     ignition:
@@ -12,8 +12,8 @@ spec:
     storage:
       files:
       - contents:
-              source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS5ydW50aW1lcy5rYXRhLXJlbW90ZS1jY10KIHJ1bnRpbWVfcGF0aCA9ICIvdXNyL2Jpbi9jb250YWluZXJkLXNoaW0ta2F0YS12Mi10cCIKIHJ1bnRpbWVfdHlwZSA9ICJ2bSIKIHJ1bnRpbWVfcm9vdCA9ICIvcnVuL3ZjIgogcnVudGltZV9jb25maWdfcGF0aCA9ICIvb3B0L2thdGEvY29uZmlndXJhdGlvbi1yZW1vdGUudG9tbCIKIHByaXZpbGVnZWRfd2l0aG91dF9ob3N0X2RldmljZXMgPSB0cnVlCg==
+              source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS5ydW50aW1lcy5rYXRhLXJlbW90ZV0KIHJ1bnRpbWVfcGF0aCA9ICIvdXNyL2Jpbi9jb250YWluZXJkLXNoaW0ta2F0YS12Mi10cCIKIHJ1bnRpbWVfdHlwZSA9ICJ2bSIKIHJ1bnRpbWVfcm9vdCA9ICIvcnVuL3ZjIgogcnVudGltZV9jb25maWdfcGF0aCA9ICIvb3B0L2thdGEvY29uZmlndXJhdGlvbi1yZW1vdGUudG9tbCIKIHByaXZpbGVnZWRfd2l0aG91dF9ob3N0X2RldmljZXMgPSB0cnVlCg==
         filesystem: root
         mode: 0644
-        path: /etc/crio/crio.conf.d/50-kata-remote-cc
+        path: /etc/crio/crio.conf.d/50-kata-remote
 

--- a/config/peerpods/runtimeclass.yaml
+++ b/config/peerpods/runtimeclass.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: node.k8s.io/v1
-handler: kata-remote-cc
+handler: kata-remote
 kind: RuntimeClass
 metadata:
-  name: kata-remote-cc
+  name: kata-remote
 overhead:
   podFixed:
     memory: "120Mi"

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -73,11 +73,11 @@ const (
 	DEFAULT_PEER_PODS                   = "10"
 	peerpodConfigCrdName                = "peerpodconfig-openshift"
 	peerpodsMachineConfigPathLocation   = "/config/peerpods"
-	peerpodsCrioMachineConfig           = "50-kata-remote-cc"
+	peerpodsCrioMachineConfig           = "50-kata-remote"
 	peerpodsCrioMachineConfigYaml       = "mc-50-crio-config.yaml"
 	peerpodsKataRemoteMachineConfig     = "40-worker-kata-remote-config"
 	peerpodsKataRemoteMachineConfigYaml = "mc-40-kata-remote-config.yaml"
-	peerpodsRuntimeClassName            = "kata-remote-cc"
+	peerpodsRuntimeClassName            = "kata-remote"
 	peerpodsRuntimeClassCpuOverhead     = "0.25"
 	peerpodsRuntimeClassMemOverhead     = "350Mi"
 )


### PR DESCRIPTION
Referencing "confidential containers" for the peer-pods runtime is unneeded, and will probably cause confusion in the long run.


Fixes: [KATA-2465](https://issues.redhat.com//browse/KATA-2465)
