### PR TITLE
Make ssh-secret optional for podvm deletion job

### DIFF
--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -49,7 +49,6 @@ spec:
             - name: ssh-key-secret
               mountPath: "/root/.ssh/"
               readOnly: true
-              optional: true
       volumes:
         - name: ssh-key-secret
           secret:
@@ -58,5 +57,6 @@ spec:
             - key: id_rsa
               path: "id_rsa"
             defaultMode: 0400
+            optional: true
 
       restartPolicy: Never


### PR DESCRIPTION
The correct way to make it optional is to provide the optional keyword in the volumes spec.

Ref: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist

Fixes: #[KATA-3233](https://issues.redhat.com//browse/KATA-3233)

