### PR TITLE
Avoid copying payload binaries to the builder image

### DIFF
--- a/config/peerpods/podvm/Dockerfile
+++ b/config/peerpods/podvm/Dockerfile
@@ -1,19 +1,16 @@
-FROM quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-payload:37c1125179912e5d1104c43fd83d567914278bcb as payload
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 
-# podvm binaries under /payload/podvm-binaries.tar.gz
 # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
 # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
 # sources for cloud-api-adaptor under /src/cloud-api-adaptor
+# The podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
 # Binaries like kubectl, packer and yq under /usr/local/bin will be installed by the scripts
 
-
-FROM registry.access.redhat.com/ubi9/ubi:9.3
 
 LABEL kata_src=https://github.com/kata-containers/kata-containers/tree/CC-0.8.0
 LABEL kata_src_commit=8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
 
-RUN mkdir -p /payload /scripts
-COPY --from=payload /podvm-binaries.tar.gz /payload/
+RUN mkdir -p /scripts
 
 ADD lib.sh aws-podvm-image-handler.sh azure-podvm-image-handler.sh  /scripts/
 

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -11,15 +11,30 @@ spec:
     metadata:
       name: osc-podvm-image-creation
     spec:
+      # Add initContainers to pull the image from the registry and copy
+      # /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz
+      initContainers:
+        - name: copy
+          image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-podvm-payload:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Copying the payload files"
+              cp /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz || exit 1
+              echo "Copied the payload files successfully"
+          volumeMounts:
+            - name: payload
+              mountPath: /payload
       containers:
         - name: create
+          # Binaries like kubectl, packer and yq are expected to be under /usr/local/bin
+          # podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
+          image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-podvm-builder:latest
           # This image contains the following
-          # podvm binaries under /payload/podvm-binaries.tar.gz
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
-          # Binaries like kubectl, packer and yq under /usr/local/bin
-          image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-podvm-builder:latest
+
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           envFrom:
@@ -35,5 +50,10 @@ spec:
                 name: aws-podvm-image-cm
                 optional: true
           command: ["/podvm-builder.sh", "create"]
-
+          volumeMounts:
+            - name: payload
+              mountPath: /payload
+      volumes:
+        - name: payload
+          emptyDir: {}
       restartPolicy: Never


### PR DESCRIPTION
This avoids duplication and enables independent dev of both the container images required for building podvm image
