### PR TITLE
azure: Delete source image on cleanup

### DIFF
--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -774,9 +774,24 @@ function delete_image_using_id() {
     # IMAGE_ID shouldn't be empty
     [[ -z "${IMAGE_ID}" ]] && error_exit "IMAGE_ID is empty"
 
-    # Delete the image
+    # Rightmost element of the input is <image-version>
+    IMAGE_VERSION=${IMAGE_ID##*/}
+
+    # Get the id of the source image
+    SOURCE_ID=$(az sig image-version show --resource-group "${AZURE_RESOURCE_GROUP}" \
+        --gallery-name "${IMAGE_GALLERY_NAME}" \
+        --gallery-image-definition "${IMAGE_DEFINITION_NAME}" \
+        --gallery-image-version "${IMAGE_VERSION}" \
+        --query "storageProfile.source.id" --output tsv) ||
+        error_exit "Failed to get the source id"
+
+    # Delete the image version
     az sig image-version delete --ids "${IMAGE_ID}" ||
-        error_exit "Failed to delete the image"
+        error_exit "Failed to delete the image version"
+
+    # Delete the source image
+    az image delete --ids "${SOURCE_ID}" ||
+        error_exit "Failed to delete the source image"
 
     # Remove the image id annotation from peer-pods-cm configmap
     delete_image_id_annotation_from_peer_pods_cm

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -787,7 +787,7 @@ function delete_image_using_id() {
 
     # Delete the image version
     az sig image-version delete --ids "${IMAGE_ID}" ||
-        error_exit "Failed to delete the image version"
+        error_exit "Failed to delete image version ${IMAGE_ID}"
 
     # Delete the source image
     az image delete --ids "${SOURCE_ID}" ||

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -783,7 +783,7 @@ function delete_image_using_id() {
         --gallery-image-definition "${IMAGE_DEFINITION_NAME}" \
         --gallery-image-version "${IMAGE_VERSION}" \
         --query "storageProfile.source.id" --output tsv) ||
-        error_exit "Failed to get the source id"
+        error_exit "Failed to get the source id for image ${IMAGE_GALLERY_NAME} version ${IMAGE_VERSION} with definition ${IMAGE_DEFINITION_NAME}"
 
     # Delete the image version
     az sig image-version delete --ids "${IMAGE_ID}" ||

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -791,7 +791,8 @@ function delete_image_using_id() {
 
     # Delete the source image
     az image delete --ids "${SOURCE_ID}" ||
-        error_exit "Failed to delete the source image"
+        error_exit "Failed to delete the source image ${SOURCE_ID}"
+
 
     # Remove the image id annotation from peer-pods-cm configmap
     delete_image_id_annotation_from_peer_pods_cm


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

OSC creates the podvm image with packer by default and publishes it in a shared gallery. When the KataConfig CRD is deleted, OSC removes the gallery but the source image created by packer is left behind. This can generate uneeded storage costs to the customer.

Fortunately, the path to the source image is available in the output of `az sig image-version show`. Fix the podvm image deletion flow to also delete the source image.

Fixes: https://issues.redhat.com/browse/KATA-3462

**- How to verify it**

1. create KataConfig for a peer pods deployment on azure
2. `RESOURCE_GROUP=$(oc get cm -n openshift-sandboxed-containers-operator peer-pods-cm -o jsonpath='{.data.AZURE_RESOURCE_GROUP}')`
3. delete KataConfig
4. `az image list -g ${RESOURCE_GROUP}` should print `[]`.
