### PR TITLE
Add two feature gates : Image based deployment and additional runtimeClasses

### DIFF
--- a/config/samples/featuregates.yaml
+++ b/config/samples/featuregates.yaml
@@ -4,19 +4,46 @@ metadata:
   name: osc-feature-gates
   namespace: openshift-sandboxed-containers-operator
 data:
-  # timeTravel allows navigating through cluster states across time.
-  # It is useful for scenarios where you want to view historical data or
-  # predict future states based on current trends. Default is "false".
-  # timeTravel: "false"
+  # OpenShift supports image layering, that allows deployment of packages by
+  # providing a custom RHCOS image. LayeredImageDeployment feature enables the
+  # support for Kata artifacts deployment using RHCOS image layer
 
-  # quantumEntanglementSync enables instant state consistency across clusters
-  # using principles of quantum mechanics. This advanced feature ensures
-  # data is synchronized across different locations without traditional
-  # network latency. Default is "false".
-  # quantumEntanglementSync: "false"
+  # Additionally you'll need to create a configmap named layeredimagedeployment-config to provide relevant
+  # configurations for this feature. Check the example yaml later on in this file
 
-  # autoHealingWithAI employs artificial intelligence to automatically
-  # detect and resolve cluster issues. It leverages machine learning algorithms
-  # to predict potential problems before they occur, ensuring high availability.
-  # Default is "true".
-  # autoHealingWithAI: "true"
+  #LayeredImageDeployment: "false"
+
+  # AdditionalRuntimeClasses feature is enables creating additional runtimeClasses
+  # This feature typically will be used with other features.
+  # For example this feature can be used with the layered image based deployment feature as well.
+  # The layered image based deployment might have configuration for multiple
+  # runtimeclasses which is then exposed to users as RuntimeClass objects
+  # created by OSC operator when this feature gate is enabled.
+
+  # Additionally you'll need to create a configmap named additionalruntimeclasses-config to provide relevant
+  # configurations for this feature. Check the example yaml later on in this file
+
+  #AdditionalRuntimeClasses: "false"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: layeredimagedeployment-config
+  namespace: openshift-sandboxed-containers-operator
+data:
+  # Provide the configurations for the LayeredImageDeployment feature
+  # osImageURL is mandatory and should be a valid URL containing the RHCOS layered image
+  #osImageURL: "quay.io/...."
+  #kernelArguments: "a=b c=d ..."
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: additionalruntimeclasses-config
+  namespace: openshift-sandboxed-containers-operator
+data:
+  # Use any one of the formats below to provide the runtime class configurations
+  #runtimeClassConfig: "name1:cpuOverHead1:memOverHead1, name2:cpuOverHead2:memOverHead2"
+  #runtimeClassConfig: "name1, name2"

--- a/controllers/cm_event_handler.go
+++ b/controllers/cm_event_handler.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+type ConfigMapEventHandler struct {
+	reconciler *KataConfigOpenShiftReconciler
+}
+
+func (ch *ConfigMapEventHandler) Create(ctx context.Context, event event.CreateEvent, queue workqueue.RateLimitingInterface) {
+
+	if ch.reconciler.kataConfig == nil {
+		return
+	}
+
+	cm := event.Object
+
+	// Check if the configmap name is one of the feature gates configmap or
+	// feature config
+	if cm.GetNamespace() != OperatorNamespace || !featuregates.IsFeatureGateConfigMap(cm.GetName()) {
+		return
+	}
+	log := ch.reconciler.Log.WithName("CMCreate").WithValues("cm name", cm.GetName())
+	log.Info("FeatureGates configmap created")
+
+	queue.Add(ch.reconciler.makeReconcileRequest())
+}
+
+func (ch *ConfigMapEventHandler) Update(ctx context.Context, event event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+
+	if ch.reconciler.kataConfig == nil {
+		return
+	}
+
+	cm := event.ObjectNew
+
+	// Check if the configmap name is one of the feature gates configmap or
+	// feature config
+	if cm.GetNamespace() != OperatorNamespace || !featuregates.IsFeatureGateConfigMap(cm.GetName()) {
+		return
+	}
+
+	log := ch.reconciler.Log.WithName("CMUpdate").WithValues("cm name", cm.GetName())
+	log.Info("FeatureGates configmap updated")
+
+	queue.Add(ch.reconciler.makeReconcileRequest())
+
+}
+
+func (ch *ConfigMapEventHandler) Delete(ctx context.Context, event event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+}
+
+func (ch *ConfigMapEventHandler) Generic(ctx context.Context, event event.GenericEvent, queue workqueue.RateLimitingInterface) {
+}

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -293,7 +294,8 @@ func (kh *KataConfigHandler) getCredentialsRequest() (*v1.CredentialsRequest, er
 	}
 
 	fileName := fmt.Sprintf(peerpodsCredentialsRequestFileFormat, provider)
