### PR TITLE
RVPS value extraction script Modification to handle few cases.

### DIFF
--- a/scripts/rvps-extraction/GetRvps.sh
+++ b/scripts/rvps-extraction/GetRvps.sh
@@ -3,18 +3,18 @@
 
 function install_packages() {
     echo "***Installing necessary packages for RVPS values extraction ***"
-    dnf install -y python3 python3-cryptography kmod 
+    dnf install -y python3 python3-cryptography kmod
     echo "***Installation Finished ***"
 }
 
 # Function to mount the image and extract se.img
 function mount_and_extract_image() {
     local img_path=$1
-    
+
     # Cleanup any previous files and directories
     rm -rf se.img /mnt/myvm
     mkdir /mnt/myvm
-    
+
     # Load nbd module and mount the image
     modprobe nbd
     if [ $? -ne 0 ]; then
@@ -22,40 +22,62 @@ function mount_and_extract_image() {
         exit 1
     fi
 
-    qemu-nbd -c /dev/nbd3 $img_path
+
+    #Check the available nbd and use it
+    nbd_available=`lsblk | grep nbd | grep 0B | awk '{print $1}' | head -1`
+
+    #Check if 'nbd' is configured and nbd_available has a valid nbd value
+    if [[ ! $nbd_available =~ ^nbd ]]; then
+  	echo "nbd is not configured . Please configure it and check the output of 'lsblk' to verify if it lists the nbds"
+  	exit 1
+    fi
+
+    echo $nbd_available "looks available. Starting Mounting the image with it.."
+    qemu-nbd -c /dev/$nbd_available $img_path
+
     if [ $? -ne 0 ]; then
         echo "Error: Failed to connect to nbd device."
         exit 1
     fi
 
 
-    mount /dev/nbd3p1 /mnt/myvm
+
+    mount /dev/"$nbd_available"p1 /mnt/myvm
     if [ $? -ne 0 ]; then
          echo "Error: Failed to mount the image. Retrying..."
          sleep 2
-         mount /dev/nbd3p1 /mnt/myvm
+         mount /dev/"$nbd_available"p1 /mnt/myvm
          if [ $? -ne 0 ]; then
-     		echo "Retrial for mounting failed. Please rerun the script"
-     		exit 1
-	 else
-		echo "Mounting on second attempt passed"
+	       echo "Retrial of mounting is failed. Please check if LPAR is overloaded or try one LPAR reboot"
+	       qemu-nbd -d /dev/"$nbd_available"
+               exit 1
+         else
+               echo "Mounting on second attempt passed"
          fi
-     fi
+
+    fi
+
     # Extract and process image
     rm -rf $PWD/output-files
-    mkdir -p $PWD/output-files        
-    rm -rf se.img 
+    mkdir -p $PWD/output-files
+    rm -rf se.img
     cp /mnt/myvm/se.img ./
     mv se.img $PWD/output-files/
-    
+
     umount /mnt/myvm
-    qemu-nbd -d /dev/nbd3
+    qemu-nbd -d /dev/$nbd_available
 }
 
 # Function to generate se-sample and ibmse-policy.rego files
 function generate_policy_files() {
     local se_tag=$1
     local se_image_phkh=$2
+
+    if [ -z "$se_image_phkh" ]; then
+        echo "There seems to be some issue in HKD.crt. Please use the correct one and run it again."
+        exit 1
+    fi
+
 
     # Create se-sample file
     cat <<EOF > $PWD/output-files/se-sample
@@ -108,18 +130,18 @@ do
             read -r img_path
 
             mount_and_extract_image $img_path
-            
+
             $PWD/static-files/pvextract-hdr -o $PWD/output-files/hdr.bin $PWD/output-files/se.img
-            
+
             # Extract necessary values
             se_tag=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.tag | awk -F ":" '{ print $2 }')
             se_image_phkh=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.image_phkh | awk -F ":" '{ print $2 }')
-            
+
             echo "se.tag: $se_tag"
             echo "se.image_phkh: $se_image_phkh"
 
             generate_policy_files $se_tag $se_image_phkh
-            
+
             provenance=$(cat $PWD/output-files/se-sample | base64 --wrap=0)
             echo "provenance = $provenance"
 
@@ -134,7 +156,7 @@ EOF
 
             ls -lrt $PWD/output-files/hdr.bin $PWD/output-files/se-message $PWD/output-files/ibmse-policy.rego
             ;;
-        
+
         "Generate RVPS from Volume")
             echo "Enter the Libvirt Pool Name"
             read -r LIBVIRT_POOL
@@ -152,11 +174,11 @@ EOF
                 echo "Downloading Failed"
                 exit 1
             fi
-            
+
             img_path=$PWD/PODVM-VOL-IMAGE/podvm_test.qcow2
-            
+
             mount_and_extract_image $img_path
-            
+
             $PWD/static-files/pvextract-hdr -o $PWD/output-files/hdr.bin $PWD/output-files/se.img
 
             # Extract necessary values
@@ -167,7 +189,7 @@ EOF
             echo "se.image_phkh: $se_image_phkh"
 
             generate_policy_files $se_tag $se_image_phkh
-            
+
             provenance=$(cat $PWD/output-files/se-sample | base64 --wrap=0)
             echo "provenance = $provenance"
 
@@ -182,11 +204,11 @@ EOF
 
             ls -lrt $PWD/output-files/hdr.bin $PWD/output-files/se-message $PWD/output-files/ibmse-policy.rego
             ;;
-        
+
         "Quit")
             break
             ;;
-        
+
         *) echo "Invalid option: $REPLY";;
     esac
 done


### PR DESCRIPTION
Description: The script needs to be modified to find 'nbd' device which is available. Also in case , HKD.crt has some issue then the script needs to produce appropriate error.


Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
1. There were a few cases where the HKD was incorrect, and script was giving blank values for parameters. This took long time to debug.
2. The script is using 'nbd3' as a default network block device which should be changed. In case 'nbd3' is not available, the script should use next available device.

More details are here -
https://issues.redhat.com/browse/KATA-3495

**- What I did**
Applied necessary changes to cater these 2.

**- How to verify it**
1. Run the script
2. Check extraction of RVPS from image which is there in local pc.
4. Check extraction of RVPS from iamge which is there in volume.
5. Try to give incorrect HKD.crt and check if it is giving proper error message.

**- Description for the changelog**
RVPS script enhancement.
