### PR TITLE
Bump OSC to 1.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.5.1
+VERSION ?= 1.5.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: 1.5.1
+  newTag: 1.5.2

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    olm.skipRange: '>=1.1.0 <1.5.1'
+    olm.skipRange: '>=1.1.0 <1.5.2'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
@@ -25,7 +25,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.5.1
+  name: sandboxed-containers-operator.v1.5.2
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -365,7 +365,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  version: 1.5.1
+  version: 1.5.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.5.1
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.5.2
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,5 +36,5 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.5.1
+  startingCSV: sandboxed-containers-operator.v1.5.2
   

--- a/hack/aws-image-job.yaml
+++ b/hack/aws-image-job.yaml
@@ -21,7 +21,7 @@ spec:
 
       initContainers:
       - name: payload
-        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.1
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
         imagePullPolicy: Always
         volumeMounts:
         - name: shared-data

--- a/hack/azure-image-job.yaml
+++ b/hack/azure-image-job.yaml
@@ -20,7 +20,7 @@ spec:
 
       initContainers:
       - name: payload
-        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.1
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
         imagePullPolicy: Always
         volumeMounts:
         - name: shared-data


### PR DESCRIPTION
As a preparatory step for the upcoming release, this bumps the version to 1.5.2 in Makefile, the CSV and images.

Note that the updated images aren't available at this stage. They will be added later. Until then the image links aren't valid.
