### PR TITLE
Changes for file based catalog in Makefile and DEVELOPMENT.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.28.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ endif
 # These images needs to be synced with the default values in the Dockerfile.
 BUILDER_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16
 TARGET_IMAGE  ?= registry.ci.openshift.org/ocp/4.16:base
+# Set if token was obtained
+AUTH_FILE ?= ""
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
@@ -145,7 +147,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build \
-		-t ${IMG} \
+		-t ${IMG} --authfile $(AUTH_FILE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg TARGET_IMAGE=$(TARGET_IMAGE) \
 		.

--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD catalog /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -1,0 +1,243 @@
+---
+defaultChannel: stable
+description: "<!-- TOC start -->\n- [Introduction to sandboxed containers](#introduction-to-sandboxed-containers)\n
+  \ * [Features & benefits of sandboxed containers](#features-benefits-of-sandboxed-containers)\n-
+  [OpenShift sandboxed containers Operator](#openshift-sandboxed-containers-operator)\n
+  \ * [Operator Architecture](#operator-architecture)\n  * [KataConfig Custom Resource
+  Definition](#kataconfig-custom-resource-definition)\n  * [Getting Started](#getting-started)\n-
+  [Operator Development](#operator-development)\n- [Demos](#demos)\n- [Further Reading](#further-reading)\n<!--
+  TOC end -->\n\n\n## Introduction to sandboxed containers\n\n[OpenShift sandboxed
+  containers](https://www.redhat.com/en/openshift-sandboxed-containers), based on
+  the [Kata Containers](https://katacontainers.io/) open source project, provides
+  an Open Container Initiative (OCI) compliant container runtime using lightweight
+  virtual machines, running your workloads in their own isolated kernel and therefore
+  contributing an additional layer of isolation back to OpenShift’s Defense-in-Depth
+  strategy. \n\n### Features & benefits of sandboxed containers\n\n- **Isolated Developer
+  Environments & Privileges Scoping** \nAs a developer working on debugging an application
+  using state-of-the-art tooling you might need elevated privileges such as `CAP_ADMIN`
+  or `CAP_BPF`. With OpenShift sandboxed containers, any impact will be limited to
+  a separate dedicated kernel.\n\n- **Legacy Containerized Workload Isolation** \nYou
+  are mid-way in converting a containerized monolith into cloud-native microservices.
+  However, the monolith still runs on your cluster unpatched and unmaintained. OpenShift
+  sandboxed containers helps isolate it in its own kernel to reduce risk.\n\n- **Safe
+  Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)** \nIf you are providing
+  a service to multiple tenants, it could mean that the service workloads are sharing
+  the same resources (e.g., worker node). By deploying in a dedicated kernel, the
+  impact of these workloads have on one another is greatly reduced.\n\n- **Additional
+  Isolation with Native Kubernetes User Experience**\nOpenShift sandboxed containers
+  is used as a compliant OCI runtime. Therefore, many operational patterns used with
+  normal containers are still preserved including but not limited to image scanning,
+  GitOps, Imagestreams, and so on.\n\nPlease refer to this [blog](https://cloud.redhat.com/blog/the-dawn-of-openshift-sandboxed-containers-overview)
+  for a detailed overview of sandboxed containers use cases and other related details.\n\n##
+  OpenShift sandboxed containers Operator\n\nThe operator manages the lifecycle (`install/configure/update`)
+  of sandboxed containers runtime (`Kata containers`) on OpenShift clusters.\n\n###
+  Operator Architecture\n\nThe following diagram shows how the operator components
+  are connected to the OpenShift overall architecture:\n\n![High Level Overview](./docs/arch.png)\n\n\nHere
+  is a brief summary of the components:\n\n- OpenShift clusters consist of controller
+  and worker nodes organized as  machine config pools. \n- The Machine Config Operator
+  (MCO) manages the operating system and keeps the cluster up to date and configured.\n-
+  The control-plane nodes run all the services that are required to control the cluster
+  such as the API server, etcd, controller-manager, and the scheduler. \n- The OpenShift
+  sandboxed containers operator runs on a control plane node.\n- The cluster worker
+  nodes run all the end-user workloads. \n- The container engine `CRI-O` uses either
+  the default container runtime `runc` or, in sandboxed containers case, the `Kata`
+  containers runtime.\n\n### KataConfig Custom Resource Definition\n\nThe operator
+  owns and control the `KataConfig` Custom Resource Definition (CRD).\nPlease refer
+  to the [code](https://github.com/openshift/sandboxed-containers-operator/blob/main/api/v1/kataconfig_types.go)
+  to find details of the `KataConfig` CRD.\n\n### Getting Started\n\nPlease refer
+  to the OpenShift release specific documentation for getting started with sandboxed
+  containers. \n- For OpenShift latest documentation please follow this [doc](https://docs.openshift.com/container-platform/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html)\n\nFurther
+  note that starting with OpenShift 4.9, the branch naming is tied to the operator
+  version and not the OpenShift version.\nFor example `release-1.1` corresponds to
+  the Operator release verson `1.1.x`.\n\n## Operator Development\n\nPlease take a
+  look at the following [doc](./docs/DEVELOPMENT.md). \nContributions are most welcome!!\n\n##
+  Demos\n\nYou can find various demos in the following [youtube channel](https://www.youtube.com/channel/UC6PCt2zbug9cF4SpnMrE68A).\n\n##
+  Further Reading\n\n- [OpenShift sandboxed containers 101](https://cloud.redhat.com/blog/openshift-sandboxed-containers-101)\n-
+  [Operator overview](https://cloud.redhat.com/blog/openshift-sandboxed-containers-operator-from-zero-to-hero-the-hard-way)\n-
+  [Troubleshooting](https://cloud.redhat.com/blog/sandboxed-containers-operator-from-zero-to-hero-the-hard-way-part-2)\n-
+  [Hybrid Cloud Blog Series](https://www.redhat.com/en/openshift-sandboxed-containers)\n"
+name: sandboxed-containers-operator
+schema: olm.package
+---
+image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.6.0
+name: sandboxed-containers-operator.v1.6.0
+package: sandboxed-containers-operator
+properties:
+- type: olm.gvk
+  value:
+    group: confidentialcontainers.org
+    kind: PeerPod
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: confidentialcontainers.org
+    kind: PeerPodConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kataconfiguration.openshift.io
+    kind: KataConfig
+    version: v1
+- type: olm.package
+  value:
+    packageName: sandboxed-containers-operator
+    version: 1.6.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "kataconfiguration.openshift.io/v1",
+            "kind": "KataConfig",
+            "metadata": {
+              "name": "example-kataconfig"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      createdAt: "2024-05-08T15:43:54Z"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.1.0 <1.5.2'
+      operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.28.0
+      operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/sandboxed-containers-operator
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: The kataconfig CR represent a installation of Kata in a cluster
+          and its current state.
+        kind: KataConfig
+        name: kataconfigs.kataconfiguration.openshift.io
+        version: v1
+      - kind: PeerPodConfig
+        name: peerpodconfigs.confidentialcontainers.org
+        version: v1alpha1
+      - kind: PeerPod
+        name: peerpods.confidentialcontainers.org
+        version: v1alpha1
+    description: |-
+      OpenShift sandboxed containers, based on the Kata Containers open source
+      project, provides an Open Container Initiative (OCI) compliant container
+      runtime using lightweight virtual machines, running your workloads in their own
+      isolated kernel and therefore contributing an additional layer of isolation
+      back to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for
+      more information.
+
+      # Requirements
+      Your cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.
+
+      # Features & benefits
+      - **Isolated Developer Environments & Privileges Scoping**
+        As a developer working on debugging an application using state-of-the-art
+        tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With
+        OpenShift sandboxed containers, any impact will be limited to a separate
+        dedicated kernel.
+
+      - **Legacy Containerized Workload Isolation**
+        You are mid-way in converting a containerized monolith into cloud-native
+        microservices. However, the monolith still runs on your cluster unpatched and
+        unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel
+        to reduce risk.
+
+      - **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**
+        If you are providing a service to multiple tenants, it could mean that the
+        service workloads are sharing the same resources (e.g., worker node). By
+        deploying in a dedicated kernel, the impact of these workloads have on one
+        another is greatly reduced.
+
+      - **Additional Isolation with Native Kubernetes User Experience**
+        OpenShift sandboxed containers is used as a compliant OCI runtime.
+        Therefore, many operational patterns used with normal containers are still
+        preserved including but not limited to image scanning, GitOps, Imagestreams,
+        and so on.
+
+      # How to install
+        Read the information about the Operator and click Install.
+
+        On the Install Operator page:
+
+        - Select `candidate` from the list of available Update Channel options.
+        This ensures that you install the latest version of OpenShift sandboxed containers
+        that is compatible with your OpenShift Container Platform version.
+
+        - For Installed Namespace, ensure that the Operator recommended namespace
+          option is selected. This installs the Operator in the mandatory
+          `openshift-sandboxed-containers-operator` namespace, which is automatically
+          created if it does not exist. Attempting to install the OpenShift
+          sandboxed containers Operator in a namespace other than
+          `openshift-sandboxed-containers-operator` causes the installation to fail.
+
+        - For Approval Strategy, ensure that Automatic, which is the default value,
+          is selected. OpenShift sandboxed containers automatically updates when a new
+          z-stream release is available.
+
+        - Click Install to make the Operator available to the OpenShift sandboxed
+          containers namespace.
+
+        - The OpenShift sandboxed containers Operator is now installed on your
+          cluster. You can trigger the Operator by enabling the runtime on your cluster.
+          You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click
+          on "create instance" on the operator overview page.
+
+      # Documentation
+      See the official documentation [here](https://docs.openshift.com/container-platform/latest/sandboxed_containers/understanding-sandboxed-containers.html)
+    displayName: OpenShift sandboxed containers Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - sandboxed-containers
+    - kata
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Sandboxed Containers Operator
+      url: https://www.github.com/openshift/sandboxed-containers-operator
+    maintainers:
+    - email: support@redhat.com'
+      name: '''Red Hat'
+    maturity: beta
+    provider:
+      name: Red Hat
+relatedImages:
+- image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
+  name: ""
+- image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.6.0
+  name: ""
+- image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.6.0
+  name: ""
+- image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:latest
+  name: caa
+- image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:latest
+  name: peerpods-webhook
+- image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:latest
+  name: kata-monitor
+- image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:latest
+  name: podvm-builder
+- image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+  name: podvm-payload
+schema: olm.bundle
+---
+schema: olm.channel
+package: sandboxed-containers-operator
+name: stable
+entries:
+  - name: sandboxed-containers-operator.v1.6.0

--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -1,6 +1,7 @@
 ---
 defaultChannel: stable
-description: "<!-- TOC start -->\n- [Introduction to sandboxed containers](#introduction-to-sandboxed-containers)\n
+description:
+  "<!-- TOC start -->\n- [Introduction to sandboxed containers](#introduction-to-sandboxed-containers)\n
   \ * [Features & benefits of sandboxed containers](#features-benefits-of-sandboxed-containers)\n-
   [OpenShift sandboxed containers Operator](#openshift-sandboxed-containers-operator)\n
   \ * [Operator Architecture](#operator-architecture)\n  * [KataConfig Custom Resource
@@ -59,185 +60,188 @@ description: "<!-- TOC start -->\n- [Introduction to sandboxed containers](#intr
 name: sandboxed-containers-operator
 schema: olm.package
 ---
-image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.6.0
-name: sandboxed-containers-operator.v1.6.0
+image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.7.0
+name: sandboxed-containers-operator.v1.7.0
 package: sandboxed-containers-operator
 properties:
-- type: olm.gvk
-  value:
-    group: confidentialcontainers.org
-    kind: PeerPod
-    version: v1alpha1
-- type: olm.gvk
-  value:
-    group: confidentialcontainers.org
-    kind: PeerPodConfig
-    version: v1alpha1
-- type: olm.gvk
-  value:
-    group: kataconfiguration.openshift.io
-    kind: KataConfig
-    version: v1
-- type: olm.package
-  value:
-    packageName: sandboxed-containers-operator
-    version: 1.6.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "kataconfiguration.openshift.io/v1",
-            "kind": "KataConfig",
-            "metadata": {
-              "name": "example-kataconfig"
+  - type: olm.gvk
+    value:
+      group: confidentialcontainers.org
+      kind: PeerPod
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: confidentialcontainers.org
+      kind: PeerPodConfig
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kataconfiguration.openshift.io
+      kind: KataConfig
+      version: v1
+  - type: olm.package
+    value:
+      packageName: sandboxed-containers-operator
+      version: 1.7.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "kataconfiguration.openshift.io/v1",
+              "kind": "KataConfig",
+              "metadata": {
+                "name": "example-kataconfig"
+              }
             }
-          }
-        ]
-      capabilities: Seamless Upgrades
-      createdAt: "2024-05-08T15:43:54Z"
-      features.operators.openshift.io/disconnected: "true"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      olm.skipRange: '>=1.1.0 <1.5.2'
-      operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
-      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
-        "OpenShift Platform Plus"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.28.0
-      operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/openshift/sandboxed-containers-operator
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: The kataconfig CR represent a installation of Kata in a cluster
-          and its current state.
-        kind: KataConfig
-        name: kataconfigs.kataconfiguration.openshift.io
-        version: v1
-      - kind: PeerPodConfig
-        name: peerpodconfigs.confidentialcontainers.org
-        version: v1alpha1
-      - kind: PeerPod
-        name: peerpods.confidentialcontainers.org
-        version: v1alpha1
-    description: |-
-      OpenShift sandboxed containers, based on the Kata Containers open source
-      project, provides an Open Container Initiative (OCI) compliant container
-      runtime using lightweight virtual machines, running your workloads in their own
-      isolated kernel and therefore contributing an additional layer of isolation
-      back to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for
-      more information.
+          ]
+        capabilities: Seamless Upgrades
+        createdAt: "2024-05-08T15:43:54Z"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        olm.skipRange: ">=1.1.0 <1.7.0"
+        operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
+        operators.openshift.io/valid-subscription:
+          '["OpenShift Container Platform",
+          "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.28.0
+        operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/openshift/sandboxed-containers-operator
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description:
+              The kataconfig CR represent a installation of Kata in a cluster
+              and its current state.
+            kind: KataConfig
+            name: kataconfigs.kataconfiguration.openshift.io
+            version: v1
+          - kind: PeerPodConfig
+            name: peerpodconfigs.confidentialcontainers.org
+            version: v1alpha1
+          - kind: PeerPod
+            name: peerpods.confidentialcontainers.org
+            version: v1alpha1
+      description: |-
+        OpenShift sandboxed containers, based on the Kata Containers open source
+        project, provides an Open Container Initiative (OCI) compliant container
+        runtime using lightweight virtual machines, running your workloads in their own
+        isolated kernel and therefore contributing an additional layer of isolation
+        back to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for
+        more information.
 
-      # Requirements
-      Your cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.
+        # Requirements
+        Your cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.
 
-      # Features & benefits
-      - **Isolated Developer Environments & Privileges Scoping**
-        As a developer working on debugging an application using state-of-the-art
-        tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With
-        OpenShift sandboxed containers, any impact will be limited to a separate
-        dedicated kernel.
+        # Features & benefits
+        - **Isolated Developer Environments & Privileges Scoping**
+          As a developer working on debugging an application using state-of-the-art
+          tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With
+          OpenShift sandboxed containers, any impact will be limited to a separate
+          dedicated kernel.
 
-      - **Legacy Containerized Workload Isolation**
-        You are mid-way in converting a containerized monolith into cloud-native
-        microservices. However, the monolith still runs on your cluster unpatched and
-        unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel
-        to reduce risk.
+        - **Legacy Containerized Workload Isolation**
+          You are mid-way in converting a containerized monolith into cloud-native
+          microservices. However, the monolith still runs on your cluster unpatched and
+          unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel
+          to reduce risk.
 
-      - **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**
-        If you are providing a service to multiple tenants, it could mean that the
-        service workloads are sharing the same resources (e.g., worker node). By
-        deploying in a dedicated kernel, the impact of these workloads have on one
-        another is greatly reduced.
+        - **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**
+          If you are providing a service to multiple tenants, it could mean that the
+          service workloads are sharing the same resources (e.g., worker node). By
+          deploying in a dedicated kernel, the impact of these workloads have on one
+          another is greatly reduced.
 
-      - **Additional Isolation with Native Kubernetes User Experience**
-        OpenShift sandboxed containers is used as a compliant OCI runtime.
-        Therefore, many operational patterns used with normal containers are still
-        preserved including but not limited to image scanning, GitOps, Imagestreams,
-        and so on.
+        - **Additional Isolation with Native Kubernetes User Experience**
+          OpenShift sandboxed containers is used as a compliant OCI runtime.
+          Therefore, many operational patterns used with normal containers are still
+          preserved including but not limited to image scanning, GitOps, Imagestreams,
+          and so on.
 
-      # How to install
-        Read the information about the Operator and click Install.
+        # How to install
+          Read the information about the Operator and click Install.
 
-        On the Install Operator page:
+          On the Install Operator page:
 
-        - Select `candidate` from the list of available Update Channel options.
-        This ensures that you install the latest version of OpenShift sandboxed containers
-        that is compatible with your OpenShift Container Platform version.
+          - Select `candidate` from the list of available Update Channel options.
+          This ensures that you install the latest version of OpenShift sandboxed containers
+          that is compatible with your OpenShift Container Platform version.
 
-        - For Installed Namespace, ensure that the Operator recommended namespace
-          option is selected. This installs the Operator in the mandatory
-          `openshift-sandboxed-containers-operator` namespace, which is automatically
-          created if it does not exist. Attempting to install the OpenShift
-          sandboxed containers Operator in a namespace other than
-          `openshift-sandboxed-containers-operator` causes the installation to fail.
+          - For Installed Namespace, ensure that the Operator recommended namespace
+            option is selected. This installs the Operator in the mandatory
+            `openshift-sandboxed-containers-operator` namespace, which is automatically
+            created if it does not exist. Attempting to install the OpenShift
+            sandboxed containers Operator in a namespace other than
+            `openshift-sandboxed-containers-operator` causes the installation to fail.
 
-        - For Approval Strategy, ensure that Automatic, which is the default value,
-          is selected. OpenShift sandboxed containers automatically updates when a new
-          z-stream release is available.
+          - For Approval Strategy, ensure that Automatic, which is the default value,
+            is selected. OpenShift sandboxed containers automatically updates when a new
+            z-stream release is available.
 
-        - Click Install to make the Operator available to the OpenShift sandboxed
-          containers namespace.
+          - Click Install to make the Operator available to the OpenShift sandboxed
+            containers namespace.
 
-        - The OpenShift sandboxed containers Operator is now installed on your
-          cluster. You can trigger the Operator by enabling the runtime on your cluster.
-          You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click
-          on "create instance" on the operator overview page.
+          - The OpenShift sandboxed containers Operator is now installed on your
+            cluster. You can trigger the Operator by enabling the runtime on your cluster.
+            You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click
+            on "create instance" on the operator overview page.
 
-      # Documentation
-      See the official documentation [here](https://docs.openshift.com/container-platform/latest/sandboxed_containers/understanding-sandboxed-containers.html)
-    displayName: OpenShift sandboxed containers Operator
-    installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: true
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: false
-      type: AllNamespaces
-    keywords:
-    - sandboxed-containers
-    - kata
-    labels:
-      operatorframework.io/arch.amd64: supported
-      operatorframework.io/os.linux: supported
-    links:
-    - name: Sandboxed Containers Operator
-      url: https://www.github.com/openshift/sandboxed-containers-operator
-    maintainers:
-    - email: support@redhat.com'
-      name: '''Red Hat'
-    maturity: beta
-    provider:
-      name: Red Hat
+        # Documentation
+        See the official documentation [here](https://docs.openshift.com/container-platform/latest/sandboxed_containers/understanding-sandboxed-containers.html)
+      displayName: OpenShift sandboxed containers Operator
+      installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: false
+          type: AllNamespaces
+      keywords:
+        - sandboxed-containers
+        - kata
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/os.linux: supported
+      links:
+        - name: Sandboxed Containers Operator
+          url: https://www.github.com/openshift/sandboxed-containers-operator
+      maintainers:
+        - email: support@redhat.com'
+          name: "'Red Hat"
+      maturity: beta
+      provider:
+        name: Red Hat
 relatedImages:
-- image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-  name: ""
-- image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.6.0
-  name: ""
-- image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.6.0
-  name: ""
-- image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:latest
-  name: caa
-- image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:latest
-  name: peerpods-webhook
-- image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:latest
-  name: kata-monitor
-- image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:latest
-  name: podvm-builder
-- image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
-  name: podvm-payload
+  - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
+    name: ""
+  - image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-bundle:v1.7.0
+    name: ""
+  - image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.7.0
+    name: ""
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:latest
+    name: caa
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:latest
+    name: peerpods-webhook
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:latest
+    name: kata-monitor
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:latest
+    name: podvm-builder
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:latest
+    name: podvm-payload
 schema: olm.bundle
 ---
 schema: olm.channel
 package: sandboxed-containers-operator
 name: stable
 entries:
-  - name: sandboxed-containers-operator.v1.6.0
+  - name: sandboxed-containers-operator.v1.7.0
+      replaces: sandboxed-containers-operator.v1.6.0

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,6 +85,7 @@ If `IMAGE_TAG_BASE` was set for your private registry, `catalog/index.yaml` will
 ```
 DEFAULT_CHANNEL="stable"  # from Makefile
 VERSION=1.7.0             # from Makefile
+PREVIOUS_VERSION=1.6.0
 BUNDLE_IMG=${IMAGE_TAG_BASE}-bundle:v${VERSION}
 make opm                  # to get bin/opm
 rm -rf catalog && mkdir -p catalog
@@ -96,6 +97,7 @@ package: sandboxed-containers-operator\n\
 name: ${DEFAULT_CHANNEL}\n\
 entries:\n\
   - name: sandboxed-containers-operator.v${VERSION}\n\
+    replaces: sandboxed-containers-operator.v${PREVIOUS_VERSION}\n
 " >> "catalog/index.yaml"
 ```
 #### Creating catalog.Dockerfile

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 - Golang - 1.21.x
 - Operator SDK version - 1.28.0
-```
+```shell
 export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
 export OS=$(uname | awk '{print tolower($0)}')
 export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.0
@@ -12,82 +12,109 @@ install -m 755 operator-sdk_linux_amd64 ${SOME_DIR_IN_YOUR_PATH}/operator-sdk
 ```
 - podman, podman-docker or docker
 - Access to OpenShift cluster (4.12+)
-- Container registry to storage images
+- Container registry to store images
 
 ### Get a token on registry.ci.openshift.org
 Our builder and base images are curated images from OpenShift.
 They are pulled from registry.ci.openshift.org, which require an authentication.
 To get access to these images, you have to login and retrieve a token, following [these steps](https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication)
 
+##### Details on token
+- You should go to _app.ci_ in the above doc, login with SSO
+- Go to _copy login_ on your _username_ in the top right
+- You will login and see _view token_.  Click on that to see
+- **Your API token is**.  The next line is your full token
+- _podman login_ with your username and the token as your password should put the token in your AUTH_FILE
+
+#### Using the token
+If docker build does not automatically use the token in the default authfile, it can be forces:
+```shell
+export AUTH_FILE='~/.docker/config.json'
+```
+
 In summary:
 - login to one of the clusters' console
 - use the console's shortcut to get the commandline login command
 - log in from the command line with the provided command
-- use "oc registry login" to save the token locally
+- use "podman login" to save the token locally
+- set AUTH_FILE to force docker-build to use the token from your file if needed
 
-### Using public images
-
-If you cannot login to registry.ci.openshift.org, a temporary solution is to use
-public images during build and test. At the time of writing, the following public images
-does the trick.
-
-```shell
-export BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:golang-1.21
-export TARGET_IMAGE=registry.ci.openshift.org/origin/4.16:base
-make docker-build
-```
-
-## Set Environment Variables
+## Change catalog for private quay registry
+### Set Environment Variables
 
 Set your quay.io userid
-```
+```shell
 export QUAY_USERID=<user>
-```
-
-```
 export IMAGE_TAG_BASE=quay.io/${QUAY_USERID}/openshift-sandboxed-containers-operator
-export IMG=quay.io/${QUAY_USERID}/openshift-sandboxed-containers-operator
 ```
 
 ## Viewing available Make targets
 ```
 make help
 ```
-
 ## Building Operator image
 ```
 make docker-build
 make docker-push
 ```
+### Skipping tests in Make
+Add SKIP_TESTS=1 when calling make.  ex:
+```
+make SKIP_TESTS=1 docker-build
+```
 
 ## Building Operator bundle image
 
-If you are deploying in an OpenShift cluster then modify the
-value of the env variable `SANDBOXED_CONTAINERS_EXTENSION` to `sandboxed-containers`
-in the file `config/manager/manager.yaml` before running the below mentioned
-commands.
+### If you are deploying in an OpenShift cluster
+Modify SANDBOXED_CONTAINERS_EXTENSION in config/manager/manager.yaml before you __Make the bundle__
+```shell
+sed -ie 's/kata-containers/sandboxed-containers/' config/manager/manager.yaml
+```
 
+### Make the bundle
 ```
 make bundle CHANNELS=candidate
 make bundle-build
 make bundle-push
 ```
 
-
 ## Building Catalog image
+#### Overwrite/create catalog/index.yaml if needed
+If `IMAGE_TAG_BASE` was set for your private registry, `catalog/index.yaml` will need to be rewritten.  Before running `make catalog-build`, run this:
+
+```
+DEFAULT_CHANNEL="stable"  # from Makefile
+VERSION=1.7.0             # from Makefile
+BUNDLE_IMG=${IMAGE_TAG_BASE}-bundle:v${VERSION}
+make opm                  # to get bin/opm
+rm -rf catalog && mkdir -p catalog
+bin/opm init  sandboxed-containers-operator --default-channel=${DEFAULT_CHANNEL} --description ./README.md --output yaml > catalog/index.yaml
+bin/opm render ${BUNDLE_IMG} --output=yaml >> catalog/index.yaml
+printf -- "---\n\
+schema: olm.channel\n\
+package: sandboxed-containers-operator\n\
+name: ${DEFAULT_CHANNEL}\n\
+entries:\n\
+  - name: sandboxed-containers-operator.v${VERSION}\n\
+" >> "catalog/index.yaml"
+```
+#### Creating catalog.Dockerfile
+If `catalog.Dockerfile` doesn't exist, it can be created with `opm generate dockerfile catalog`.  It should not need to be recreated or changed.
+
+
 ```
 make catalog-build
 make catalog-push
 ```
 
-## Installing the Operator using OpenShift Web console 
+## Installing the Operator using OpenShift Web console
 
 ### Create Custom Operator Catalog
 
-Create a new `CatalogSource` yaml. Replace `user` with your quay.io user and
-`version` with the operator version.
+Create a new `CatalogSource` yaml. Replace `${QUAY_USERID}` with your quay.io user and
+`${VERSION}` with the operator VERSION from the Makefile
 
-```
+```shell
 cat > my_catalog.yaml <<EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -97,7 +124,7 @@ metadata:
 spec:
  displayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/${QUAY_USERID}/openshift-sandboxed-containers-operator-catalog:version
+ image:  quay.io/${QUAY_USERID}/openshift-sandboxed-containers-operator-catalog:v${VERSION}
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -106,19 +133,19 @@ EOF
 ```
 Deploy the catalog
 ```
-oc create -f my_catalog.yaml
+oc apply -f my_catalog.yaml
 ```
 
-The new operator should be now available for installation from the OpenShift web console
+The new operator should become available for installation from the OpenShift web console
 
 
 ## Installing the Operator using CLI
 
 When deploying the Operator using CLI, cert-manager needs to be installed otherwise
-webhook will not start. `cert-manager` is not required when deploying via the web console as OLM 
+webhook will not start. `cert-manager` is not required when deploying via the web console as OLM
 takes care of webhook certificate management. You can read more on this [here]( https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#deploying-an-operator-with-webhooks-using-olm)
 
-### Install cert-manager 
+### Install cert-manager
 ```
  oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
[KATA-3122](https://issues.redhat.com/browse/KATA-3122) Changes for FBC catalog to replace sqlite

**- What I did**
- Makefile
  - add an token variable for docker-build so the public images are not used
  - change the (downloaded) opm version to 1.28.0
  - change catalog-build for file based catalogs, replacing sqlite
- docs/DEVELOPMENT.md
  - explain how to use the token instead of public images
  - sed to change SANDBOXED_CONTAINERS_EXTENSION for openshift
  - where to add SKIP_TESTS

**- How to verify it**
Build per DEVELOPMENT.md
Create a catsrc using your catalog & install in your cluster
Install the operator in your cluster

**- Description for the changelog**
Changes for file based catalog instead of sqlite