-	yamlData, err := readCredentialsRequestYAML(fileName)
+	credentialsRequestsYamlFile := filepath.Join(peerpodsCredentialsRequestsPathLocation, fileName)
+	yamlData, err := readYamlFile(credentialsRequestsYamlFile)
 	if os.IsNotExist(err) {
 		kh.reconciler.Log.Info("no CredentialsRequestYAML for provider", "err", err, "provider", provider)
 		return nil, nil
@@ -324,7 +326,8 @@ func (kh *KataConfigHandler) skipCredentialRequests() bool {
 	// check if CredentialsRequest implementation exists for the cloud provider
 	if provider, err := getCloudProviderFromInfra(kh.reconciler.Client); err == nil {
 		fileName := fmt.Sprintf(peerpodsCredentialsRequestFileFormat, provider)
-		if _, err := readCredentialsRequestYAML(fileName); os.IsNotExist(err) {
+		credentialsRequestsYamlFile := filepath.Join(peerpodsCredentialsRequestsPathLocation, fileName)
+		if _, err := readYamlFile(credentialsRequestsYamlFile); os.IsNotExist(err) {
 			kh.reconciler.Log.Info("no CredentialsRequest yaml file for provider, skipping", "provider", provider, "filename", fileName)
 			return true
 		}

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -242,7 +243,9 @@ func newImageGenerator(client client.Client) (*ImageGenerator, error) {
 func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, error) {
 	igLogger.Info("Create Job out of YAML file", "jobFileName", jobFileName)
 
-	yamlData, err := readJobYAML(jobFileName)
+	jobYamlFile := filepath.Join(peerpodsImageJobsPathLocation, jobFileName)
+
+	yamlData, err := readYamlFile(jobYamlFile)
 	if err != nil {
 		return nil, err
 	}
@@ -630,7 +633,8 @@ func (r *ImageGenerator) createImageConfigMapFromFile() error {
 	}
 
 	filename := r.provider + "-podvm-image-cm.yaml"
-	yamlData, err := readConfigMapYAML(filename)
+	configMapYamlFile := filepath.Join(peerpodsImageJobsPathLocation, filename)
+	yamlData, err := readYamlFile(configMapYamlFile)
 	if err != nil {
 		return err
 	}

--- a/controllers/mc_handler.go
+++ b/controllers/mc_handler.go
@@ -1,0 +1,195 @@
+package controllers
+
+/*
+This code handles the installation of Kata artifacts using an RHCOS extension or image and deploying it
+via MachineConfig
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	ignTypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	extension_mc_name = "50-enable-sandboxed-containers-extension"
+	image_mc_name     = "50-enable-sandboxed-containers-image"
+)
+
+type DeploymentState struct {
+	PreviousMethod string
+	PreviousMcName string
+}
+
+// If the first return value is 'true' it means that the MC was just created
+// by this call, 'false' means that it's already existed.  As usual, the first
+// return value is only valid if the second one is nil.
+func (r *KataConfigOpenShiftReconciler) createMc(machinePool string) (bool, error) {
+
+	// In case we're returning an error we want to make it explicit that
+	// the first return value is "not care".  Unfortunately golang seems
+	// to lack syntax for creating an expression with default bool value
+	// hence this work-around.
+	var dummy bool
+
+	/* Create Machine Config object to deploy sandboxed containers artifacts */
+	mcName := extension_mc_name
+	if r.FeatureGatesStatus[featuregates.LayeredImageDeployment] {
+		mcName = image_mc_name
+	}
+
+	r.Log.Info("Checking if MachineConfig exists", "mc.Name", mcName)
+	mc := &mcfgv1.MachineConfig{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcName}, mc)
+	if err != nil && (k8serrors.IsNotFound(err) || k8serrors.IsGone(err)) {
+		r.Log.Info("creating new MachineConfig")
+		mc, err = r.newMCForCR(machinePool)
+		if err != nil {
+			return dummy, err
+		}
+
+		err = r.Client.Create(context.TODO(), mc)
+		if err != nil {
+			r.Log.Error(err, "Failed to create a new MachineConfig ", "mc.Name", mc.Name)
+			return dummy, err
+		}
+		r.Log.Info("MachineConfig successfully created", "mc.Name", mc.Name)
+		return true, nil
+	} else if err != nil {
+		r.Log.Info("failed to retrieve MachineConfig", "err", err)
+		return dummy, err
+	} else {
+		r.Log.Info("MachineConfig already exists")
+		return false, nil
+	}
+}
+
+// Create a new MachineConfig object for the Custom Resource
+func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {
+	r.Log.Info("Creating MachineConfig for Custom Resource")
+
+	ic := ignTypes.Config{
+		Ignition: ignTypes.Ignition{
+			Version: "3.2.0",
+		},
+	}
+
+	icb, err := json.Marshal(ic)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.FeatureGatesStatus[featuregates.LayeredImageDeployment] {
+		r.Log.Info("Creating MachineConfig for Custom Resource with image")
+		return r.newImageMCForCR(machinePool, icb)
+	} else {
+		r.Log.Info("Creating MachineConfig for Custom Resource with extension")
+		return r.newExtensionMCForCR(machinePool, icb)
+	}
+
+}
+
+// Create a new MachineConfig object for the Custom Resource with the extension
+func (r *KataConfigOpenShiftReconciler) newExtensionMCForCR(machinePool string, icb []byte) (*mcfgv1.MachineConfig, error) {
+	extension := getExtensionName()
+
+	mc := mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: extension_mc_name,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": machinePool,
+				"app":                                    r.kataConfig.Name,
+			},
+			Namespace: OperatorNamespace,
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Extensions: []string{extension},
+			Config: runtime.RawExtension{
+				Raw: icb,
+			},
+		},
+	}
+
+	return &mc, nil
+}
+
+// Create a new MachineConfig object for the Custom Resource with the image
+func (r *KataConfigOpenShiftReconciler) newImageMCForCR(machinePool string, icb []byte) (*mcfgv1.MachineConfig, error) {
+
+	// Get the LayeredImageDeployment feature gate parameters
+	imageParams := r.FeatureGates.GetFeatureGateParams(context.TODO(), featuregates.LayeredImageDeployment)
+	// Ensure at least osImageURL is set
+	if _, ok := imageParams["osImageURL"]; !ok {
+		return nil, fmt.Errorf("osImageURL not set in feature gate %s", featuregates.LayeredImageDeployment)
+	}
+
+	mc := mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: image_mc_name,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": machinePool,
+				"app":                                    r.kataConfig.Name,
+			},
+			Namespace: OperatorNamespace,
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			OSImageURL: imageParams["osImageURL"],
+			Config: runtime.RawExtension{
+				Raw: icb,
+			},
+		},
+	}
+
+	if kernelArguments, ok := imageParams["kernelArguments"]; ok {
+		// Parse the kernel arguments and set them in the MachineConfig
+		// Note that in the configmap the kernel arguments are stored as a single string
+		// eg. "a=b c=d ..." and we need to split them into individual arguments
+		// eg ["a=b", "c=d", ...]
+		// Split the kernel arguments string into individual arguments
+		mc.Spec.KernelArguments = strings.Fields(kernelArguments)
+	}
+
+	return &mc, nil
+}
+
+// Delete the MachineConfig object
+func (r *KataConfigOpenShiftReconciler) deleteMc(mcName string) error {
+	r.Log.Info("Deleting MachineConfig", "mc.Name", mcName)
+	mc := &mcfgv1.MachineConfig{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcName}, mc)
+	if err != nil {
+		if k8serrors.IsNotFound(err) || k8serrors.IsGone(err) {
+			r.Log.Info("MachineConfig not found. Most likely it was already deleted.")
+			return nil
+		}
+		r.Log.Info("failed to retrieve MachineConfig", "err", err)
+		return err
+	}
+
+	r.Log.Info("deleting MachineConfig")
+	err = r.Client.Delete(context.TODO(), mc)
+	if err != nil {
+		r.Log.Error(err, "Failed to delete MachineConfig")
+		return err
+	}
+
+	r.Log.Info("MachineConfig successfully deleted")
+	return nil
+}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -2081,14 +2082,16 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 func (r *KataConfigOpenShiftReconciler) enablePeerPodsMc() error {
 
 	//Create MachineConfig for kata-remote hyp CRIO config
-	err := r.createMcFromFile(peerpodsCrioMachineConfigYaml)
+	crioMachineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, peerpodsCrioMachineConfigYaml)
+	err := r.createMcFromFile(crioMachineConfigFilePath)
 	if err != nil {
 		r.Log.Info("Error in creating CRIO MachineConfig", "err", err)
 		return err
 	}
 
 	//Create MachineConfig for kata-remote hyp config toml
