### PR TITLE
image-generator: fix image creation edge cases

### DIFF
--- a/config/peerpods/podvm/aws-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-create-job.yaml
@@ -44,8 +44,6 @@ spec:
             value: aws
           - name: PODVM_DISTRO
             value: rhel
-          - name: IMAGE_NAME
-            value: "peer-pod-ami"
 #          - name: INSTANCE_TYPE
 #            value: "t3.small" # default is t3.small, uncomment and modify if not available in your region
         envFrom:
@@ -59,6 +57,7 @@ spec:
         - -c
         - |
           set -e
+          [[ ! "${IMAGE_NAME}" ]] && UUID=$(uuidgen) && export IMAGE_NAME="peer-pod-ami-${UUID::6}" && echo "IMAGE_NAME:${IMAGE_NAME}"
           dnf install -y make git unzip
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip

--- a/config/peerpods/podvm/aws-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-create-job.yaml
@@ -46,6 +46,8 @@ spec:
             value: rhel
 #          - name: INSTANCE_TYPE
 #            value: "t3.small" # default is t3.small, uncomment and modify if not available in your region
+#          - name: IMAGE_NAME
+#            value: "aws-podvm-image-name" # set custom image name for custom image if you wish to avoid its deletion
         envFrom:
         - secretRef:
             name: peer-pods-secret

--- a/config/peerpods/podvm/aws-VM-image-delete-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-delete-job.yaml
@@ -26,13 +26,13 @@ spec:
         env:
           - name: PODVM_DISTRO
             value: rhel
-          - name: IMAGE_NAME
-            value: "peer-pod-ami"
         command:
         - /bin/sh
         - -c
         - |
           set -e
+          [[ ! "${PODVM_AMI_ID}" ]] && echo "PODVM_AMI_ID is missing, it's unknown which image to delete" && exit 1
+          [[ "${IMAGE_NAME}" ]] && echo "IMAGE_NAME:${IMAGE_NAME} is set, it implies image was not automatically created, delete it manually" && exit 0
           dnf install -y unzip
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
@@ -41,8 +41,8 @@ spec:
           export MAC=$(curl -m 3 -s http://169.254.169.254/latest/meta-data/mac)
           [[ ! "${AWS_REGION}" ]] && export AWS_REGION=$(curl -m 30 -s --show-error http://169.254.169.254/latest/meta-data/placement/region)
           [[ ! "${AWS_REGION}" ]] && echo "AWS_REGION is missing" && exit 1
-          export IMAGE_NAME=${IMAGE_NAME:-peer-pod-ami}
-          PODVM_AMI_ID=$(aws ec2 describe-images --query "Images[*].[ImageId]" --filters "Name=name,Values=${IMAGE_NAME}" --region ${AWS_REGION} --output text) && \
           echo "Deleting AMI: ${PODVM_AMI_ID}"
-          aws ec2 deregister-image --image-id ${PODVM_AMI_ID} --region ${AWS_REGION}
-          echo "Deleting AMI: ${PODVM_AMI_ID} - DONE"
+          RES=$(aws ec2 deregister-image --image-id "${PODVM_AMI_ID}" --region "${AWS_REGION}" 2>&1) || ERR=true
+          echo ${RES}
+          [[ ${ERR} ]] && [[ "$RES" =~ InvalidAMIID\.(Unavailable|NotFound) ]] # if deregister returned error and image is already deleted, continue
+          echo "Deleted AMI: ${PODVM_AMI_ID} - DONE"

--- a/config/peerpods/podvm/azure-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-create-job.yaml
@@ -50,8 +50,6 @@ spec:
             value: "rhel-raw"
           - name: SKU
             value: "9_2"
-          - name: IMAGE_NAME
-            value: "peer-pod-vmimage"
         envFrom:
         - secretRef:
             name: peer-pods-secret
@@ -63,6 +61,7 @@ spec:
         - -c
         - |
           set -e
+          [[ ! "${IMAGE_NAME}" ]] && UUID=$(uuidgen) && export IMAGE_NAME="peer-pod-vmimage-${UUID::6}" && echo "IMAGE_NAME:${IMAGE_NAME}"
           rpm --import https://packages.microsoft.com/keys/microsoft.asc
           dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
           dnf install -y make git azure-cli unzip

--- a/config/peerpods/podvm/azure-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-create-job.yaml
@@ -50,6 +50,8 @@ spec:
             value: "rhel-raw"
           - name: SKU
             value: "9_2"
+#          - name: IMAGE_NAME
+#            value: "azure-podvm-image-name" # set custom image name for custom image if you wish to avoid its deletion
         envFrom:
         - secretRef:
             name: peer-pods-secret

--- a/config/peerpods/podvm/azure-VM-image-delete-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-delete-job.yaml
@@ -17,8 +17,6 @@ spec:
         securityContext:
           runAsUser: 0 # needed for container mode dnf access
         env:
-          - name: IMAGE_NAME
-            value: "peer-pod-vmimage"
         envFrom:
         - secretRef:
             name: peer-pods-secret
@@ -30,6 +28,8 @@ spec:
         - -c
         - |
           set -e
+          [[ ! "${AZURE_IMAGE_ID}" ]] && echo "AZURE_IMAGE_ID is missing, it's unknown which image should be deleted" && exit 1
+          [[ "${IMAGE_NAME}" ]] && echo "IMAGE_NAME:${IMAGE_NAME} is set, it implies image was not automatically created, delete it manually " && exit 0
           rpm --import https://packages.microsoft.com/keys/microsoft.asc
           dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
           yum install -y azure-cli
@@ -41,6 +41,6 @@ spec:
           [[ ! "${AZURE_CLIENT_SECRET}" ]] && echo "AZURE_CLIENT_SECRET is missing" && exit 1
           [[ ! "${AZURE_CLIENT_ID}" ]] && echo "AZURE_CLIENT_ID is missing" && exit 1
           az login --service-principal --user=${AZURE_CLIENT_ID} --password=${AZURE_CLIENT_SECRET} --tenant=${AZURE_TENANT_ID} && \
-          az image delete --image-name "${IMAGE_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" && \
+          az image delete --ids "${AZURE_IMAGE_ID}" && \
           echo "DONE"
       restartPolicy: Never


### PR DESCRIPTION
* at creation: name images with unique naming to aviod name reuse failures
* at deletion: ignore if image is already deleted

Fixes: #[KATA-2618](https://issues.redhat.com//browse/KATA-2618)

to test:
```
quay.io/snir/osc-operator:v9.9.2618
quay.io/snir/osc-operator-catalog:v9.9.2618
quay.io/snir/osc-operator-bundle:v9.9.2618
```
in OCP make sure to set also:
`oc set env deployment.apps/controller-manager SANDBOXED_CONTAINERS_EXTENSION=sandboxed-containers -n openshift-sandboxed-containers-operator`