### PR TITLE
Fix the podvm-payload image references on `release-1.5` branch

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,13 +77,16 @@ spec:
         - name: PEERPODS_NAMESPACE
           value: "openshift-sandboxed-containers-operator"
         - name: RELATED_IMAGE_KATA_MONITOR
-          value: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-monitor:latest
+          value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.5.3
         - name: SANDBOXED_CONTAINERS_EXTENSION
           value: kata-containers
         - name: RELATED_IMAGE_CAA
-          value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:latest
+          value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.5.3
         - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-          value: "quay.io/confidential-containers/peer-pods-webhook:latest" 
+          value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.5.3
+        - name: RELATED_IMAGE_PODVM_PAYLOAD
+          value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.3
+
         imagePullPolicy: Always
         resources:
           limits:

--- a/config/peerpods/podvm/aws-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/aws-VM-image-create-job.yaml
@@ -20,7 +20,7 @@ spec:
 
       initContainers:
       - name: payload
-        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.3
         imagePullPolicy: Always
         volumeMounts:
         - name: shared-data

--- a/config/peerpods/podvm/azure-VM-image-create-job.yaml
+++ b/config/peerpods/podvm/azure-VM-image-create-job.yaml
@@ -19,7 +19,7 @@ spec:
 
       initContainers:
       - name: payload
-        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.3
         imagePullPolicy: Always
         volumeMounts:
         - name: shared-data


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**


Fixes: [KATA-2898](https://issues.redhat.com//browse/KATA-2898)
Fixes: [KATA-2899](https://issues.redhat.com//browse/KATA-2899)

**- What I did**

`git cherry-pick c783681e4c5422c68ca2d6e3c0bdb9be5ca51565` and referenced related jiras.

**- How to verify it**

- Checkout this PR
- Same change as c783681e4c5422c68ca2d6e3c0bdb9be5ca51565