### PR TITLE
KATA-2881: add new annotations to CSV

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,9 +13,15 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=1.1.0 <1.5.3'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
-    operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
CVP downstream requires new annotations to exist in the CSV. https://docs.openshift.com/container-platform/4.15/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs

Closes: [KATA-2881](https://issues.redhat.com//browse/KATA-2881)

**- What I did**
Added the annotations to CSV.  I set disconnected to true and all the rest false.  We can update them if that is wrong, but this should satisfy CVP.

**- How to verify it**
Make bundle.  Check bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml to see if new annotations are in rendered CSV

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
