### PR TITLE
baremetal-coco: tdx: Add DCAP deployment

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -473,6 +473,17 @@ function verify_params() {
 
 }
 
+function uninstall_intel_device_plugins() {
+    echo "Intel Device Plugins operator | starting the uninstall"
+
+    pushd intel-dpo || return 1
+    oc delete -f sgx_device_plugin.yaml || return 1
+    oc delete -f install_operator.yaml || return 1
+    popd || return 1
+
+    echo "Intel Device Plugins operator | deployment uninstalled successfully"
+}
+
 function uninstall_node_feature_discovery() {
     tee_type="${1:-}"
 
@@ -501,6 +512,10 @@ function uninstall_node_feature_discovery() {
 # It won't delete the cluster
 function uninstall() {
     echo "Uninstalling all the artifacts"
+
+    if [ "$TEE_TYPE" = "tdx" ]; then
+        uninstall_intel_device_plugins || exit 1
+    fi
 
     # Uninstall NFD
     uninstall_node_feature_discovery "$TEE_TYPE" || return 1

--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -287,13 +287,13 @@ EOF
     echo "KataConfig object successfully created"
 }
 
-# Function to set aa_kbc_params for teh Kata agent to be used for
+# Function to set kernel_params for teh Kata agent to be used for
 # attestation
 # Use drop-in configuration via MachineConfig
 # This function accepts the TEE type as an argument
 # It also accepts the Trustee URL as an argument
 # Trustee URL should be complete URL with the form http(s)://<trustee_ip>:<port>
-function set_aa_kbc_params_for_kata_agent() {
+function set_kernel_params_for_kata_agent() {
     local tee_type=${1}
     local trustee_url=${2}
     local source=""
@@ -731,7 +731,7 @@ wait_for_runtimeclass kata || exit 1
 create_runtimeclasses "$TEE_TYPE" || exit 1
 
 # set the aa_kbc_params config for the kata agent to be used CoCo attestation
-set_aa_kbc_params_for_kata_agent "$TEE_TYPE" "$TRUSTEE_URL" || exit 1
+set_kernel_params_for_kata_agent "$TEE_TYPE" "$TRUSTEE_URL" || exit 1
 
 # If single node OpenShift, then wait for the master MCP to be ready
 # Else wait for kata-oc MCP to be ready

--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -652,6 +652,9 @@ verify_params || exit 1
 # Check if oc command is available
 check_command "oc" || exit 1
 
+# Check if jq command is available
+check_command "jq" || exit 1
+
 # Display the cluster information
 oc cluster-info || exit 1
 
@@ -668,8 +671,6 @@ fi
 # If ADD_IMAGE_PULL_SECRET is true, then add additional cluster-wide image pull secret
 if [ "$ADD_IMAGE_PULL_SECRET" = true ]; then
     echo "Adding additional cluster-wide image pull secret"
-    # Check if jq command is available
-    check_command "jq" || exit 1
     add_image_pull_secret || exit 1
 
     echo "Waiting for MCP to be ready"

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/ns.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-dcap

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pccs-config
+  namespace: intel-dcap
+data:
+  default.json: |
+    {
+      "HTTPS_PORT" : 8042,
+      "hosts" : "0.0.0.0",
+      "uri": "https://api.trustedservices.intel.com/sgx/certification/v4/",
+      "ApiKey" : "${PCCS_API_KEY}",
+      "proxy" : "${CLUSTER_HTTPS_PROXY}",
+      "RefreshSchedule": "0 0 1 * * *",
+      "UserTokenHash" : "${PCCS_USER_TOKEN_HASH}",
+      "AdminTokenHash" : "${PCCS_ADMIN_TOKEN_HASH}",
+      "CachingFillMode" : "LAZY",
+      "OPENSSL_FIPS_MODE" : false,
+      "LogLevel" : "info",
+      "DB_CONFIG" : "sqlite",
+      "sqlite" : {
+        "database" : "${PCCS_DB_NAME}",
+        "username" : "${PCCS_DB_USERNAME}",
+        "password" : "${PCCS_DB_PASSWORD}",
+        "options" : {
+          "host": "localhost",
+          "dialect": "sqlite",
+          "pool": {
+            "max": 5,
+            "min": 0,
+            "acquire": 30000,
+            "idle": 10000
+          },
+          "define": {
+            "freezeTableName": true
+          },
+          "logging" : true,
+          "storage": "/var/cache/pccs/pckcache.db"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pccs-tls
+  namespace: intel-dcap
+type: Opaque
+data:
+  private.pem: ${PCCS_PEM}
+  file.crt: ${PCCS_CERT}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pccs-service
+  namespace: intel-dcap
+spec:
+  selector:
+    trustedservices.intel.com/cache: pccs
+  ports:
+  - name: pccs
+    protocol: TCP
+    port: 8042
+    targetPort: pccs-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pccs
+  namespace: intel-dcap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pccs
+  template:
+    metadata:
+      labels:
+        app: pccs
+        trustedservices.intel.com/cache: pccs
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ${PCCS_NODE}
+      initContainers:
+       - name: init-seclabel
+         image: quay.io/openshift_sandboxed_containers/init-seclabel:latest
+         command: ["sh", "-c", "chcon -Rt container_file_t /var/cache/pccs"]
+         volumeMounts:
+         - name: host-database
+           mountPath: /var/cache/pccs
+         securityContext:
+           runAsUser: 0
+           runAsGroup: 0
+           privileged: true  # Required for chcon to work on host files
+      containers:
+        - name: pccs
+          image: quay.io/openshift_sandboxed_containers/dcap/pccs:1.21
+          ports:
+            - containerPort: 8042
+              name: pccs-port
+          volumeMounts:
+            - name: pccs-tls
+              mountPath: /opt/intel/pccs/ssl_key
+              readOnly: true
+            - name: pccs-config
+              mountPath: /opt/intel/pccs/config
+              readOnly: true
+            - name: host-database
+              mountPath: /var/cache/pccs/
+          securityContext:
+            runAsUser: 0
+      volumes:
+        - name: pccs-tls
+          secret:
+            secretName: pccs-tls
+        - name: pccs-config
+          configMap:
+            name: pccs-config
+        - name: host-database
+          hostPath:
+            path: /var/cache/pccs/
+            type: DirectoryOrCreate

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qgs-config
+  namespace: intel-dcap
+data:
+  qgs.conf: |
+    port = 4050
+    number_threads = 4
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sgx-default-qcnl-conf
+  namespace: intel-dcap
+data:
+  sgx_default_qcnl.conf: |
+    {
+      "pccs_url": "https://pccs-service:8042/sgx/certification/v4/",
+      "use_secure_cert": false,
+      "retry_times": 6,
+      "retry_delay": 10,
+      "pck_cache_expire_hours": 168,
+      "verify_collateral_cache_expire_hours": 168,
+      "local_cache_only": false
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tdx-qgs
+  namespace: intel-dcap
+spec:
+  nodeSelector:
+    intel.feature.node.kubernetes.io/tdx: true
+  selector:
+    matchLabels:
+      app: tdx-qgs
+  template:
+    metadata:
+      labels:
+        app: tdx-qgs
+      annotations:
+        sgx.intel.com/quote-provider: tdx-qgs
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: tdx-qgs
+          image: quay.io/openshift_sandboxed_containers/dcap/tdx-qgs:1.21
+          workingDir: /opt/intel/tdx-qgs
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          resources:
+            limits:
+              sgx.intel.com/epc: "512Ki"
+              sgx.intel.com/enclave: 1
+              sgx.intel.com/provision: 1
+          volumeMounts:
+            - name: qgs-config
+              mountPath: /etc/qgs.conf
+              subPath: qgs.conf
+            - name: sgx-default-qcnl-conf
+              mountPath: /etc/sgx_default_qcnl.conf
+              subPath: sgx_default_qcnl.conf
+      volumes:
+        - name: qgs-config
+          configMap:
+            name: qgs-config
+        - name: sgx-default-qcnl-conf
+          configMap:
+            name: sgx-default-qcnl-conf

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/registration-ds.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/registration-ds.yaml.in
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pccs-registration
+  namespace: intel-dcap
+type: Opaque
+data:
+  USER_TOKEN: ${USER_TOKEN}
+  PCCS_URL: ${PCCS_URL}
+  SECURE_CERT: ${SECURE_CERT}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-dcap-registration-flow
+  namespace: intel-dcap
+spec:
+  selector:
+    matchLabels:
+      name: intel-dcap-registration-flow
+  template:
+    metadata:
+      labels:
+        name: intel-dcap-registration-flow
+    spec:
+      nodeSelector:
+        intel.feature.node.kubernetes.io/sgx: 'true'
+      automountServiceAccountToken: false
+      containers:
+      - name: intel-dcap-registration-flow
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: true
+          privileged: true # Required to access host efivarfs
+        volumeMounts:
+          - name: efivars
+            mountPath: /sys/firmware/efi/efivars
+        workingDir: "/opt/intel/sgx-pck-id-retrieval-tool/"
+        image: quay.io/openshift_sandboxed_containers/dcap/dcap-registration-flow:latest
+        imagePullPolicy: IfNotPresent
+        envFrom:
+        - secretRef:
+            name: pccs-registration
+      volumes:
+        - name: efivars
+          hostPath:
+            path: /sys/firmware/efi/efivars/


### PR DESCRIPTION
Please, see each commit message for a better explanation of what's being done.

This is out for early testing, and there are a few things to consider:
* We will **NOT** require any SELinux changes, as I was able to work that requirement around with an init container
* Tests must be performed on multi-node setup, as so far it's only been tested on single node ones

I will give instructions to @bpradipt, and give him access to a clean SNO cluster, so he can go ahead and give it a try during the time I will be off.

**KNOWN ISSUES**:
- [x] Registration on a factory reset machine leads to the following error:
  * From the registration pods logs:
  ```
  Error: unexpected error occurred while sending data to cache server.
  Error: the data couldn't be sent to cache server!

  Intel(R) Software Guard Extensions PCK Cert ID Retrieval Tool Version 1.22.100.3

  Warning: platform manifest is not available or current platform is not multi-package platform.
  ```
  * From the pccs pod logs:
  ```
  2024-12-19 19:03:00.253 [info]: Client Request-ID : 27fdde775ad94d3e8274ed805ab4ba8b
  2024-12-19 19:03:00.257 [info]: Executing (default): SELECT `qe_id`, `pce_id`, `platform_manifest`, `enc_ppid`, `fmspc`, `ca`, `created_time`, `updated_time` FROM `platforms` AS `Platforms` WHERE `Platforms`.`qe_id` = '16D27A5828C08A20BAE67D9EA535B88B' AND `Platforms`.`pce_id` = '0000';
  2024-12-19 19:03:00.582 [info]: Request-ID is : 4b80d2c7d79b4357bda779a72422dc89
  2024-12-19 19:03:00.582 [debug]: Request URL https://api.trustedservices.intel.com/sgx/certification/v4/pckcerts
  2024-12-19 19:03:00.583 [error]: Intel PCS server returns error(404).
  2024-12-19 19:03:00.583 [error]: Error: No cache data for this platform.
    at Module.getPckCertFromPCS (file:///opt/intel/pccs/services/logic/commonCacheLogic.js:159:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async LazyCachingMode.registerPlatforms (file:///opt/intel/pccs/services/caching_modes/cachingMode.js:163:7)
    at async Module.registerPlatforms (file:///opt/intel/pccs/services/platformsRegService.js:107:3)
    at async postPlatforms (file:///opt/intel/pccs/controllers/platformsController.js:52:5)
  2024-12-19 19:03:00.586 [info]: 10.128.0.40 - - [19/Dec/2024:19:03:00 +0000] "POST /sgx/certification/v4/platforms HTTP/1.1" 404 32 "-" "-"
  ```
- [x] registration pod may start before the pccs pod after a reboot