### PR TITLE
Fix `make test` to unbreak `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 ifneq (, $(SKIP_TESTS))
 	@echo Skipping tests. Unset SKIP_TESTS to actually run them.
 else
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GOFLAGS) ./... -coverprofile cover.out
-	# set write flag on created folder, so that we can clean it up
+	# Just build the test and set write flag on created folder, so that we can clean it up
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GOFLAGS) ./... -coverprofile cover.out -c
 	chmod +w $(LOCALBIN)/k8s/$(ENVTEST_K8S_VERSION)*
+	# Then run the test
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(GOFLAGS) ./... -coverprofile cover.out
 endif
 
 ##@ Build


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

`make test` is known to be failing since a long time. An issue is that it thus leaks a directory that prevents `make clean` to succeed because of restrictive file access modes.

**- What I did**

Separate the building of the test, which introduces the file access mode issue, from the actual test run. This allows to fully benefit from the access mode fixing introduced by PR #240.

**- How to verify it**

- `make test` # which will likely fail
- `make clean` # always succeed with this PR, fail otherwise
