### PR TITLE
KATA-3270: pod overhead for peer pods reduce actual worker capacity

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -78,15 +78,16 @@ const (
 	peerpodsCrioMachineConfigYaml       = "mc-50-crio-config.yaml"
 	peerpodsKataRemoteMachineConfig     = "40-worker-kata-remote-config"
 	peerpodsKataRemoteMachineConfigYaml = "mc-40-kata-remote-config.yaml"
-	kataRuntimeClassName                = "kata"
-	kataRuntimeClassCpuOverhead         = "0.25"
-	kataRuntimeClassMemOverhead         = "160Mi"
-	peerpodsRuntimeClassName            = "kata-remote"
-	peerpodsRuntimeClassCpuOverhead     = "0.25"
-	peerpodsRuntimeClassMemOverhead     = "120Mi"
 	// Use same Pod Overhead as upstream kata-deploy using, see
 	// https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/runtimeclasses/kata-qemu.yaml#L7
+	kataRuntimeClassName        = "kata"
+	kataRuntimeClassCpuOverhead = "0.25"
+	// We need a higher value than upstream (see https://github.com/openshift/sandboxed-containers-operator/pull/84)
+	kataRuntimeClassMemOverhead = "350Mi"
 	// https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/runtimeclasses/kata-remote.yaml#L7
+	peerpodsRuntimeClassName        = "kata-remote"
+	peerpodsRuntimeClassCpuOverhead = "0.25"
+	peerpodsRuntimeClassMemOverhead = "120Mi"
 )
 
 // +kubebuilder:rbac:groups=kataconfiguration.openshift.io,resources=kataconfigs;kataconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -702,7 +703,6 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 				Name: runtimeClassName,
 			},
 			Handler: runtimeClassName,
-
 			Overhead: &nodeapi.Overhead{
 				PodFixed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse(cpuOverhead),

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -78,9 +78,15 @@ const (
 	peerpodsCrioMachineConfigYaml       = "mc-50-crio-config.yaml"
 	peerpodsKataRemoteMachineConfig     = "40-worker-kata-remote-config"
 	peerpodsKataRemoteMachineConfigYaml = "mc-40-kata-remote-config.yaml"
+	kataRuntimeClassName                = "kata"
+	kataRuntimeClassCpuOverhead         = "0.25"
+	kataRuntimeClassMemOverhead         = "160Mi"
 	peerpodsRuntimeClassName            = "kata-remote"
 	peerpodsRuntimeClassCpuOverhead     = "0.25"
-	peerpodsRuntimeClassMemOverhead     = "350Mi"
+	peerpodsRuntimeClassMemOverhead     = "120Mi"
+	// Use same Pod Overhead as upstream kata-deploy using, see
+	// https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/runtimeclasses/kata-qemu.yaml#L7
+	// https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/runtimeclasses/kata-remote.yaml#L7
 )
 
 // +kubebuilder:rbac:groups=kataconfiguration.openshift.io,resources=kataconfigs;kataconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -696,8 +702,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 				Name: runtimeClassName,
 			},
 			Handler: runtimeClassName,
-			// Use same values for Pod Overhead as upstream kata-deploy using, see
-			// https://github.com/kata-containers/packaging/blob/f17450317563b6e4d6b1a71f0559360b37783e19/kata-deploy/k8s-1.18/kata-runtimeClasses.yaml#L7
+
 			Overhead: &nodeapi.Overhead{
 				PodFixed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse(cpuOverhead),
@@ -1169,7 +1174,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 	if !isMcoUpdating {
 		r.Log.Info("create runtime class")
 		r.resetInProgressCondition()
-		err := r.createRuntimeClass("kata", "0.25", "350Mi")
+		err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead)
 		if err != nil {
 			// Give sometime for the error to go away before reconciling again
 			return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Peer pods' overhead reduce actual worker capacity, however most of the RAM/CPU allocated in cloud instance.

Fixes: [KATA-3270](https://issues.redhat.com/browse/KATA-3270)

**- What I did**

Operator create 'kata-remote' runtime class with a specific and lower overhead, like in upstream.

**- How to verify it**
1. create KataConfig for a peer pods
2. check 'kata-remote' runtime class created a lower overhead than 'kata' runtime class
3. 
**- Description for the changelog**
Use separate pod's overhead related constants for kata and peer pods.

[EDIT from Greg: adapted description to final version]
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
