### PR TITLE
Create libvirt pool and volume on KVM host & libvirt config map update

### DIFF
--- a/config/peerpods/peerpodscm.yaml
+++ b/config/peerpods/peerpodscm.yaml
@@ -8,4 +8,4 @@ data:
   #LIBVIRT_NET: "default
   #LIBVIRT_POOL: "default"
   #LIBVIRT_VOL_NAME: "default"
-  #LIBVIRT_DIR_NAME: "/var/lib/libvirt/images/"
+  #LIBVIRT_DIR_NAME: "/var/lib/libvirt/images/default"

--- a/config/peerpods/peerpodscm.yaml
+++ b/config/peerpods/peerpodscm.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 data:
   #CLOUD_PROVIDER: "libvirt"
+  #LIBVIRT_NET: "default
+  #LIBVIRT_POOL: "default"
+  #LIBVIRT_VOL_NAME: "default"
+  #LIBVIRT_DIR_NAME: "/var/lib/libvirt/images/"

--- a/config/peerpods/peerpodssecret.yaml
+++ b/config/peerpods/peerpodssecret.yaml
@@ -7,8 +7,6 @@ type: Opaque
 stringData:
   #CLOUD_PROVIDER: "libvirt"
   #LIBVIRT_URI: "qemu+ssh://root@192.168.122.1/system?no_verify=1"
-  #LIBVIRT_NET: "default
-  #LIBVIRT_POOL: "default"
   #REDHAT_OFFLINE_TOKEN: "" #Required to download rhel base image : Download token from https://access.redhat.com/management/api
   #HOST_KEY_CERTS: "" #Download the certificate from https://www.ibm.com/support/resourcelink/api/content/public/host-key-documents.html and make sure the certficate lines are aligned
   # Example:

--- a/config/peerpods/podvm/README.md
+++ b/config/peerpods/podvm/README.md
@@ -37,7 +37,7 @@ provided config.
 
 ## PodVM Image Upload Configuration
 
-The PodVM image can be embedded into a container image. This container image can then be unwrapped and uploaded to the libvirt volume specified in the `peer-pods-secret`. Please note that this feature is currently supported only for the libvirt provider.
+The PodVM image can be embedded into a container image. This container image can then be unwrapped and uploaded to the libvirt volume specified in the `peer-pods-cm`. Please note that this feature is currently supported only for the libvirt provider.
 
 To create an OCI image with the PodVM image, you can use the `Dockerfile.podvm-oci` as follows:
 

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -599,9 +599,9 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 	// azure ConfigMap Keys
 	azureConfigMapKeys := []string{"AZURE_RESOURCE_GROUP", "AZURE_REGION", "CLOUD_PROVIDER"}
 	// libvirt Secret Keys
-	libvirtSecretKeys := []string{"CLOUD_PROVIDER", "LIBVIRT_URI", "LIBVIRT_POOL", "LIBVIRT_VOL_NAME"}
+	libvirtSecretKeys := []string{"CLOUD_PROVIDER", "LIBVIRT_URI"}
 	// libvirt ConfigMap Keys
-	libvirtConfigMapKeys := []string{"CLOUD_PROVIDER"}
+	libvirtConfigMapKeys := []string{"CLOUD_PROVIDER", "LIBVIRT_POOL", "LIBVIRT_VOL_NAME", "LIBVIRT_DIR_NAME"}
 
 	// Check for each cloud provider if respective ConfigMap keys are present in the peerPodsConfigMap
 	switch r.provider {


### PR DESCRIPTION
- Description of the problem which is fixed/What is the use case
Added script to Automatically create libvirt pool and volume on KVM host - https://github.com/openshift/sandboxed-containers-operator/issues/435


Adding some test log results :

```
Checking existence of libvirt pool 'sl-pool-1' and volume 'sl-volume-1'...
virsh -d 0 -c 'qemu+ssh://root@192.168.122.1/system?no_verify=1' pool-info 'sl-pool-1'
pool-info: pool(optdata): sl-pool-1
pool-info: found option <pool>: sl-pool-1
pool-info: <pool> trying as pool NAME
error: failed to get pool 'sl-pool-1'
error: Storage pool not found: no storage pool with matching name 'sl-pool-1'
vol-info: pool(optdata): sl-pool-1
vol-info: vol(optdata): sl-volume-1
vol-info: found option <pool>: sl-pool-1
vol-info: <pool> trying as pool NAME
error: failed to get pool 'sl-pool-1'
error: Storage pool not found: no storage pool with matching name 'sl-pool-1'
Libvirt pool 'sl-pool-1' or volume 'sl-volume-1' does not exist. Proceeding to create...
pool-define-as: name(optdata): sl-pool-1
pool-define-as: type(optdata): dir
pool-define-as: target(optdata): /var/lib/libvirt/images
Pool sl-pool-1 defined
pool-start: pool(optdata): sl-pool-1
pool-start: found option <pool>: sl-pool-1
pool-start: <pool> trying as pool NAME
Pool sl-pool-1 started
vol-create-as: pool(optdata): sl-pool-1
vol-create-as: name(optdata): sl-volume-1
vol-create-as: capacity(optdata): 20G
vol-create-as: allocation(optdata): 2G
vol-create-as: prealloc-metadata(bool)
vol-create-as: format(optdata): qcow2
vol-create-as: found option <pool>: sl-pool-1
vol-create-as: <pool> trying as pool NAME
Vol sl-volume-1 created
Created libvirt pool and volume successfully.
Creating qcow2 image for libvirt provider from scratch

```

If pool and volume already exsist:

```
Checking existence of libvirt pool 'sl-pool-1' and volume 'sl-volume-1'...
virsh -d 0 -c 'qemu+ssh://root@192.168.122.1/system?no_verify=1' pool-info 'sl-pool-1'
pool-info: pool(optdata): sl-pool-1
pool-info: found option <pool>: sl-pool-1
pool-info: <pool> trying as pool NAME
Name:      sl-pool-1
UUID:      d9dc84d3-9a18-4833-8d66-95c2dc26aa9b
State:     running
Pool persistent flag value: 1
Persistent:   yes
Autostart:   no
Capacity:    2.00 TiB
Allocation:   1.32 TiB
Available:   699.47 GiB
vol-info: pool(optdata): sl-pool-1
vol-info: vol(optdata): sl-volume-1
vol-info: found option <pool>: sl-pool-1
vol-info: <pool> trying as pool NAME
vol-info: found option <vol>: sl-volume-1
vol-info: <vol> trying as vol name
Name:      sl-volume-1
Type:      file
Capacity:    100.00 GiB
Allocation:   1.13 GiB
Disclaimer: A Libvirt pool named 'sl-pool-1' with volume 'sl-volume-1' already exists on the KVM host. Image will be uploaded to same volume.
Creating qcow2 image for libvirt provider from scratch
```

Deleting test log result :

```
Deleting Libvirt image id
Deleting Libvirt image
vol-delete: pool(optdata): sl-pool-1
vol-delete: vol(optdata): sl-volume-1
vol-delete: found option <pool>: sl-pool-1
vol-delete: <pool> trying as pool NAME
vol-delete: found option <vol>: sl-volume-1
vol-delete: <vol> trying as vol name
Vol sl-volume-1 deleted
Volume 'sl-volume-1' deleted successfully.
Other volumes are present in the pool. Pool will not be deleted.
Deleted libvirt image successfully
Deleting libvirt volume from peer-pods-cm configmap
configmap/peer-pods-cm patched
libvirt image id deleted from peer-pods-cm configmap successfully
configmap/peer-pods-cm patched (no change)

```