### PR TITLE
Bump to 1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.8.0  ## OSC_VERSION
+VERSION ?= 1.8.1  ## OSC_VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-11-19T13:55:17Z"
+    createdAt: "2024-11-29T15:05:07Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -21,7 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.8.0'
+    olm.skipRange: '>=1.1.0 <1.8.1'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -32,7 +32,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.8.0
+  name: sandboxed-containers-operator.v1.8.1
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -411,17 +411,17 @@ spec:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
                 - name: RELATED_IMAGE_KATA_MONITOR
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1
                 - name: SANDBOXED_CONTAINERS_EXTENSION
                   value: kata-containers
                 - name: RELATED_IMAGE_CAA
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.1
                 - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.1
                 - name: RELATED_IMAGE_PODVM_BUILDER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.1
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -429,7 +429,7 @@ spec:
                 - configMapRef:
                     name: peer-pods-cm
                     optional: true
-                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.0
+                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.1
                 imagePullPolicy: Always
                 name: manager
                 ports:
@@ -525,7 +525,7 @@ spec:
               containers:
               - command:
                 - /metrics-server
-                image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
+                image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1
                 name: metrics-server
                 ports:
                 - containerPort: 8091
@@ -591,18 +591,18 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1
     name: kata-monitor
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.1
     name: caa
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.1
     name: peerpods-webhook
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.1
     name: podvm-payload
-  replaces: sandboxed-containers-operator.v1.7.0
-  version: 1.8.0
+  replaces: sandboxed-containers-operator.v1.8.0
+  version: 1.8.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.8.0
+  newTag: v1.8.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,17 +77,17 @@ spec:
             - name: PEERPODS_NAMESPACE
               value: "openshift-sandboxed-containers-operator"
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1  ## OSC_VERSION
             - name: SANDBOXED_CONTAINERS_EXTENSION
               value: kata-containers
             - name: RELATED_IMAGE_CAA
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.8.1  ## OSC_VERSION
             - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.0 ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.8.1 ## OSC_VERSION
             - name: RELATED_IMAGE_PODVM_BUILDER
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1  ## OSC_VERSION
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.1  ## OSC_VERSION
           imagePullPolicy: Always
           resources:
             limits:

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.1.0 <1.8.0'
+    olm.skipRange: '>=1.1.0 <1.8.1'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -372,8 +372,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  replaces: sandboxed-containers-operator.v1.7.0
-  version: 1.8.0
+  replaces: sandboxed-containers-operator.v1.8.0
+  version: 1.8.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/metrics/metrics-deployment.yaml
+++ b/config/metrics/metrics-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: metrics-server
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
           command: ["/metrics-server"]
           ports:
             - containerPort: 8091

--- a/config/metrics/metrics-deployment.yaml
+++ b/config/metrics/metrics-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: metrics-server
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1  ## OSC_VERSION
           command: ["/metrics-server"]
           ports:
             - containerPort: 8091

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -15,7 +15,7 @@ spec:
       # /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz
       initContainers:
         - name: copy
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.1  ## OSC_VERSION
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -29,7 +29,7 @@ spec:
         - name: create
           # Binaries like kubectl, packer and yq are expected to be under /usr/local/bin
           # podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1  ## OSC_VERSION
           # This image contains the following
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -19,7 +19,7 @@ spec:
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           # Binaries like kubectl, packer and yq under /usr/local/bin
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           env:

--- a/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: delete-gallery
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.8.1  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           envFrom:

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.8.0  ## OSC_VERSION
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.8.1  ## OSC_VERSION
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,4 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.8.0  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.8.1  ## OSC_VERSION

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -131,20 +131,33 @@ Uncomment all entries marked with `[CERTMANAGER]` in manifest files under `confi
 make install && make deploy
 ```
 
+### Adding new containers to OSC
+
+When adding a new container definition in some pod yaml, make sure to tag the `image`
+field with `OSC_VERSION`, e.g.
+
+```
+image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+```
+
+Do the same when adding new `RELATED_IMAGE` entries in the environment of the controller
+in `config/manager/manager.yaml`, e.g.
+
+```
+            - name: RELATED_IMAGE_KATA_MONITOR
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+```
+
+This is a best effort to track locations where OSC version bumps should happen.
+
 ### Updating versions
 
-When starting a new version, the locations tagged with `OSC_VERSION` should be updated with the new version number. A few places are also tagged with `OSC_VERSION_BEFORE`, referring to the version being replaced.
+When starting a new version, several locations should be updated with the new version number :
+- all the locations tagged with `OSC_VERSION`
+- the `spec.version` field in `config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml`
+- the `olm.skipRange` annotation in the `spec.metadata` field in `config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml`
 
-On the  `main` branch `1.5.2`, the following locations were identified, but looking for the version pattern would give too many false positives on `devel` with `1.7.0`, and even more false positives were found with `1.8.0`. Most hits were in `go.mod` or `go.sum` and should be ignored, since they refer to dependencies with unrelated version numbering.
+The `spec.replaces` field in `config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml` should be updated with the number
+of the latest officialy released version.
 
-```
-Makefile:6:VERSION ?= 1.5.2
-config/manager/kustomization.yaml:16:  newTag: 1.5.2
-config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:16:    olm.skipRange: '>=1.1.0 <1.5.2'
-config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:28:  name: sandboxed-containers-operator.v1.5.2
-config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml:368:  version: 1.5.2
-config/samples/deploy.yaml:9: image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.5.2
-config/samples/deploy.yaml:39:  startingCSV: sandboxed-containers-operator.v1.5.2
-hack/aws-image-job.yaml:24:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
-hack/azure-image-job.yaml:23:        image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.5.2
-```
+Finally, run `make bundle` : this should propagate the version bump to the rest of the tree.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -137,7 +137,7 @@ When adding a new container definition in some pod yaml, make sure to tag the `i
 field with `OSC_VERSION`, e.g.
 
 ```
-image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1  ## OSC_VERSION
 ```
 
 Do the same when adding new `RELATED_IMAGE` entries in the environment of the controller
@@ -145,7 +145,7 @@ in `config/manager/manager.yaml`, e.g.
 
 ```
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1  ## OSC_VERSION
 ```
 
 This is a best effort to track locations where OSC version bumps should happen.


### PR DESCRIPTION
This is _slighly_ improving the OSC version bump workflow and puts it in practice to prepare the release of OSC 1.8.1.