### PR TITLE
backport: azure: use RHEL 9.4 as base image

### DIFF
--- a/config/peerpods/podvm/azure-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/azure-podvm-image-cm.yaml
@@ -26,8 +26,10 @@ data:
   IMAGE_DEFINITION_VM_GENERATION: "V2"
   IMAGE_DEFINITION_ARCHITECTURE: "x64"
 
-  # Base image
-  BASE_IMAGE_SKU: "93_gen2" # this is default for V2 image generation
+  # base image - should be coordinated with IMAGE_DEFINITION_VM_GENERATION
+  BASE_IMAGE_PUBLISHER: "redhat"
+  BASE_IMAGE_OFFER: "RHEL"
+  BASE_IMAGE_SKU: "94_gen2"
 
   # Image
   IMAGE_BASE_NAME: "podvm-image"
@@ -46,8 +48,6 @@ data:
   INSTALL_PACKAGES: "no"
   DOWNLOAD_SOURCES: "no"
   CONFIDENTIAL_COMPUTE_ENABLED: "no"
-  # snp/tdx
-  CONFIDENTIAL_COMPUTE_TYPE: "snp"
   DISABLE_CLOUD_CONFIG: "true"
   ENABLE_NVIDIA_GPU: "no"
   UPDATE_PEERPODS_CM: "yes"

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -249,30 +249,7 @@ function create_image_using_packer() {
     set_image_version_and_name
     # Set the base image details
 
-    if [[ "${PODVM_DISTRO}" == "rhel" ]]; then
-        export BASE_IMAGE_PUBLISHER="redhat"
-        export BASE_IMAGE_OFFER="rhel-raw"
-
-        # If CONFIDENTIAL_COMPUTE_ENABLED is set to yes, then force IMAGE_DEFINITION_VM_GENERATION to V2
-        [[ "${CONFIDENTIAL_COMPUTE_ENABLED}" == "yes" ]] &&
-            export IMAGE_DEFINITION_VM_GENERATION="V2"
-
-        # If CONFIDENTIAL_COMPUTE_ENABLED is set to yes, CONFIDENTIAL_COMPUTE_TYPE is snp and BASE_IMAGE_SKU is not set,
-        # then set BASE_IMAGE_SKU to 9_3_cvm_sev_snp
-        [[ "${CONFIDENTIAL_COMPUTE_ENABLED}" == "yes" && "${CONFIDENTIAL_COMPUTE_TYPE}" == "snp" && -z "${BASE_IMAGE_SKU}" ]] &&
-            export BASE_IMAGE_OFFER="rhel-cvm" && export BASE_IMAGE_SKU="9_3_cvm_sev_snp"
-
-        # If CONFIDENTIAL_COMPUTE_ENABLED is set to yes, CONFIDENTIAL_COMPUTE_TYPE is tdx and BASE_IMAGE_SKU is not set,
-        # then set BASE_IMAGE_SKU to rhel93_tdxpreview
-        [[ "${CONFIDENTIAL_COMPUTE_ENABLED}" == "yes" && "${CONFIDENTIAL_COMPUTE_TYPE}" == "tdx" && -z "${BASE_IMAGE_SKU}" ]] &&
-            export BASE_IMAGE_OFFER="rhel_test_offers" && export BASE_IMAGE_SKU="rhel93_tdxpreview"
-
-        # If VM_GENERATION is V1 and BASE_IMAGE_SKU is not set, then set BASE_IMAGE_SKU to 9_3
-        [[ "${IMAGE_DEFINITION_VM_GENERATION}" == "V1" && -z "${BASE_IMAGE_SKU}" ]] &&
-            export BASE_IMAGE_SKU="9_3"
-    else
-        # TBD Add support for other distros
-        # Error out if the distro is not supported
+    if [[ "${PODVM_DISTRO}" != "rhel" ]]; then
         error_exit "Unsupported distro"
     fi
 


### PR DESCRIPTION
this is base image without disk encryption which suits for peer-pods, CoCo TDX and CoCo SEV-SNP
CONFIDENTIAL_COMPUTE_TYPE is removed as not used anymore

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>
(cherry picked from commit 8492b92e73ef1bb0361b5e9e7363cce67f099967)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
