### PR TITLE
Build and deploy the metrics server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY PROJECT PROJECT
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY main.go main.go
+COPY cmd/metrics cmd/metrics/
 COPY api api/
 COPY config config/
 COPY controllers controllers/
@@ -26,6 +27,7 @@ RUN make build
 FROM ${TARGET_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
+COPY --from=builder /workspace/bin/metrics-server .
 COPY --from=builder /workspace/config/peerpods /config/peerpods
 
 RUN useradd  -r -u 499 nonroot

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-12-13T13:12:54Z"
+    createdAt: "2024-12-16T08:07:37Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -495,7 +495,7 @@ spec:
               containers:
               - command:
                 - /metrics-server
-                image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1
+                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.8.1
                 name: metrics-server
                 ports:
                 - containerPort: 8091

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -1,5 +1,12 @@
 resources:
-  - metrics-deployment.yaml
-  - metrics-service.yaml
-  - metrics-servicemonitor.yaml
-  - metrics-prometheus-rules.yaml
+- metrics-deployment.yaml
+- metrics-service.yaml
+- metrics-servicemonitor.yaml
+- metrics-prometheus-rules.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: metrics-server
+  newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
+  newTag: v1.8.1

--- a/config/metrics/metrics-deployment.yaml
+++ b/config/metrics/metrics-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: metrics-server
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.8.1  ## OSC_VERSION
+          image: metrics-server:latest
           command: ["/metrics-server"]
           ports:
             - containerPort: 8091


### PR DESCRIPTION
The metrics server is deployed alongside the OSC controller to collect SLI/SLO oriented metrics. It is currently assumed to be shipped in the OSC monitor image. This is suboptimal since the OSC repo doesn't build the OSC monitor image.

Build it and deploy it in the same container image as the controller. This is clearer and ensures a custom operator build also has a functional metrics server. This will also avoid the e2e check in the upstream CI to fail because the OSC monitor image isn't published yet.