### PR TITLE
Fix signature check for CoCo

### DIFF
--- a/config/peerpods/podvm/lib.sh
+++ b/config/peerpods/podvm/lib.sh
@@ -246,15 +246,18 @@ function prepare_source_code() {
 
     # Enable image signature check
     if [[ "$CONFIDENTIAL_COMPUTE_ENABLED" == "yes" ]]; then
-	cat<<EOF>"${podvm_dir}"/files/etc/agent-config.toml
+        local agent_config_file="/etc/agent-config.toml"
+
+        cat<<EOF>"${podvm_dir}/files${agent_config_file}"
 server_addr = "unix:///run/kata-containers/agent.sock"
 guest_components_procs = "none"
 image_registry_auth = "file:///run/peerpod/auth.json"
 enable_signature_verification = true
 image_policy_file = "kbs:///default/security-policy/osc"
 EOF
-	sed -i 's,/run/peerpod/agent-config.toml,/etc/agent-config.toml,' \
-	    "${podvm_dir}"/files/etc/systemd/system/kata-agent.service
+        sed -i "s,/run/peerpod/agent-config.toml,${agent_config_file},g" \
+            "${podvm_dir}"/files/etc/systemd/system/kata-agent.service
+        echo "sudo cp -a /tmp/files${agent_config_file} ${agent_config_file}" >>"${podvm_dir}"/qcow2/copy-files.sh
     fi
 }
 


### PR DESCRIPTION
PR #468 forgot to teach the `copy-files.sh` of the CAA podvm build flow about the added `/etc/kata-agent.toml` config file.

Fix that now. This doesn't have any impact on non-confidential peer pods.

Fixes: https://issues.redhat.com/browse/KATA-3455
