### PR TITLE
peerpod: Remote hypervisor config files needs to be updated to align with upstream changes

### DIFF
--- a/config/peerpods/mc-50-crio-config.yaml
+++ b/config/peerpods/mc-50-crio-config.yaml
@@ -12,8 +12,7 @@ spec:
     storage:
       files:
       - contents:
-              source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS5ydW50aW1lcy5rYXRhLXJlbW90ZV0KIHJ1bnRpbWVfcGF0aCA9ICIvdXNyL2Jpbi9jb250YWluZXJkLXNoaW0ta2F0YS12Mi10cCIKIHJ1bnRpbWVfdHlwZSA9ICJ2bSIKIHJ1bnRpbWVfcm9vdCA9ICIvcnVuL3ZjIgogcnVudGltZV9jb25maWdfcGF0aCA9ICIvb3B0L2thdGEvY29uZmlndXJhdGlvbi1yZW1vdGUudG9tbCIKIHByaXZpbGVnZWRfd2l0aG91dF9ob3N0X2RldmljZXMgPSB0cnVlCg==
+              source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS5ydW50aW1lcy5rYXRhLXJlbW90ZV0KIHJ1bnRpbWVfcGF0aCA9ICIvdXNyL2Jpbi9jb250YWluZXJkLXNoaW0ta2F0YS12Mi10cCIKIHJ1bnRpbWVfdHlwZSA9ICJ2bSIKIHJ1bnRpbWVfcm9vdCA9ICIvcnVuL3ZjIgogcnVudGltZV9jb25maWdfcGF0aCA9ICIvb3B0L2thdGEvY29uZmlndXJhdGlvbi1yZW1vdGUudG9tbCIKIHByaXZpbGVnZWRfd2l0aG91dF9ob3N0X2RldmljZXMgPSB0cnVlCgogcnVudGltZV9wdWxsX2ltYWdlID0gdHJ1ZQogYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsKICJpby5rdWJlcm5ldGVzLmNyaS1vLkRldmljZXMiLApdCg==
         filesystem: root
         mode: 0644
         path: /etc/crio/crio.conf.d/50-kata-remote
-


### PR DESCRIPTION
- add `runtime_pull_image = true` to 50-kata-remote config file
- require "add support for pull-in-guest method" from crio v1.29.0 (ocp 4.16.0)
- make CAA latest main branch codes works well in OCP 4.16.0

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

CAA latest main branch codes are base on kata-agent main branch code already, it will always pull image in guest.
Without this change the CAA latest main branch codes can't work well in OCP cluster, the error logs when create a peerpod look like:
```
Pulling image separately not support on main. It is required to use the nydus-snapshotter, which isn't configured properly here.
```
related code https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/pkg/adaptor/proxy/service.go#L85C18-L85C146

**- What I did**

- crio v1.29.0+ include [`add support for pull-in-guest method`](https://github.com/cri-o/cri-o/pull/7471)
- OCP cluster v4.16.0, crio version is `v1.29.5+29c95f3`

so we need enable the pull-in-guest function in crio config file `50-kata-remote`:
```
[crio.runtime.runtimes.kata-remote]
 runtime_path = "/usr/bin/containerd-shim-kata-v2-tp"
 runtime_type = "vm"
 runtime_root = "/run/vc"
 runtime_config_path = "/opt/kata/configuration-remote.toml"
 privileged_without_host_devices = true

 runtime_pull_image = true
 allowed_annotations = [
 "io.kubernetes.cri-o.Devices",
]
```

**- How to verify it**
- Create OCP 4.16.0
```
[root@bastion-ocp-cn-new ~]# oc version
Client Version: 4.16.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: 4.16.0
Kubernetes Version: v1.29.5+29c95f3

[root@bastion-ocp-cn-new ~]# oc get nodes
NAME                                                         STATUS   ROLES                  AGE     VERSION
control-plane-ocp-cn-new-0.ocp-cn-new.test-ocp-cn-new.coco   Ready    control-plane,master   6d20h   v1.29.5+29c95f3
control-plane-ocp-cn-new-1.ocp-cn-new.test-ocp-cn-new.coco   Ready    control-plane,master   6d20h   v1.29.5+29c95f3
control-plane-ocp-cn-new-2.ocp-cn-new.test-ocp-cn-new.coco   Ready    control-plane,master   6d20h   v1.29.5+29c95f3
worker-ocp-cn-new-0.ocp-cn-new.test-ocp-cn-new.coco          Ready    kata-oc,worker         6d20h   v1.29.5+29c95f3
worker-ocp-cn-new-1.ocp-cn-new.test-ocp-cn-new.coco          Ready    kata-oc,worker         6d20h   v1.29.5+29c95f3
[root@bastion-ocp-cn-new ~]# 
```
- Install latest sandboxed-containers-operator

- login to worker nodes
    - update the file `/etc/crio/crio.conf.d/50-kata-remote` add one line ` runtime_pull_image = true`
    - restart crio
- Update CAA image to latest opensource tag base on the main branch
https://quay.io/repository/confidential-containers/cloud-api-adaptor?tab=tags
eg.
```
quay.io/confidential-containers/cloud-api-adaptor:dev-0480804f8f7d06202a5a18fef3a966ec6e4e59c7
```
- Build podvm image, make sure the embedded pause image is: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7f3cb6f9d265291b47a7491c2ba4f4dd0752a18b661eee40584f9a5dbcbe13bb"
    run follow commands before build podvm image
    ```
    rm -rf  /root/cloud-api-adaptor/src/cloud-api-adaptor/podvm-mkosi/resources/binaries-tree/pause_bundle
    mkdir /tmp/pause
    skopeo copy "docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7f3cb6f9d265291b47a7491c2ba4f4dd0752a18b661eee40584f9a5dbcbe13bb" "oci:/tmp/pause:7f3cb6f9d265291b47a7491c2ba4f4dd0752a18b661eee40584f9a5dbcbe13bb" --authfile /root/auth.json
    
    umoci unpack --rootless --image "/tmp/pause:7f3cb6f9d265291b47a7491c2ba4f4dd0752a18b661eee40584f9a5dbcbe13bb" /root/cloud-api-adaptor/src/cloud-api-adaptor/podvm-mkosi/resources/binaries-tree/pause_bundle
    ``` 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add " runtime_pull_image = true" to "50-kata-remote" file to use the pull-in-guest function from crio.
