### PR TITLE
Handling the case when imageGenerator is nil for libvirt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -mod=mod -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=linux go build $(GOFLAGS) -mod=mod -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -117,6 +117,10 @@ func InitializeImageGenerator(client client.Client) error {
 	igOnce.Do(func() {
 		ig, err = newImageGenerator(client)
 	})
+	// Reset the sync.Once if there was an error
+	if err != nil {
+		igOnce = sync.Once{}
+	}
 	return err
 }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
```
2024-06-03T06:57:57Z	INFO	Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference	{"controller": "kataconfig", "controllerGroup": "kataconfiguration.openshift.io", "controllerKind": "KataConfig", "KataConfig": {"name":"example-kataconfig"}, "namespace": "", "name": "example-kataconfig", "reconcileID": "97fbdc02-176c-41ce-a1bb-774fa4b52f84"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3d70db8]
```

`ImageCreate` panics when it hits the libvirt flow, which is crashing the `controller-manager` on s390x at the moment.

**- What I did**
add an extra condition to check if the `ImageCreate` object is nil, then return failure.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
