### PR TITLE
Bump OSC version to 1.8.0, and document where version appears

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.7.0
+VERSION ?= 1.8.0  ## OSC_VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.7.0'
+    olm.skipRange: '>=1.1.0 <1.8.0'  ## OSC_VERSION
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -32,7 +32,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.7.0
+  name: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -411,17 +411,17 @@ spec:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
                 - name: RELATED_IMAGE_KATA_MONITOR
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.7.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
                 - name: SANDBOXED_CONTAINERS_EXTENSION
                   value: kata-containers
                 - name: RELATED_IMAGE_CAA
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.7.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
                 - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.7.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0  ## OSC_VERSION
                 - name: RELATED_IMAGE_PODVM_BUILDER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.7.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -429,7 +429,7 @@ spec:
                 - configMapRef:
                     name: peer-pods-cm
                     optional: true
-                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.7.0
+                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.0  ## OSC_VERSION
                 imagePullPolicy: Always
                 name: manager
                 ports:
@@ -566,18 +566,18 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.7.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
     name: kata-monitor
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.7.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
     name: caa
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.7.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0  ## OSC_VERSION
     name: peerpods-webhook
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.7.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
     name: podvm-payload
-  replaces: sandboxed-containers-operator.v1.6.0
-  version: 1.7.0
+  replaces: sandboxed-containers-operator.v1.7.0  ## OSC_VERSION_BEFORE
+  version: 1.8.0  ## VERSION
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.7.0
+  newTag: v1.8.0  ## OSC_VERSION

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,17 +77,17 @@ spec:
             - name: PEERPODS_NAMESPACE
               value: "openshift-sandboxed-containers-operator"
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.7.0
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
             - name: SANDBOXED_CONTAINERS_EXTENSION
               value: kata-containers
             - name: RELATED_IMAGE_CAA
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.7.0
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
             - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.7.0
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0 ## OSC_VERSION
             - name: RELATED_IMAGE_PODVM_BUILDER
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.7.0
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
           imagePullPolicy: Always
           resources:
             limits:

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.7.0'
+    olm.skipRange: '>=1.1.0 <1.8.0'  ## OSC_VERSION
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -31,7 +31,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.7.0
+  name: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -372,8 +372,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  replaces: sandboxed-containers-operator.v1.6.0
-  version: 1.7.0
+  replaces: sandboxed-containers-operator.v1.7.0  ## OSC_VERSION_BEFORE
+  version: 1.8.0  ## OSC_VERSION
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -15,7 +15,7 @@ spec:
       # /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz
       initContainers:
         - name: copy
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.7.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -29,7 +29,7 @@ spec:
         - name: create
           # Binaries like kubectl, packer and yq are expected to be under /usr/local/bin
           # podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
           # This image contains the following
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -19,7 +19,7 @@ spec:
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           # Binaries like kubectl, packer and yq under /usr/local/bin
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           env:

--- a/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: delete-gallery
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.7.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           envFrom:

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.7.0
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.8.0  ## OSC_VERSION
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,5 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.7.0
-  
+  startingCSV: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,7 +80,7 @@ make catalog-build
 make catalog-push
 ```
 
-## Installing the Operator using OpenShift Web console 
+## Installing the Operator using OpenShift Web console
 
 ### Create Custom Operator Catalog
 
@@ -115,10 +115,10 @@ The new operator should be now available for installation from the OpenShift web
 ## Installing the Operator using CLI
 
 When deploying the Operator using CLI, cert-manager needs to be installed otherwise
-webhook will not start. `cert-manager` is not required when deploying via the web console as OLM 
+webhook will not start. `cert-manager` is not required when deploying via the web console as OLM
 takes care of webhook certificate management. You can read more on this [here]( https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#deploying-an-operator-with-webhooks-using-olm)
 
-### Install cert-manager 
+### Install cert-manager
 ```
  oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```
@@ -131,5 +131,20 @@ Uncomment all entries marked with `[CERTMANAGER]` in manifest files under `confi
 make install && make deploy
 ```
 
+### Updating versions
 
+When starting a new version, the locations tagged with `OSC_VERSION` should be updated with the new version number. A few places are also tagged with `OSC_VERSION_BEFORE`, referring to the version being replaced.
 
+On the  `main` branch `1.5.2`, the following locations were identified, but looking for the version pattern would give too many false positives on `devel` with `1.7.0`, and even more false positives were found with `1.8.0`. Most hits were in `go.mod` or `go.sum` and should be ignored, since they refer to dependencies with unrelated version numbering.
+
+```
+Makefile:6:VERSION ?= 1.5.2
+config/manager/kustomization.yaml:16:  newTag: 1.5.2
+config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:16:    olm.skipRange: '>=1.1.0 <1.5.2'
+config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:28:  name: sandboxed-containers-operator.v1.5.2
+config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:368:  version: 1.5.2
+config/samples/deploy.yaml:9: image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.5.2
+config/samples/deploy.yaml:39:  startingCSV: sandboxed-containers-operator.v1.5.2
+hack/aws-image-job.yaml:24:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
+hack/azure-image-job.yaml:23:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
+```


### PR DESCRIPTION
Bump the version number of OSC to the upcoming release, 1.8.0, and document where the version number appears in the sources.

When starting a new version, many locations need to be updated (here shown with current version `1.5.2` on `main` branch):

```
Makefile:6:VERSION ?= 1.5.2
config/manager/kustomization.yaml:16:  newTag: 1.5.2
config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:16:    olm.skipRange: '>=1.1.0 <1.5.2'
config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:28:  name: sandboxed-containers-operator.v1.5.2
config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:368:  version: 1.5.2
config/samples/deploy.yaml:9: image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.5.2
config/samples/deploy.yaml:39:  startingCSV: sandboxed-containers-operator.v1.5.2
hack/aws-image-job.yaml:24:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
hack/azure-image-job.yaml:23:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
```

The places needing change above have been labeled with `OSC_VERSION`. The reason is that version number `1.5.2` itself appears in places that are not related to OSC, for example:

```
go.sum:966:github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
go.sum:1760:github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
go.sum:1768:github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
```

As we are migrating towards 1.8.0, there are even more places referring to a 1.8.0 version that is not related to OSC:

```
go.sum:43:cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
go.sum:66:cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
go.sum:837:github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
go.sum:1092:github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
go.sum:1293:github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
go.sum:1361:github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
go.sum:1373:github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
go.sum:1557:github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
go.sum:1629:github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
go.sum:1890:github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
go.sum:2828:google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
```

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
