### PR TITLE
baremetal-coco: Remove leftover instruction from the script

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -663,7 +663,6 @@ function uninstall() {
     echo "Uninstalling all the artifacts"
 
     if [ "$TEE_TYPE" = "tdx" ]; then
-	oc delete -f mc-vsock-loopback-module.yaml || exit 1
         echo "Waiting for MCP to be READY"
         # If single node OpenShift, then wait for the master MCP to be ready
         # Else wait for kata-oc MCP to be ready


### PR DESCRIPTION
This was mistakenly added in order to try to enforce that the vsock_loopback module was loaded, and then ended up being removed as part of the series enabling DCAP for TDX.  However, this part slipped the developers and reviews (sorry!).