### PR TITLE
Adding libvirt provider to helper interactive script for setting peer-pods-cm

### DIFF
--- a/scripts/cm-helpers/README.md
+++ b/scripts/cm-helpers/README.md
@@ -8,6 +8,7 @@ cloud provider, recommended best practices, and user-provided input.
 ### Supported Cloud Providers
 * AWS
 * Azure
+* Libvirt
 
 ### Prerequisites
 * jq, kubectl or oc installed

--- a/scripts/cm-helpers/pp-cm-helper.sh
+++ b/scripts/cm-helpers/pp-cm-helper.sh
@@ -47,6 +47,8 @@ aws_optional=("PODVM_AMI_ID")
 azure_vars=("AZURE_INSTANCE_SIZE" "AZURE_INSTANCE_SIZES" "AZURE_SUBNET_ID" "AZURE_NSG_ID" "AZURE_REGION" "AZURE_RESOURCE_GROUP")
 azure_optional=("AZURE_IMAGE_ID")
 
+libvirt_vars=("LIBVIRT_POOL" "LIBVIRT_VOL_NAME" "LIBVIRT_DIR_NAME")
+libvirt_optional=("LIBVIRT_IMAGE_ID")
 
 #### Functions
 
@@ -160,6 +162,11 @@ function getLocalDefaults() {
     AZURE_INSTANCE_SIZE=${AZURE_INSTANCE_SIZE:-${AZURE_INSTANCE_SIZE_default}}
     [[ "${DISABLECVM}" == true ]] && AZURE_INSTANCE_SIZES=${AZURE_INSTANCE_SIZES:-Standard_B2als_v2,Standard_D2as_v5,Standard_D4as_v5,Standard_D2ads_v5}
     #AZURE_IMAGE_ID=${AZURE_IMAGE_ID}
+
+    # libvirt
+    LIBVIRT_POOL=${LIBVIRT_POOL:-default}
+    LIBVIRT_VOL_NAME=${LIBVIRT_VOL_NAME:-default}
+    LIBVIRT_DIR_NAME=${LIBVIRT_DIR_NAME:-default}
 }
 
 function userVerification() {
@@ -173,6 +180,10 @@ function userVerification() {
         "azure")
             verifyAndSetVars "${azure_vars[@]}"
             verifyAndSetVars "${azure_optional[@]}"
+            ;;
+        "libvirt")
+            verifyAndSetVars "${libvirt_vars[@]}"
+            verifyAndSetVars "${libvirt_optional[@]}"
             ;;
         *)
             error_exit "Invalid provider";;
@@ -227,7 +238,11 @@ function initialization() {
 
 initialization
 
-getIMDSDefaults
+if [ "$cld" != "libvirt" ]; then
+    getIMDSDefaults
+else
+    echo "Provider is libvirt, skipping getIMDSDefaults."
+fi
 
 getLocalDefaults
 


### PR DESCRIPTION
Currently helper script has only support for AWS and Azure extending it to Libvirt as well.

```
[root@bastion-sl ~]# ./cm-helper.sh ch
##### OSC ConfigMap Configurator #####
Cluster infrastructure is libvirt
Env file: /tmp/pp-cm-env-HDIJ.env
Provider is libvirt, skipping getIMDSDefaults.

###### Setting Values (press Enter for the [suggested] value, "drop" to remove key)
CLOUD_PROVIDER [libvirt]: 
VXLAN_PORT [9000]: 
PROXY_TIMEOUT [5m]: 
DISABLECVM [true]: 
LIBVIRT_POOL [default]: sl-testing
LIBVIRT_VOL_NAME [default]: sl-testing
LIBVIRT_DIR_NAME [default]: /var/lib/libvirt/images/
Cloud Provider is libvirt

###### Applying
Apply the Changes to the peer-pods-cm ConfigMap? [y/N] y
configmap/peer-pods-cm created
{
  "CLOUD_PROVIDER": "libvirt",
  "DISABLECVM": "true",
  "LIBVIRT_DIR_NAME": "/var/lib/libvirt/images/",
  "LIBVIRT_POOL": "sl-testing",
  "LIBVIRT_VOL_NAME": "sl-testing",
  "PROXY_TIMEOUT": "5m",
  "VXLAN_PORT": "9000"
}
Restart DaemonSet so that CM will be taken into account? [y/N] N
[root@bastion-sl ~]# 
```