### PR TITLE
Introduce `replaces` field in CSV

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -371,6 +371,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
+  replaces: sandboxed-containers-operator.v1.5.2
   version: 1.5.3
   webhookdefinitions:
   - admissionReviewVersions:


### PR DESCRIPTION
This is now mandated by CVP if the CSV uses the `skipRange` field.
