### PR TITLE
Remove duplicate code for reading yamls

### DIFF
--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -293,7 +294,8 @@ func (kh *KataConfigHandler) getCredentialsRequest() (*v1.CredentialsRequest, er
 	}
 
 	fileName := fmt.Sprintf(peerpodsCredentialsRequestFileFormat, provider)
-	yamlData, err := readCredentialsRequestYAML(fileName)
+	credentialsRequestsYamlFile := filepath.Join(peerpodsCredentialsRequestsPathLocation, fileName)
+	yamlData, err := readYamlFile(credentialsRequestsYamlFile)
 	if os.IsNotExist(err) {
 		kh.reconciler.Log.Info("no CredentialsRequestYAML for provider", "err", err, "provider", provider)
 		return nil, nil
@@ -324,7 +326,8 @@ func (kh *KataConfigHandler) skipCredentialRequests() bool {
 	// check if CredentialsRequest implementation exists for the cloud provider
 	if provider, err := getCloudProviderFromInfra(kh.reconciler.Client); err == nil {
 		fileName := fmt.Sprintf(peerpodsCredentialsRequestFileFormat, provider)
-		if _, err := readCredentialsRequestYAML(fileName); os.IsNotExist(err) {
+		credentialsRequestsYamlFile := filepath.Join(peerpodsCredentialsRequestsPathLocation, fileName)
+		if _, err := readYamlFile(credentialsRequestsYamlFile); os.IsNotExist(err) {
 			kh.reconciler.Log.Info("no CredentialsRequest yaml file for provider, skipping", "provider", provider, "filename", fileName)
 			return true
 		}

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -242,7 +243,9 @@ func newImageGenerator(client client.Client) (*ImageGenerator, error) {
 func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, error) {
 	igLogger.Info("Create Job out of YAML file", "jobFileName", jobFileName)
 
-	yamlData, err := readJobYAML(jobFileName)
+	jobYamlFile := filepath.Join(peerpodsImageJobsPathLocation, jobFileName)
+
+	yamlData, err := readYamlFile(jobYamlFile)
 	if err != nil {
 		return nil, err
 	}
@@ -630,7 +633,8 @@ func (r *ImageGenerator) createImageConfigMapFromFile() error {
 	}
 
 	filename := r.provider + "-podvm-image-cm.yaml"
-	yamlData, err := readConfigMapYAML(filename)
+	configMapYamlFile := filepath.Join(peerpodsImageJobsPathLocation, filename)
+	yamlData, err := readYamlFile(configMapYamlFile)
 	if err != nil {
 		return err
 	}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -2179,14 +2180,16 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 func (r *KataConfigOpenShiftReconciler) enablePeerPodsMc() error {
 
 	//Create MachineConfig for kata-remote hyp CRIO config
-	err := r.createMcFromFile(peerpodsCrioMachineConfigYaml)
+	crioMachineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, peerpodsCrioMachineConfigYaml)
+	err := r.createMcFromFile(crioMachineConfigFilePath)
 	if err != nil {
 		r.Log.Info("Error in creating CRIO MachineConfig", "err", err)
 		return err
 	}
 
 	//Create MachineConfig for kata-remote hyp config toml
-	err = r.createMcFromFile(peerpodsKataRemoteMachineConfigYaml)
+	kataConfigMachineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, peerpodsKataRemoteMachineConfigYaml)
+	err = r.createMcFromFile(kataConfigMachineConfigFilePath)
 	if err != nil {
 		r.Log.Info("Error in creating kata remote configuration.toml MachineConfig", "err", err)
 		return err
@@ -2326,10 +2329,12 @@ func (r *KataConfigOpenShiftReconciler) disablePeerPods() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createMcFromFile(mcFileName string) error {
-	yamlData, err := readMachineConfigYAML(mcFileName)
+// Create the MachineConfigs from file
+// Full path of the file should be provided
+func (r *KataConfigOpenShiftReconciler) createMcFromFile(machineConfigYamlFile string) error {
+	yamlData, err := readYamlFile(machineConfigYamlFile)
 	if err != nil {
-		r.Log.Info("Error in reading MachineConfigYaml", "mcFileName", mcFileName, "err", err)
+		r.Log.Info("Error in reading MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
 		return err
 	}
 
@@ -2337,7 +2342,7 @@ func (r *KataConfigOpenShiftReconciler) createMcFromFile(mcFileName string) erro
 
 	machineConfig, err := parseMachineConfigYAML(yamlData)
 	if err != nil {
-		r.Log.Info("Error in parsing MachineConfigYaml", "mcFileName", mcFileName, "err", err)
+		r.Log.Info("Error in parsing MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
 		return err
 	}
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -73,9 +72,11 @@ func parseJobYAML(yamlData []byte) (*batchv1.Job, error) {
 	return job, nil
 }
 
-func readJobYAML(jobFileName string) ([]byte, error) {
-	jobFilePath := filepath.Join(peerpodsImageJobsPathLocation, jobFileName)
-	yamlData, err := os.ReadFile(jobFilePath)
+// Method to read yaml file.
+// The full path of the yaml file is passed as an argument
+// Returns the yaml data and an error
+func readYamlFile(yamlFile string) ([]byte, error) {
+	yamlData, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return nil, err
 	}
@@ -91,15 +92,6 @@ func parseMachineConfigYAML(yamlData []byte) (*mcfgv1.MachineConfig, error) {
 	return machineConfig, nil
 }
 
-func readMachineConfigYAML(mcFileName string) ([]byte, error) {
-	machineConfigFilePath := filepath.Join(peerpodsMachineConfigPathLocation, mcFileName)
-	yamlData, err := os.ReadFile(machineConfigFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
-}
-
 func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, error) {
 	credentialsRequest := &ccov1.CredentialsRequest{}
 	err := yaml.Unmarshal(yamlData, credentialsRequest)
@@ -107,26 +99,6 @@ func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, er
 		return nil, err
 	}
 	return credentialsRequest, nil
-}
-
-func readCredentialsRequestYAML(crFileName string) ([]byte, error) {
-	credentialsRequestsFilePath := filepath.Join(peerpodsCredentialsRequestsPathLocation, crFileName)
-	yamlData, err := os.ReadFile(credentialsRequestsFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
-}
-
-// Method to read config map yaml
-
-func readConfigMapYAML(cmFileName string) ([]byte, error) {
-	configMapFilePath := filepath.Join(peerpodsImageJobsPathLocation, cmFileName)
-	yamlData, err := os.ReadFile(configMapFilePath)
-	if err != nil {
-		return nil, err
-	}
-	return yamlData, nil
 }
 
 // Method to parse config map yaml


### PR DESCRIPTION
We had different methods to read yaml files depending on the kubernetes object. However this is really not needed as all the methods simply were reading files with the only difference being the file location.
This commit simplifies the code and uses a single readYamlFile method. The caller should set the full path of the yaml file to be read. Further any additional requirements to read different yaml files will no longer need a new method

