### PR TITLE
Make ssh-secret optional for podvm creation job

### DIFF
--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -57,11 +57,10 @@ spec:
             - name: payload
               mountPath: /payload
             - name: regauth
-              mountPath: /tmp/regauth  
+              mountPath: /tmp/regauth
             - name: ssh-key-secret
               mountPath: "/root/.ssh/"
               readOnly: true
-              optional: true             
       volumes:
         - name: payload
           emptyDir: {}
@@ -75,4 +74,5 @@ spec:
             - key: id_rsa
               path: "id_rsa"
             defaultMode: 0400
+            optional: true
       restartPolicy: Never


### PR DESCRIPTION
The correct way to make it optional is to provide the optional keyword in the volumes spec.

Ref: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist

Fixes: #[KATA-3233](https://issues.redhat.com//browse/KATA-3233)

