### PR TITLE
Fix CSV for 1.5.3

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,9 +13,15 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=1.1.0 <1.5.3'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
-    operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -365,6 +365,7 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
+  replaces: sandboxed-containers-operator.v1.5.2
   version: 1.5.3
   webhookdefinitions:
   - admissionReviewVersions:


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

This brings changes of #398 and #399 to 1.5.3.

Fixes: [KATA-2876](https://issues.redhat.com//browse/KATA-2876)

**- What I did**

`git cherry-pick -sx 696aef2b492a1f3ab78b33c1a365b904dac80e51` and adpated version to 1.5.3
`git cherry-pick -sx 02086163095a8e97df209f3bbbd3d5d8293842e2` and fixed a trivial context conflict

**- How to verify it**

- Checkout the PR
- Verify that CSV was converted from `operators.openshift.io/infrastructure-features` to `features.operators.openshift.io` 
- Verify that CSV has the `replaces: sandboxed-containers-operator.v1.5.2`  required by `olm.skipRange: '>=1.1.0 <1.5.3'`