### PR TITLE
podvm: Fix payload image override

### DIFF
--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -311,10 +311,13 @@ func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, er
 	// If RELATED_PODVM_PAYLOAD_IMAGE environment variable is set, use it
 	// Otherwise, use the default podvm payload image
 	// There is only one initContainer in the job, so we don't need to check the container name
-	podvmPayloadImage := os.Getenv("RELATED_IMAGE_PODVM_PAYLOAD")
-	if podvmPayloadImage != "" {
-		igLogger.Info("Using podvm payload image from environment variable", "image", podvmPayloadImage)
-		job.Spec.Template.Spec.InitContainers[0].Image = podvmPayloadImage
+	// The initContainer is only used for the create job "osc-podvm-create-job.yaml"
+	if jobFileName == "osc-podvm-create-job.yaml" {
+		podvmPayloadImage := os.Getenv("RELATED_IMAGE_PODVM_PAYLOAD")
+		if podvmPayloadImage != "" {
+			igLogger.Info("Using podvm payload image from environment variable", "image", podvmPayloadImage)
+			job.Spec.Template.Spec.InitContainers[0].Image = podvmPayloadImage
+		}
 	}
 
 	return job, nil


### PR DESCRIPTION
The payload image override was incorrectly done for both create and delete jobs. The payload image is used via initContainer and applicable only for the create job. It must not be set for delete job as the delete job spec doesn't have initContainer in the spec.