### PR TITLE
Handle processing of a sample featuregate

### DIFF
--- a/config/samples/featuregates.yaml
+++ b/config/samples/featuregates.yaml
@@ -8,15 +8,3 @@ data:
   # It is useful for scenarios where you want to view historical data or
   # predict future states based on current trends. Default is "false".
   # timeTravel: "false"
-
-  # quantumEntanglementSync enables instant state consistency across clusters
-  # using principles of quantum mechanics. This advanced feature ensures
-  # data is synchronized across different locations without traditional
-  # network latency. Default is "false".
-  # quantumEntanglementSync: "false"
-
-  # autoHealingWithAI employs artificial intelligence to automatically
-  # detect and resolve cluster issues. It leverages machine learning algorithms
-  # to predict potential problems before they occur, ensuring high availability.
-  # Default is "true".
-  # autoHealingWithAI: "true"

--- a/controllers/fg_handler.go
+++ b/controllers/fg_handler.go
@@ -1,0 +1,52 @@
+package controllers
+
+import (
+	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
+)
+
+// Create enum to represent the state of the feature gates
+type FeatureGateState int
+
+const (
+	Enabled FeatureGateState = iota
+	Disabled
+)
+
+// Function to handle the feature gates
+func (r *KataConfigOpenShiftReconciler) processFeatureGates() error {
+
+	fgStatus, err := featuregates.NewFeatureGateStatus(r.Client)
+	if err != nil {
+		r.Log.Info("There were errors in getting feature gate status.", "err", err)
+		return err
+	}
+
+	// Check which feature gates are enabled in the FG ConfigMap and
+	// perform the necessary actions
+	// The feature gates are defined in internal/featuregates/featuregates.go
+	// and are fetched from the ConfigMap in the namespace
+	// Eg. TimeTravelFeatureGate
+
+	if featuregates.IsEnabled(fgStatus, featuregates.TimeTravelFeatureGate) {
+		r.Log.Info("Feature gate is enabled", "featuregate", featuregates.TimeTravelFeatureGate)
+		// Perform the necessary actions
+		r.handleTimeTravelFeature(Enabled)
+	} else {
+		r.Log.Info("Feature gate is disabled", "featuregate", featuregates.TimeTravelFeatureGate)
+		// Perform the necessary actions
+		r.handleTimeTravelFeature(Disabled)
+	}
+
+	return err
+
+}
+
+// Function to handle the TimeTravel feature gate
+func (r *KataConfigOpenShiftReconciler) handleTimeTravelFeature(state FeatureGateState) {
+	// Perform the necessary actions for the TimeTravel feature gate
+	if state == Enabled {
+		r.Log.Info("Starting TimeTravel")
+	} else {
+		r.Log.Info("Stopping TimeTravel")
+	}
+}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -36,7 +36,6 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
-	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
 	corev1 "k8s.io/api/core/v1"
 	nodeapi "k8s.io/api/node/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,8 +60,7 @@ type KataConfigOpenShiftReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 
-	kataConfig   *kataconfigurationv1.KataConfig
-	FeatureGates *featuregates.FeatureGates
+	kataConfig *kataconfigurationv1.KataConfig
 }
 
 const (
@@ -123,8 +121,10 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	if r.FeatureGates.IsEnabled(ctx, "timeTravel") {
-		r.Log.Info("TimeTravel feature is enabled. Performing feature-specific logic...")
+	err = r.processFeatureGates()
+	if err != nil {
+		r.Log.Info("Unable to process feature gates", "err", err)
+		return ctrl.Result{}, err
 	}
 
 	return func() (ctrl.Result, error) {

--- a/docs/FEATURE-GATES.md
+++ b/docs/FEATURE-GATES.md
@@ -2,9 +2,26 @@
 
 Feature Gates in the Openshift Sandboxed Containers operator allow
 administrators to enable or disable specific features. These features are
-controlled through the `FeatureGates` struct in the operator's configuration,
+controlled through the feature gates configmap (`osc-feature-gates`),
 providing a flexible approach to testing new features and managing the rollout
 of stable functionalities.
+
+## Design choices
+
+The feature gates are handled within the KataConfig reconcile loop.  If there
+are any errors with feature gate processing, the reconciliation process
+continues and doesn't re-queue.  In case of any errors in determining whether a
+feature gate is enabled or not (for example if the configMap is deleted or some
+other API server errors), the processing of the  feature gate is same as the
+default compiled in state of the respective feature gate.
+
+The status of individual feature gates is stored in the `FeatureGateStatus`
+struct that is populated in the beginning of the reconcile loop with the status
+of the feature gates from the  configMap. This ensures that the entire feature
+gate configMap is only read once from the API server instead of making repeated
+calls to the API server for checking individual feature gates.
+Any errors in reading the configMap from the API server will requeue a reconciliation request,
+except for when configMap is not found.
 
 ## Maturity Levels
 
@@ -41,7 +58,10 @@ adjusting your cluster's behavior as needed.
 
 ### Enabling and disabling features
 
-To enable a feature, you modify your `ConfigMap` object like so:
+A feature is enabled by explicitly setting it's value to `"true"` (case sensitive)
+and disabled by setting it's value to `"false"` (case sensitive)
+
+To enable a feature, you modify the `ConfigMap` object like so:
 
 ```yaml
 apiVersion: v1
@@ -51,11 +71,8 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 data:
   timeTravel: "true"
-  quantumEntanglementSync: "false"
-  autoHealingWithAI: "true"
 ```
 
-In this example, `timeTravel` is explicitly enabled, while
-`quantumEntanglementSync` is disabled, and `autoHealingWithAI` is enabled,
+In this example, `timeTravel` is explicitly enabled,
 showcasing how to manage the state of each feature individually. Regardless the
 default values they have.

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ import (
 
 	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
 	"github.com/openshift/sandboxed-containers-operator/controllers"
-	"github.com/openshift/sandboxed-containers-operator/internal/featuregates"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -143,11 +142,6 @@ func main() {
 			Client: mgr.GetClient(),
 			Log:    ctrl.Log.WithName("controllers").WithName("KataConfig"),
 			Scheme: mgr.GetScheme(),
-			FeatureGates: &featuregates.FeatureGates{
-				Client:        mgr.GetClient(),
-				Namespace:     OperatorNamespace,
-				ConfigMapName: "osc-feature-gates",
-			},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create KataConfig controller for OpenShift cluster", "controller", "KataConfig")
 			os.Exit(1)


### PR DESCRIPTION
Few key things to note
- Use a single sample feature gate.
- Move the feature gate as a string constant.
- The feature gates are handled within the KataConfig reconcile loop.
- If there are any errors with feature gate processing, the reconciliation process continues and doesn't re-queue
- Feature gate processing, in case of any errors in determining whether it is enabled or not (for example if the configMap is deleted or some other API server errors), is same as the default compiled in state of the respective feature gate

Related to #[KATA-2947](https://issues.redhat.com//browse/KATA-2947)
