### PR TITLE
Require CRI-O 1.28

### DIFF
--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -369,6 +369,7 @@ spec:
   - email: support@redhat.com'
     name: '''Red Hat'
   maturity: beta
+  minKubeVersion: 1.28.0
   provider:
     name: Red Hat
   replaces: sandboxed-containers-operator.v1.6.0


### PR DESCRIPTION
Peer pods now require a feature that is only available in CRI-O 1.28 and newer. Let's make sure OSC cannot be deployed without this requirement being met. This means that users of OCP 4.14 and older will need to upgrade to 4.15 in order to install OSC.

The OSC 1.7.0 downstream release will use a bigger hammer to prevent installation. No real need to propagate this to the release-1.7 branch.