### PR TITLE
Fix upgrade from OSC 1.4.1

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -48,9 +48,9 @@ type KataConfigSpec struct {
 
 // KataConfigStatus defines the observed state of KataConfig
 type KataConfigStatus struct {
-	// RuntimeClass is the names of the RuntimeClasses created by this controller
+	// RuntimeClasses is the names of the RuntimeClasses created by this controller
 	// +optional
-	RuntimeClass []string `json:"runtimeClass"`
+	RuntimeClasses []string `json:"runtimeClasses"`
 
 	// +optional
 	KataNodes KataNodesStatus `json:"kataNodes,omitempty"`

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -561,7 +561,7 @@ func (r *KataConfigOpenShiftReconciler) listKataPods() error {
 	}
 	for _, pod := range podList.Items {
 		if pod.Spec.RuntimeClassName != nil {
-			if contains(r.kataConfig.Status.RuntimeClass, *pod.Spec.RuntimeClassName) {
+			if contains(r.kataConfig.Status.RuntimeClasses, *pod.Spec.RuntimeClassName) {
 				return fmt.Errorf("Existing pods using \"%v\" RuntimeClass found. Please delete the pods manually for KataConfig deletion to proceed", *pod.Spec.RuntimeClassName)
 			}
 		}
@@ -720,8 +720,8 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 		}
 	}
 
-	if !contains(r.kataConfig.Status.RuntimeClass, runtimeClassName) {
-		r.kataConfig.Status.RuntimeClass = append(r.kataConfig.Status.RuntimeClass, runtimeClassName)
+	if !contains(r.kataConfig.Status.RuntimeClasses, runtimeClassName) {
+		r.kataConfig.Status.RuntimeClasses = append(r.kataConfig.Status.RuntimeClasses, runtimeClassName)
 	}
 
 	return nil

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1667,10 +1667,6 @@ const (
 // will be returned.
 func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 
-	if r.getInProgressConditionValue() != corev1.ConditionTrue {
-		return nil
-	}
-
 	err, nodeList := r.getNodes()
 	if err != nil {
 		return err


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

This fixes [KATA-2593 (Kata Operator upgrade failed 1.4.1 to 1.5.0)](https://issues.redhat.com/browse/KATA-2593) .

**- What I did**

Renamed the offending field in KataConfigStatus and improved idempotency of the controller.

**- How to verify it**

1. Install OSC 1.4.1 with automatic upgrade enabled [use catalog image at *]
2. Create a KataConfig
3. Setup a catalog source with this PR [use catalog image at **]
4. Patch the subscription of the operator to select the new source
```
oc patch subscription -n openshift-sandboxed-containers-operator sandboxed-containers-operator -p '{"spec":{"source":"my-operator-catalog", "startingCSV":"sandboxed-containers-operator.v1.5.1", "channel":"candidate"}}' --type merge
```
5. Upgrade should start and complete successfully

The following scenarios should be checked :

- [ ] User has 1.4.1 installed (described above)
- [ ] User has 1.4.1/1.5.0 in pending state ([KATA-2593](https://issues.redhat.com/browse/KATA-2593)).
       I believe this requires to first uninstall OSC completely, aka `oc delete ns openshift-sandboxed-containers-operator`
- [ ] User has 1.5.0 installed

[*] quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:1.4.1-10
[**] quay.io/rhgkurz/openshift-sandboxed-containers-operator-catalog:v1.5.1

**- Description for the changelog**
