### PR TITLE
Switch base image of OSC to rhel9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use OpenShift golang builder image
 # These images needs to be synced with the images in the Makefile.
 ARG BUILDER_IMAGE=${BUILDER_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17}
-ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.ci.openshift.org/ocp/4.17:base}
+ARG TARGET_IMAGE=${TARGET_IMAGE:-registry.ci.openshift.org/ocp/4.17:base-rhel9}
 FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 
 # These images needs to be synced with the default values in the Dockerfile.
 BUILDER_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
-TARGET_IMAGE  ?= registry.ci.openshift.org/ocp/4.17:base
+TARGET_IMAGE  ?= registry.ci.openshift.org/ocp/4.17:base-rhel9
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,7 +33,7 @@ does the trick.
 
 ```shell
 export BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:golang-1.22
-export TARGET_IMAGE=registry.ci.openshift.org/origin/4.17:base
+export TARGET_IMAGE=registry.ci.openshift.org/origin/4.17:base-rhel9
 make docker-build
 ```
 


### PR DESCRIPTION
For the sake of being consistent with the builder which is rhel9 already.