-	err = r.createMcFromFile(peerpodsKataRemoteMachineConfigYaml)
+	kataConfigMachineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, peerpodsKataRemoteMachineConfigYaml)
+	err = r.createMcFromFile(kataConfigMachineConfigFilePath)
 	if err != nil {
 		r.Log.Info("Error in creating kata remote configuration.toml MachineConfig", "err", err)
 		return err
@@ -2235,10 +2238,12 @@ func (r *KataConfigOpenShiftReconciler) disablePeerPods() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createMcFromFile(mcFileName string) error {
-	yamlData, err := readMachineConfigYAML(mcFileName)
+// Create the MachineConfigs from file
+// Full path of the file should be provided
+func (r *KataConfigOpenShiftReconciler) createMcFromFile(machineConfigYamlFile string) error {
+	yamlData, err := readYamlFile(machineConfigYamlFile)
 	if err != nil {
-		r.Log.Info("Error in reading MachineConfigYaml", "mcFileName", mcFileName, "err", err)
+		r.Log.Info("Error in reading MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
 		return err
 	}
 
@@ -2246,7 +2251,7 @@ func (r *KataConfigOpenShiftReconciler) createMcFromFile(mcFileName string) erro
 
 	machineConfig, err := parseMachineConfigYAML(yamlData)
 	if err != nil {
-		r.Log.Info("Error in parsing MachineConfigYaml", "mcFileName", mcFileName, "err", err)
+		r.Log.Info("Error in parsing MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
 		return err
 	}
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -43,12 +43,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -1559,38 +1556,6 @@ func (eh *NodeEventHandler) Delete(ctx context.Context, event event.DeleteEvent,
 func (eh *NodeEventHandler) Generic(ctx context.Context, event event.GenericEvent, queue workqueue.RateLimitingInterface) {
 }
 
-func configMapFilterPredicate(reconciler *KataConfigOpenShiftReconciler) predicate.Predicate {
-	isRelevantConfigMap := func(obj client.Object) bool {
-		if reconciler == nil || reconciler.FeatureGates == nil {
-			return false
-		}
-
-		configMap, ok := obj.(*corev1.ConfigMap)
-		if !ok {
-			return false
-		}
-
-		relevantNamespace := configMap.Namespace == reconciler.FeatureGates.Namespace
-		relevantName := configMap.Name == reconciler.FeatureGates.ConfigMapName
-		return relevantNamespace && relevantName
-	}
-
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return isRelevantConfigMap(e.Object)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isRelevantConfigMap(e.ObjectNew)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isRelevantConfigMap(e.Object)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return isRelevantConfigMap(e.Object)
-		},
-	}
-}
-
 func (r *KataConfigOpenShiftReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kataconfigurationv1.KataConfig{}).
@@ -1602,8 +1567,7 @@ func (r *KataConfigOpenShiftReconciler) SetupWithManager(mgr ctrl.Manager) error
 			&NodeEventHandler{r}).
 		Watches(
 			&corev1.ConfigMap{},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(configMapFilterPredicate(r)),
+			&ConfigMapEventHandler{r},
 		).Complete(r)
 }
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -888,6 +888,13 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Revert the feature gate status configmap to default
+	err = r.FeatureGates.RevertFeatureGateStatusConfigMapToDefault(context.TODO())
+	if err != nil {
+		r.Log.Info("Error reverting feature gate status configmap to default", "err", err)
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	r.Log.Info("Uninstallation completed. Proceeding with the KataConfig deletion")
 	if err = r.removeFinalizer(); err != nil {
 		return ctrl.Result{Requeue: true}, nil

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -119,6 +119,14 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Check for enabled FeatureGates by retrieving the FeatureGateStatus
 	r.FeatureGatesStatus = r.FeatureGates.GetFeatureGateStatus(ctx)
 
+	// If FeatureGateStatus is nil, we cannot proceed. Log the error and reconcile
+	// This ensures we don't take any action if we cannot determine the FeatureGateStatus
+	// Which could be due to an error in fetching the ConfigMap or the ConfigMap not being present
+	if r.FeatureGatesStatus == nil {
+		r.Log.Info("FeatureGateStatus is nil, cannot proceed. Check if the feature gate configmap is present")
+		return ctrl.Result{}, nil
+	}
+
 	return func() (ctrl.Result, error) {
 
 		// k8s resource correctness checking on creation/modification

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -63,8 +63,9 @@ type KataConfigOpenShiftReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 
-	kataConfig   *kataconfigurationv1.KataConfig
-	FeatureGates *featuregates.FeatureGates
+	kataConfig         *kataconfigurationv1.KataConfig
+	FeatureGates       *featuregates.FeatureGates
+	FeatureGatesStatus featuregates.FeatureGateStatus
 }
 
 const (
@@ -125,9 +126,8 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	if r.FeatureGates.IsEnabled(ctx, "timeTravel") {
-		r.Log.Info("TimeTravel feature is enabled. Performing feature-specific logic...")
-	}
+	// Check for enabled FeatureGates by retrieving the FeatureGateStatus
+	r.FeatureGatesStatus = r.FeatureGates.GetFeatureGateStatus(ctx)
 
 	return func() (ctrl.Result, error) {
 

--- a/controllers/rc_handler.go
+++ b/controllers/rc_handler.go
@@ -1,0 +1,385 @@
+package controllers
+
+/*
+This code handles the creation and deletion of additional runtime classes based on the
+additionalRuntimeClasses feature gate configuration.
+Typically the additionalRuntimeClasses will be used with other feature gates like the
+imageBasedDeployment. Since multiple features have a need to create additional runtimeClasses
+this functionality is made into a separate feature rather then being embedded into multiple different
+features.
+
+The feature gate configuration is read from the ConfigMap osc-feature-gate-additional-rc-config.
+The runtimeClassConfig key in the ConfigMap contains the configuration for additional runtime classes.
+The configuration is in the format:
+runtimeClassConfig="name1:cpuOverHead1:memOverHead1, name2:cpuOverHead2:memOverHead2"
+or
+runtimeClassConfig="name1, name2"
+
+The runtimeClassConfig key is read and the runtime classes are created based on the configuration.
+If the feature gate is disabled, the additional runtime classes are deleted.
+
+The reconcile loop should ensure the following:
+1. Create or delete runtimeClasses and update r.kataConfig.Status.RuntimeClasses field
+2. The runtimeClasses to create or delete consists of the following (in order)
+	- default runtimeClass "kata"
+	- runtimeClass "kata-remote" if peer pods is enabled
+	- runtimeClasses from the feature-gate config runtimeClassConfig key.
+
+	runtimeClassConfig is an array of the RuntimeClassConfig struct, consisting of the following fields:
+	- ClassName: Name of the runtimeClass
+	- CPUOverhead: CPU overhead for the runtimeClass
+	- MemoryOverhead: Memory overhead for the runtimeClass
+
+	The r.kataConfig.Status.RuntimeClasses is a string array of runtimeClass names
+
+	So at any given point in time, the runtimeClasses on the system should consists of
+	- default runtimeClass "kata"
+	- runtimeClass "kata-remote" if peer pods is enabled
+	- runtimeClasses from the feature-gate config runtimeClassConfig key if present.
+
+*/
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
+	corev1 "k8s.io/api/core/v1"
+	nodeapi "k8s.io/api/node/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cri-api/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type RuntimeClassConfig struct {
+	ClassName      string
+	CPUOverhead    string
+	MemoryOverhead string
+}
+
+const (
+	defaultRuntimeClassName         = "kata"
+	defaultCPUOverhead              = "0.25"
+	defaultMemoryOverhead           = "350Mi"
+	peerpodsRuntimeClassName        = "kata-remote"
+	peerpodsRuntimeClassCpuOverhead = "0.25"
+	peerpodsRuntimeClassMemOverhead = "350Mi"
+)
+
+// Method to get additional runtimeClass configuration from the
+// feature-gate configmap.
+// additionalRuntimeClasses.params: |
+//
+//	runtimeClassConfig="name1:cpuOverHead1:memOverHead1, name2:cpuOverHead2:memOverHead2"
+//
+// or
+// runtimeClassConfig="name1, name2"
+func (r *KataConfigOpenShiftReconciler) getRuntimeClassConfigs() []RuntimeClassConfig {
+	runtimeClassConfigs := []RuntimeClassConfig{}
+
+	// Get the AdditionalRuntimeClasses feature gate parameters
+	additionalRuntimeClassesParams := r.FeatureGates.GetFeatureGateParams(context.TODO(), featuregates.AdditionalRuntimeClasses)
+	// If the runtimeClassConfig key is not present, return empty runtimeClassConfig
+	if _, ok := additionalRuntimeClassesParams["runtimeClassConfig"]; !ok {
+		return runtimeClassConfigs
+	}
+
+	runtimeClassConfig := additionalRuntimeClassesParams["runtimeClassConfig"]
+	for _, runtimeClass := range strings.Split(runtimeClassConfig, ",") {
+		// It is expected that the runtimeClass is in the format name:cpuOverhead:memOverhead
+		// Or it can be just the name of the runtimeClass
+		// If the cpuOverhead and memOverhead are not provided, default to defaultCPUOverhead and defaultMemOverhead
+		runtimeClassParts := strings.Split(runtimeClass, ":")
+		cpuOverhead := defaultCPUOverhead
+		memoryOverhead := defaultMemoryOverhead
+		if len(runtimeClassParts) == 3 {
+			cpuOverhead = runtimeClassParts[1]
+			memoryOverhead = runtimeClassParts[2]
+		}
+
+		runtimeClassConfigs = append(runtimeClassConfigs, RuntimeClassConfig{
+			// Trim white spaces in the runtimeClass name
+			ClassName:      strings.TrimSpace(runtimeClassParts[0]),
+			CPUOverhead:    cpuOverhead,
+			MemoryOverhead: memoryOverhead,
+		})
+	}
+
+	// Filter out duplicates if any
+	runtimeClassConfigs = removeDuplicates(runtimeClassConfigs)
+
+	return runtimeClassConfigs
+}
+
+// Method to create the runtimeClass objects
+func (r *KataConfigOpenShiftReconciler) createRuntimeClasses(runtimeClassConfigs []RuntimeClassConfig) error {
+	for _, config := range runtimeClassConfigs {
+		rc := func() *nodeapi.RuntimeClass {
+			rc := &nodeapi.RuntimeClass{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "node.k8s.io/v1",
+					Kind:       "RuntimeClass",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.ClassName,
+				},
+				Handler: config.ClassName,
+				Overhead: &nodeapi.Overhead{
+					PodFixed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse(config.CPUOverhead),
+						corev1.ResourceMemory: resource.MustParse(config.MemoryOverhead),
+					},
+				},
+			}
+
+			nodeSelector := r.getNodeSelectorAsMap()
+
+			rc.Scheduling = &nodeapi.Scheduling{
+				NodeSelector: nodeSelector,
+			}
+
+			r.Log.Info("RuntimeClass NodeSelector:", "nodeSelector", nodeSelector)
+
+			return rc
+		}()
+
+		if err := controllerutil.SetControllerReference(r.kataConfig, rc, r.Scheme); err != nil {
+			return err
+		}
+
+		foundRc := &nodeapi.RuntimeClass{}
+		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: rc.Name}, foundRc)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+
+			r.Log.Info("Creating a new RuntimeClass", "rc.Name", rc.Name)
+			err = r.Client.Create(context.TODO(), rc)
+			// We are not checking for k8serrors.IsAlreadyExists error here
+			// since we are checking for existing runtimeClass above.
+			if err != nil {
+				return err
+			}
+
+		}
+
+		// If the runtimeClass is not present in the KataConfig status field, add it
+		r.Log.Info("RuntimeClass created", "rc.Name", rc.Name)
+
+		if !contains(r.kataConfig.Status.RuntimeClasses, config.ClassName) {
+			r.kataConfig.Status.RuntimeClasses = append(r.kataConfig.Status.RuntimeClasses, config.ClassName)
+		}
+
+	}
+
+	return nil
+}
+
+// Method to create default runtimeClass object
+func (r *KataConfigOpenShiftReconciler) createDefaultRuntimeClass() error {
+	return r.createRuntimeClasses([]RuntimeClassConfig{
+		{
+			ClassName:      defaultRuntimeClassName,
+			CPUOverhead:    defaultCPUOverhead,
+			MemoryOverhead: defaultMemoryOverhead,
+		},
+	})
+
+}
+
+// Method to create default runtimeClass for peer pods
+func (r *KataConfigOpenShiftReconciler) createPeerPodsRuntimeClass() error {
+	return r.createRuntimeClasses([]RuntimeClassConfig{
+		{
+			ClassName:      peerpodsRuntimeClassName,
+			CPUOverhead:    peerpodsRuntimeClassCpuOverhead,
+			MemoryOverhead: peerpodsRuntimeClassMemOverhead,
+		},
+	})
+}
+
+// Method to delete the runtimeClass objects
+func (r *KataConfigOpenShiftReconciler) deleteRuntimeClasses(runtimeClassNames []string) error {
+	for _, rcName := range runtimeClassNames {
+		rc := &nodeapi.RuntimeClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rcName,
+			},
+		}
+		r.Log.Info("Deleting RuntimeClass", "rcName", rcName)
+		if err := r.Client.Delete(context.TODO(), rc); err != nil {
+			if errors.IsNotFound(err) {
+				// If the RuntimeClass is not found, it may have been deleted already. Continue to the next one.
+				continue
+			}
+			return fmt.Errorf("failed to delete RuntimeClass %s: %v", rcName, err)
+		}
+		// Remove the runtimeClass from the r.kataConfig.Status.RuntimeClasses field
+		if contains(r.kataConfig.Status.RuntimeClasses, rcName) {
+			r.kataConfig.Status.RuntimeClasses = remove(r.kataConfig.Status.RuntimeClasses, rcName)
+		}
+
+	}
+	return nil
+}
+
+// Method to check and handle additional runtimeClasses
+func (r *KataConfigOpenShiftReconciler) handleAdditionalRuntimeClasses() error {
+	// If additionalRuntimeClass feature is enabled, create additional runtime classes
+	if r.FeatureGatesStatus[featuregates.AdditionalRuntimeClasses] {
+		// Check if AdditionalRuntimeClasses config is provided
+		// If not log an error and return
+		if !r.FeatureGates.IsFeatureConfigMapPresent(context.TODO(), featuregates.AdditionalRuntimeClasses) {
+			r.Log.Info("AdditionalRuntimeClasses feature is enabled but no configuration provided")
+			err := fmt.Errorf("AdditionalRuntimeClasses feature is enabled but no configuration provided")
+			return err
+		}
+
+		r.Log.Info("create additional runtime classes")
+		runtimeClassConfigs := r.getRuntimeClassConfigs()
+		if len(runtimeClassConfigs) > 0 {
+
+			// Get the runtimeClassConfigs that should exist on the cluster
+			finalRuntimeClassConfigs := r.getRuntimeClassConfigsThatShouldExist(runtimeClassConfigs)
+
+			// Create or delete runtimeClasses
+			err := r.createOrDeleteRuntimeClasses(finalRuntimeClassConfigs)
+			if err != nil {
+				return err
+			}
+
+		} else {
+			r.Log.Info("no additional runtime classes to create")
+		}
+		r.Log.Info("additional runtime classes created")
+	} else {
+		// If AdditionalRuntimeClasses is disabled and KataConfig status field has multiple runtimeClasses then
+		// we need to delete those additional runtimeClasses
+
+		// Get the runtimeClassConfigs that should exist on the cluster
+		finalRuntimeClassConfigs := r.getRuntimeClassConfigsThatShouldExist(nil)
+
+		// Create or delete runtimeClasses
+		err := r.createOrDeleteRuntimeClasses(finalRuntimeClassConfigs)
+		if err != nil {
+			return err
+		}
+
+		r.Log.Info("additional runtime classes removed from KataConfig status")
+
+	}
+	return nil
+}
+
+// getRuntimeClassConfigsThatShouldExist returns the runtimeClasses that should exist on the cluster
+func (r *KataConfigOpenShiftReconciler) getRuntimeClassConfigsThatShouldExist(runtimeClassConfigs []RuntimeClassConfig) []RuntimeClassConfig {
+	finalRuntimeClassConfigs := make([]RuntimeClassConfig, 0)
+
+	// Always include default runtimeClass "kata"
+	finalRuntimeClassConfigs = append(finalRuntimeClassConfigs, RuntimeClassConfig{
+		ClassName:      defaultRuntimeClassName,
+		CPUOverhead:    defaultCPUOverhead,
+		MemoryOverhead: defaultMemoryOverhead,
+	})
+
+	// Include runtimeClass "kata-remote" if peer pods are enabled
+	if r.kataConfig.Spec.EnablePeerPods {
+		finalRuntimeClassConfigs = append(finalRuntimeClassConfigs, RuntimeClassConfig{
+			ClassName:      peerpodsRuntimeClassName,
+			CPUOverhead:    peerpodsRuntimeClassCpuOverhead,
+			MemoryOverhead: peerpodsRuntimeClassMemOverhead,
+		})
+	}
+
+	// Add runtimeClassConfigs if present
+	if runtimeClassConfigs != nil {
+		finalRuntimeClassConfigs = append(finalRuntimeClassConfigs, runtimeClassConfigs...)
+	}
+
+	return finalRuntimeClassConfigs
+}
+
+// Method to create or delete runtimeClasses
+// It should delete runtimeClasses that are not in the KataConfig status field
+func (r *KataConfigOpenShiftReconciler) createOrDeleteRuntimeClasses(runtimeClassConfigs []RuntimeClassConfig) error {
+
+	// Create the runtimeClasses. If the runtimeClass already exists, it will be skipped
+	err := r.createRuntimeClasses(runtimeClassConfigs)
+	if err != nil {
+		return err
+	}
+
+	// Get the list of runtimeClasses that should not exist on the system
+	runtimeClassNamesToDelete := r.getRuntimeClassNamesToDelete(runtimeClassConfigs)
+
+	// Delete the runtimeClasses that should not exist on the system
+	err = r.deleteRuntimeClasses(runtimeClassNamesToDelete)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Method to find out which runtimeClasses to Delete
+func (r *KataConfigOpenShiftReconciler) getRuntimeClassNamesToDelete(runtimeClassConfigs []RuntimeClassConfig) []string {
+	// Get the runtimeClassNames that should exist on the system
+	runtimeClassNames := getRuntimeClassNames(runtimeClassConfigs)
+
+	// Get the runtimeClassNames that are present in the KataConfig status field
+	// This is faster than getting the runtimeClasses from the Kube API
+	// The runtimeClasses in the KataConfig status field are updated when the runtimeClasses are created or deleted anyway
+	runtimeClassNamesInStatus := r.kataConfig.Status.RuntimeClasses
+
+	// Find out which runtimeClasses to delete
+	runtimeClassNamesToDelete := []string{}
+	for _, rc := range runtimeClassNamesInStatus {
+		if !contains(runtimeClassNames, rc) {
+			runtimeClassNamesToDelete = append(runtimeClassNamesToDelete, rc)
+		}
+	}
+
+	return runtimeClassNamesToDelete
+}
+
+// Method to remove duplicates in RuntimeClassConfig struct based on ClassName field
+// Search for matching ClassName in the array and remove duplicates
+func removeDuplicates(runtimeClassConfigs []RuntimeClassConfig) []RuntimeClassConfig {
+	encountered := map[string]bool{}
+	result := []RuntimeClassConfig{}
+
+	for v := range runtimeClassConfigs {
+		if encountered[runtimeClassConfigs[v].ClassName] {
+			// Do not add duplicate
+		} else {
+			encountered[runtimeClassConfigs[v].ClassName] = true
+			result = append(result, runtimeClassConfigs[v])
+		}
+	}
+	return result
+}
+
+// Method to get runtimeClassNames array from RuntimeClassConfigs
+func getRuntimeClassNames(runtimeClassConfigs []RuntimeClassConfig) []string {
+	var runtimeClassNames []string
+	for _, rc := range runtimeClassConfigs {
+		runtimeClassNames = append(runtimeClassNames, rc.ClassName)
+	}
+	return runtimeClassNames
+}
+
+// Method to remove runtimeClassName from the runtimeClassNames array
+func remove(runtimeClassNames []string, runtimeClassName string) []string {
+	var result []string
+	for _, rc := range runtimeClassNames {
+		if rc != runtimeClassName {
+			result = append(result, rc)
+		}
+	}
+	return result
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -73,9 +72,11 @@ func parseJobYAML(yamlData []byte) (*batchv1.Job, error) {
 	return job, nil
 }
 
-func readJobYAML(jobFileName string) ([]byte, error) {
-	jobFilePath := filepath.Join(peerpodsImageJobsPathLocation, jobFileName)
-	yamlData, err := os.ReadFile(jobFilePath)
+// Method to read yaml file.
+// The full path of the job yaml file is passed as an argument
+// Returns the yaml data and an error
+func readYamlFile(yamlFile string) ([]byte, error) {
+	yamlData, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return nil, err
 	}
@@ -91,15 +92,6 @@ func parseMachineConfigYAML(yamlData []byte) (*mcfgv1.MachineConfig, error) {
 	return machineConfig, nil
 }
 
-func readMachineConfigYAML(mcFileName string) ([]byte, error) {
-	machineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, mcFileName)
-	yamlData, err := os.ReadFile(machineConfigFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
-}
-
 func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, error) {
 	credentialsRequest := &ccov1.CredentialsRequest{}
 	err := yaml.Unmarshal(yamlData, credentialsRequest)
@@ -107,26 +99,6 @@ func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, er
 		return nil, err
 	}
 	return credentialsRequest, nil
-}
-
-func readCredentialsRequestYAML(crFileName string) ([]byte, error) {
-	credentialsRequestsFilePath := filepath.Join(peerpodsCredentialsRequestsPathLocation, crFileName)
-	yamlData, err := os.ReadFile(credentialsRequestsFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
-}
-
-// Method to read config map yaml
-
-func readConfigMapYAML(cmFileName string) ([]byte, error) {
-	configMapFilePath := filepath.Join(peerpodsImageJobsPathLocation, cmFileName)
-	yamlData, err := os.ReadFile(configMapFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
 }
 
 // Method to parse config map yaml

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
+	k8s.io/cri-api v0.23.1
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/controller-tools v0.11.3
 )
@@ -145,7 +146,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
-	k8s.io/cri-api v0.23.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/cri-api v0.23.1
+	k8s.io/kubectl v0.22.1
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/controller-tools v0.11.3
 )
@@ -61,6 +62,7 @@ require (
 	github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,7 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
@@ -3067,6 +3068,7 @@ k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2R
 k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5OhxCKlKJy0sHc+PcDwFB24dQ=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
+k8s.io/kubectl v0.22.1 h1:kpXO+ajPNTzAVLDM9pAzCsWH9MtCMr92zpcvXMt7P6E=
 k8s.io/kubectl v0.22.1/go.mod h1:mjAOgEbMNMtZWxnfM6jd+nPjPsaoLqO5xanc78WcSbw=
 k8s.io/kubelet v0.22.1/go.mod h1:rZuP1msr5NH7IGApW60DYFR3Cs3On4ftWLMJRfg+iU4=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/internal/featuregates/featuregates.go
+++ b/internal/featuregates/featuregates.go
@@ -26,31 +26,6 @@ var DefaultFeatureGates = map[string]bool{
 
 var fgLogger logr.Logger = ctrl.Log.WithName("featuregates")
 
-func (fg *FeatureGates) IsEnabled(ctx context.Context, feature string) bool {
-	if fg == nil {
-		return false
-	}
-	cfgMap := &corev1.ConfigMap{}
-	err := fg.Client.Get(ctx,
-		client.ObjectKey{Name: fg.ConfigMapName, Namespace: fg.Namespace},
-		cfgMap)
-
-	if err != nil {
-		fgLogger.Info("Error fetching feature gates", "err", err)
-	} else {
-		if value, exists := cfgMap.Data[feature]; exists {
-			fgLogger.Info("Feature gate enabled", "feature", feature)
-			return value == "true"
-		}
-	}
-
-	defaultValue, exists := DefaultFeatureGates[feature]
-	if exists {
-		return defaultValue
-	}
-	return false
-}
-
 // Method to read the feature specific config parameters from the configmap
 // The feature specific config params are stored in their own configmap like this
 // data: |

--- a/internal/featuregates/featuregates.go
+++ b/internal/featuregates/featuregates.go
@@ -19,7 +19,7 @@ type FeatureGates struct {
 // FeatureGate Status Struct map of string and bool
 type FeatureGateStatus map[string]bool
 
-var DefaultFeatureGates = map[string]bool{
+var DefaultFeatureGatesStatus = map[string]bool{
 	LayeredImageDeployment:   false,
 	AdditionalRuntimeClasses: false,
 }
@@ -74,7 +74,7 @@ func (fg *FeatureGates) GetFeatureGateStatus(ctx context.Context) FeatureGateSta
 	}
 
 	// Populate the status struct with the default values for the feature gates which are not present in the configmap
-	for key, value := range DefaultFeatureGates {
+	for key, value := range DefaultFeatureGatesStatus {
 		if _, exists := featureGateStatus[key]; !exists {
 			featureGateStatus[key] = value
 		}

--- a/internal/featuregates/featuregates.go
+++ b/internal/featuregates/featuregates.go
@@ -20,7 +20,8 @@ type FeatureGates struct {
 type FeatureGateStatus map[string]bool
 
 var DefaultFeatureGates = map[string]bool{
-	LayeredImageDeployment: false,
+	LayeredImageDeployment:   false,
+	AdditionalRuntimeClasses: false,
 }
 
 var fgLogger logr.Logger = ctrl.Log.WithName("featuregates")

--- a/internal/featuregates/featuregates_test.go
+++ b/internal/featuregates/featuregates_test.go
@@ -1,0 +1,98 @@
+package featuregates
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFeatureGates_GetFeatureGateParams(t *testing.T) {
+	fg := &FeatureGates{
+		Client:    fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+		Namespace: "test-namespace",
+	}
+
+	ctx := context.TODO()
+
+	t.Run("FeatureGate not found", func(t *testing.T) {
+		feature := "non-existent-feature"
+
+		params := fg.GetFeatureGateParams(ctx, feature)
+
+		if len(params) != 0 {
+			t.Errorf("Expected empty params, got: %v", params)
+		}
+	})
+
+	t.Run("FeatureGate found", func(t *testing.T) {
+		feature := "AdditionalRuntimeClasses"
+
+		cfgMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AdditionalRuntimeClassesConfig,
+				Namespace: fg.Namespace,
+			},
+			Data: map[string]string{
+				"runtimeClassConfig": "name1,name2",
+			},
+		}
+
+		err := fg.Client.Create(ctx, cfgMap)
+		if err != nil {
+			t.Fatalf("Failed to create ConfigMap: %v", err)
+		}
+
+		params := fg.GetFeatureGateParams(ctx, feature)
+
+		expectedParams := map[string]string{
+			"runtimeClassConfig": "name1,name2",
+		}
+
+		if len(params) != len(expectedParams) {
+			t.Errorf("Expected %d params, got: %d", len(expectedParams), len(params))
+		}
+
+		for key, value := range expectedParams {
+			if params[key] != value {
+				t.Errorf("Expected param %s to have value %s, got: %s", key, value, params[key])
+			}
+		}
+
+		// Clean up the created ConfigMap
+		err = fg.Client.Delete(ctx, cfgMap)
+		if err != nil {
+			t.Fatalf("Failed to delete ConfigMap: %v", err)
+		}
+	})
+
+	t.Run("FeatureGate configmap not found", func(t *testing.T) {
+		feature := "LayeredImageDeployment"
+
+		params := fg.GetFeatureGateParams(ctx, feature)
+
+		if len(params) != 0 {
+			t.Errorf("Expected empty params, got: %v", params)
+		}
+
+	})
+
+	t.Run("FeatureGate configmap not found", func(t *testing.T) {
+		feature := "LayeredImageDeployment"
+
+		params := fg.GetFeatureGateParams(ctx, feature)
+
+		if len(params) != 0 {
+			t.Errorf("Expected empty params, got: %v", params)
+		}
+
+		// Check existence of params["kernelArguments"] in the returned map
+		if _, ok := params["kernelArguments"]; ok {
+			t.Errorf("Expected empty params to not contain key 'kernelArguments'")
+		}
+
+	})
+}

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -1,5 +1,7 @@
 package featuregates
 
+import "strings"
+
 /* Design aspects of implementing feature gates
 
 - feature gate is only for experimental features
@@ -10,6 +12,7 @@ package featuregates
 
 const (
 	FeatureGatesConfigMapName = "osc-feature-gates"
+	LayeredImageDeployment    = "LayeredImageDeployment"
 )
 
 // Sample ConfigMap with Features
@@ -21,6 +24,24 @@ metadata:
   name: osc-feature-gates
   namespace: openshift-sandboxed-containers-operator
 data:
-  "timeTravel":              false,
-  "quantumEntanglementSync": false,
+  LayeredImageDeployment: "false"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: layeredimagedeployment-config
+  namespace: openshift-sandboxed-containers-operator
+data:
+  osImageURL="quay.io/...."
+  kernelArguments="a=b c=d ..."
 */
+
+// Get the feature gate configmap name from the feature gate name
+// The feature configmap is lower case of the feature name with -config suffix
+// Kubernetes expects the name to be a lowercase RFC 1123 subdomain
+func GetFeatureGateConfigMapName(feature string) string {
+
+	return strings.ToLower(feature) + "-config"
+
+}

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -11,8 +11,9 @@ import "strings"
 */
 
 const (
-	FeatureGatesConfigMapName = "osc-feature-gates"
-	LayeredImageDeployment    = "LayeredImageDeployment"
+	FeatureGatesConfigMapName    = "osc-feature-gates"
+	LayeredImageDeployment       = "LayeredImageDeployment"
+	LayeredImageDeploymentConfig = "layeredimagedeployment-config"
 )
 
 // Sample ConfigMap with Features
@@ -44,4 +45,17 @@ func GetFeatureGateConfigMapName(feature string) string {
 
 	return strings.ToLower(feature) + "-config"
 
+}
+
+// Check if the configmap is a feature gate configmap
+// We use explicit check for the feature gate configmap
+// and avoid reconstructing the feature name from configmap name
+// and do the match
+func IsFeatureGateConfigMap(configMapName string) bool {
+	switch configMapName {
+	case FeatureGatesConfigMapName, LayeredImageDeploymentConfig:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -10,11 +10,11 @@ import "strings"
 */
 
 const (
-	FeatureGatesConfigMapName      = "osc-feature-gates"
-	LayeredImageDeployment         = "LayeredImageDeployment"
-	LayeredImageDeploymentConfig   = "layeredimagedeployment-config"
-	AdditionalRuntimeClasses       = "AdditionalRuntimeClasses"
-	AdditionalRuntimeClassesConfig = "additionalruntimeclasses-config"
+	FeatureGatesStatusConfigMapName = "osc-feature-gates"
+	LayeredImageDeployment          = "LayeredImageDeployment"
+	LayeredImageDeploymentConfig    = "layeredimagedeployment-config"
+	AdditionalRuntimeClasses        = "AdditionalRuntimeClasses"
+	AdditionalRuntimeClassesConfig  = "additionalruntimeclasses-config"
 )
 
 // Sample ConfigMap with Features
@@ -66,7 +66,7 @@ func GetFeatureGateConfigMapName(feature string) string {
 // and do the match
 func IsFeatureGateConfigMap(configMapName string) bool {
 	switch configMapName {
-	case FeatureGatesConfigMapName, LayeredImageDeploymentConfig, AdditionalRuntimeClassesConfig:
+	case FeatureGatesStatusConfigMapName, LayeredImageDeploymentConfig, AdditionalRuntimeClassesConfig:
 		return true
 	default:
 		return false

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -3,7 +3,6 @@ package featuregates
 import "strings"
 
 /* Design aspects of implementing feature gates
-
 - feature gate is only for experimental features
 - Keep the feature gate as simple boolean.
 - Any config specific for a feature gate should be in it’s own configMap. This aligns with our current implementation of peer-pods and image generator feature
@@ -11,9 +10,11 @@ import "strings"
 */
 
 const (
-	FeatureGatesConfigMapName    = "osc-feature-gates"
-	LayeredImageDeployment       = "LayeredImageDeployment"
-	LayeredImageDeploymentConfig = "layeredimagedeployment-config"
+	FeatureGatesConfigMapName      = "osc-feature-gates"
+	LayeredImageDeployment         = "LayeredImageDeployment"
+	LayeredImageDeploymentConfig   = "layeredimagedeployment-config"
+	AdditionalRuntimeClasses       = "AdditionalRuntimeClasses"
+	AdditionalRuntimeClassesConfig = "additionalruntimeclasses-config"
 )
 
 // Sample ConfigMap with Features
@@ -26,16 +27,29 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 data:
   LayeredImageDeployment: "false"
+  AdditionalRuntimeClasses: "false"
+*/
 
----
+// Sample ConfigMap with configs for individual features
+/*
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: layeredimagedeployment-config
   namespace: openshift-sandboxed-containers-operator
 data:
-  osImageURL="quay.io/...."
-  kernelArguments="a=b c=d ..."
+  osImageURL: "quay.io/...."
+  kernelArguments: "a=b c=d ..."
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: additionalruntimeclasses-config
+  namespace: openshift-sandboxed-containers-operator
+data:
+  runtimeClassConfig: "name1:cpuOverHead1:memOverHead1, name2:cpuOverHead2:memOverHead2"
+  #runtimeClassConfig: "name1, name2"
 */
 
 // Get the feature gate configmap name from the feature gate name
@@ -44,7 +58,6 @@ data:
 func GetFeatureGateConfigMapName(feature string) string {
 
 	return strings.ToLower(feature) + "-config"
-
 }
 
 // Check if the configmap is a feature gate configmap
@@ -53,7 +66,7 @@ func GetFeatureGateConfigMapName(feature string) string {
 // and do the match
 func IsFeatureGateConfigMap(configMapName string) bool {
 	switch configMapName {
-	case FeatureGatesConfigMapName, LayeredImageDeploymentConfig:
+	case FeatureGatesConfigMapName, LayeredImageDeploymentConfig, AdditionalRuntimeClassesConfig:
 		return true
 	default:
 		return false

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -1,0 +1,26 @@
+package featuregates
+
+/* Design aspects of implementing feature gates
+
+- feature gate is only for experimental features
+- Keep the feature gate as simple boolean.
+- Any config specific for a feature gate should be in it’s own configMap. This aligns with our current implementation of peer-pods and image generator feature
+- When we decide to make the feature as a stable feature, it should move to kataConfig.spec
+*/
+
+const (
+	FeatureGatesConfigMapName = "osc-feature-gates"
+)
+
+// Sample ConfigMap with Features
+
+/*
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osc-feature-gates
+  namespace: openshift-sandboxed-containers-operator
+data:
+  "timeTravel":              false,
+  "quantumEntanglementSync": false,
+*/

--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func main() {
 			FeatureGates: &featuregates.FeatureGates{
 				Client:        mgr.GetClient(),
 				Namespace:     OperatorNamespace,
-				ConfigMapName: featuregates.FeatureGatesConfigMapName,
+				ConfigMapName: featuregates.FeatureGatesStatusConfigMapName,
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create KataConfig controller for OpenShift cluster", "controller", "KataConfig")

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 			FeatureGates: &featuregates.FeatureGates{
 				Client:        mgr.GetClient(),
 				Namespace:     OperatorNamespace,
-				ConfigMapName: "osc-feature-gates",
+				ConfigMapName: featuregates.FeatureGatesConfigMapName,
 			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create KataConfig controller for OpenShift cluster", "controller", "KataConfig")


### PR DESCRIPTION
This is a feature enhancement adding two feature gates which typically goes together.
- Image based deployment and additional runtimeClasses
An example configmap enabling the feature
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: osc-feature-gates
  namespace: openshift-sandboxed-containers-operator
data:
  LayeredImageDeployment: "false"
  AdditionalRuntimeClasses: "false"
```

Sample ConfigMap with configs for individual features
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: layeredimagedeployment-config
  namespace: openshift-sandboxed-containers-operator
data:
  osImageURL: "quay.io/bpradipt/coco:ocp415"
  kernelArguments: "kvm_intel.tdx=1"
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: additionalruntimeclasses-config
  namespace: openshift-sandboxed-containers-operator
data:
  runtimeClassConfig: "kata-cc-tdx, kata-cc-sim"
```

This code can be tested on an OCP cluster by following the instructions from this repo:
https://github.com/bpradipt/coco-install/tree/main/osc-image-deploy
SNO should be fine as well for testing.

