### PR TITLE
Add separate event handler for configmap updates

### DIFF
--- a/controllers/cm_event_handler.go
+++ b/controllers/cm_event_handler.go
@@ -1,0 +1,82 @@
+package controllers
+
+import (
+	"context"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+type ConfigMapEventHandler struct {
+	reconciler *KataConfigOpenShiftReconciler
+}
+
+func (ch *ConfigMapEventHandler) Create(ctx context.Context, event event.CreateEvent, queue workqueue.RateLimitingInterface) {
+
+	if ch.reconciler.kataConfig == nil {
+		return
+	}
+
+	cm := event.Object
+
+	// Check if the configMap name is relevant to the operator
+	if cm.GetNamespace() != OperatorNamespace || !isConfigMapRelevant(cm.GetName()) {
+		return
+	}
+	log := ch.reconciler.Log.WithName("CMCreate").WithValues("cm name", cm.GetName())
+	log.Info("FeatureGates configMap created")
+
+	queue.Add(ch.reconciler.makeReconcileRequest())
+}
+
+func (ch *ConfigMapEventHandler) Update(ctx context.Context, event event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+
+	if ch.reconciler.kataConfig == nil {
+		return
+	}
+
+	cm := event.ObjectNew
+	cmOld := event.ObjectOld
+
+	// Check if the configMap name is relevant to the operator
+	if cm.GetNamespace() != OperatorNamespace || !isConfigMapRelevant(cm.GetName()) {
+		return
+	}
+
+	log := ch.reconciler.Log.WithName("CMUpdate").WithValues("cm name", cm.GetName())
+	log.Info("FeatureGates configMap updated")
+
+	// Check if the configMap data has actually changed
+	// Otherwise we don't need to do anything
+	dataOld := cmOld.DeepCopyObject().(*corev1.ConfigMap).Data
+	dataNew := cm.DeepCopyObject().(*corev1.ConfigMap).Data
+	if reflect.DeepEqual(dataOld, dataNew) {
+		log.Info("No change in configMap data")
+		return
+	}
+
+	queue.Add(ch.reconciler.makeReconcileRequest())
+
+}
+
+func (ch *ConfigMapEventHandler) Delete(ctx context.Context, event event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	if ch.reconciler.kataConfig == nil {
+		return
+	}
+
+	cm := event.Object
+
+	/// Check if the configMap name is relevant to the operator
+	if cm.GetNamespace() != OperatorNamespace || !isConfigMapRelevant(cm.GetName()) {
+		return
+	}
+	log := ch.reconciler.Log.WithName("CMDelete").WithValues("cm name", cm.GetName())
+	log.Info("FeatureGates configMap deleted")
+
+	queue.Add(ch.reconciler.makeReconcileRequest())
+}
+
+func (ch *ConfigMapEventHandler) Generic(ctx context.Context, event event.GenericEvent, queue workqueue.RateLimitingInterface) {
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	peerPodsSecretName = "peer-pods-secret"
+	FeatureGatesCM     = "osc-feature-gates"
 )
 
 // Define a struct to represent event information
@@ -173,4 +174,9 @@ func getCloudProviderFromInfra(c client.Client) (string, error) {
 	}
 
 	return strings.ToLower(string(infrastructure.Status.PlatformStatus.Type)), nil
+}
+
+// Method to check if the configMap is relevant for the operator
+func isConfigMapRelevant(configMapName string) bool {
+	return configMapName == FeatureGatesCM
 }


### PR DESCRIPTION
With the previous code of predicate func, the reconcile loop was not receiving the KataConfig struct. Instead the reconcile loop was called with the OSC featuregate configmap.

The new method ensures that for featuregate configMap changes, the reconcile loop is called with the KataConfig struct.
