### PR TITLE
Update bundle manifests to include metrics-server

### DIFF
--- a/bundle/manifests/operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: prometheus-operator
+  name: operator-metrics-monitor
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: "8091"
+    scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app: operator-metrics-server

--- a/bundle/manifests/operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/operator-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operator-metrics-server
+  name: operator-metrics-service
+spec:
+  ports:
+  - port: 8091
+    protocol: TCP
+    targetPort: 8091
+  selector:
+    app: operator-metrics-server
+status:
+  loadBalancer: {}

--- a/bundle/manifests/osc-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/osc-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: osc-alerts
+spec:
+  groups:
+  - name: osc_alerts
+    rules:
+    - alert: KataRemoteWorkloadFailureHigh
+      annotations:
+        description: The failure ratio of kata-remote workloads is above 25% for more
+          than 30 minutes. This may indicate issues with the runtime or configuration.
+        summary: High Kata Remote Workload Failure Ratio
+      expr: kata_remote_workload_failure_ratio > 25
+      for: 30m
+      labels:
+        severity: warning
+    - alert: kata_active_instance
+      annotations:
+        summary: Kata instance alive signal
+      expr: vector(1)
+      labels:
+        purpose: alive_signal
+        severity: info

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-10-04T09:21:08Z"
+    createdAt: "2024-11-19T13:55:17Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -21,7 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.8.0'  ## OSC_VERSION
+    olm.skipRange: '>=1.1.0 <1.8.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -32,7 +32,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION
+  name: sandboxed-containers-operator.v1.8.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -411,17 +411,17 @@ spec:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
                 - name: RELATED_IMAGE_KATA_MONITOR
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
                 - name: SANDBOXED_CONTAINERS_EXTENSION
                   value: kata-containers
                 - name: RELATED_IMAGE_CAA
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0
                 - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0  ## OSC_VERSION
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0
                 - name: RELATED_IMAGE_PODVM_BUILDER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -429,7 +429,7 @@ spec:
                 - configMapRef:
                     name: peer-pods-cm
                     optional: true
-                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.0  ## OSC_VERSION
+                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.0
                 imagePullPolicy: Always
                 name: manager
                 ports:
@@ -508,6 +508,31 @@ spec:
                   defaultMode: 384
                   optional: true
                   secretName: ssh-key-secret
+      - label:
+          app: operator-metrics-server
+        name: operator-metrics-server
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: operator-metrics-server
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: operator-metrics-server
+            spec:
+              containers:
+              - command:
+                - /metrics-server
+                image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
+                name: metrics-server
+                ports:
+                - containerPort: 8091
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
       permissions:
       - rules:
         - apiGroups:
@@ -566,18 +591,18 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
     name: kata-monitor
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0
     name: caa
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0  ## OSC_VERSION
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0
     name: peerpods-webhook
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0
     name: podvm-payload
-  replaces: sandboxed-containers-operator.v1.7.0  ## OSC_VERSION_BEFORE
-  version: 1.8.0  ## VERSION
+  replaces: sandboxed-containers-operator.v1.7.0
+  version: 1.8.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.8.0  ## OSC_VERSION
+  newTag: v1.8.0

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.8.0'  ## OSC_VERSION
+    olm.skipRange: '>=1.1.0 <1.8.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -31,7 +31,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION
+  name: sandboxed-containers-operator.v1.8.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -372,8 +372,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  replaces: sandboxed-containers-operator.v1.7.0  ## OSC_VERSION_BEFORE
-  version: 1.8.0  ## OSC_VERSION
+  replaces: sandboxed-containers-operator.v1.7.0
+  version: 1.8.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - metrics-deployment.yaml
   - metrics-service.yaml
   - metrics-servicemonitor.yaml
+  - metrics-prometheus-rules.yaml

--- a/config/metrics/metrics-deployment.yaml
+++ b/config/metrics/metrics-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: metrics-server
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.7.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
           command: ["/metrics-server"]
           ports:
             - containerPort: 8091


### PR DESCRIPTION
Sorry if I missed this before. I was not using the OperatorHub to deploy them. Thanks @gkurz for spotting this.

There is one commit that I'm not sure we should include now or later. Its prefixed with RFC.