### PR TITLE
don't let KataConfig deletion start while installation is still in progress

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -134,8 +134,10 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 
 		// Check if the KataConfig instance is marked to be deleted, which is
-		// indicated by the deletion timestamp being set.
-		if r.kataConfig.GetDeletionTimestamp() != nil {
+		// indicated by the deletion timestamp being set.  However, don't let
+		// uninstallation commence if another operation (installation, update)
+		// is underway.
+		if r.kataConfig.GetDeletionTimestamp() != nil && !r.isInstalling() && !r.isUpdating() {
 			res, err := r.processKataConfigDeleteRequest()
 
 			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
@@ -1944,6 +1946,22 @@ func (r *KataConfigOpenShiftReconciler) resetInProgressCondition() {
 	cond.Message = ""
 
 	r.Log.Info("InProgress Condition reset")
+}
+
+func (r *KataConfigOpenShiftReconciler) isInstalling() bool {
+	cond := r.findInProgressCondition()
+	if cond == nil {
+		return false;
+	}
+	return cond.Status == corev1.ConditionTrue && cond.Reason == "Installing";
+}
+
+func (r *KataConfigOpenShiftReconciler) isUpdating() bool {
+	cond := r.findInProgressCondition()
+	if cond == nil {
+		return false;
+	}
+	return cond.Status == corev1.ConditionTrue && cond.Reason == "Updating";
 }
 
 func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {


### PR DESCRIPTION
When KataConfig deletion processing is allowed to start while a previous installation or update is still running both processes will interfere with each other, resulting in a variety of possible cluster states, most of them undesirable (most often, uninstallation blocks indefinitely).

This PR alleviates the situation by not allowing uninstallation to start while installation or an update is still underway.  Once the current operation finishes uninstallation should start immediately.

Fixes [KATA-1851](https://issues.redhat.com//browse/KATA-1851)