### PR TITLE
Add config files to create RHCOS layered image

### DIFF
--- a/config/rhcos-layer/.gitignore
+++ b/config/rhcos-layer/.gitignore
@@ -1,0 +1,2 @@
+snp/rhcos-coco-snp.initrd.tar.xz
+tdx/kata-containers-tdx-repo.tar.xz

--- a/config/rhcos-layer/Makefile
+++ b/config/rhcos-layer/Makefile
@@ -1,0 +1,89 @@
+# Default variables
+
+REGISTRY_AUTH_FILE := ocp_pull_secret.json
+IMAGE_STD ?= quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:latest
+IMAGE_TDX ?= quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:tdx-latest
+IMAGE_SNP ?= quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:snp-latest
+KATA_COCO_ARTEFACTS ?= quay.io/openshift_sandboxed_containers/kata-coco-artefacts:latest
+
+TEE ?=
+
+# Default target
+.PHONY: build
+build:  check-podman get-pull-secret get-ocp-release-image ## Default target: Build the RHCOS layer
+	@echo "Building RHCOS layer..."
+	@if [ "$(TEE)" == "" ]; then \
+		echo "Building standard RHCOS layer with kata binaries"  ;\
+		podman build --authfile $(REGISTRY_AUTH_FILE) --build-arg OCP_RELEASE_IMAGE=$(shell cat ./.ocp-release-image) -t $(IMAGE_STD) -f standard/Containerfile . ;\
+	elif [ "$(TEE)" == "tdx" ]; then \
+		echo "Building tdx RHCOS layer with kata binaries" ;\
+		podman create --name kata $(KATA_COCO_ARTEFACTS) ;\
+		podman cp kata:/kata-containers-tdx-repo.tar.xz tdx/ ;\
+		podman rm kata ;\
+		podman build --authfile $(REGISTRY_AUTH_FILE) --build-arg OCP_RELEASE_IMAGE=$(shell cat ./.ocp-release-image) -t $(IMAGE_TDX) -f tdx/Containerfile . ;\
+	else [ "$(TEE)" == "snp" ]; \
+		echo "Building snp RHCOS layer with kata binaries" ;\
+		podman create --name kata $(KATA_COCO_ARTEFACTS) ;\
+		podman cp kata:/rhcos-coco-snp.initrd.tar.xz snp/ ;\
+		podman rm kata ;\
+		podman build --authfile $(REGISTRY_AUTH_FILE) --build-arg OCP_RELEASE_IMAGE=$(shell cat ./.ocp-release-image) -t $(IMAGE_SNP) -f snp/Containerfile . ;\
+	fi
+
+# Target to check if 'jq' is available
+.PHONY: check-jq
+check-jq: ## Check if 'jq' command is available
+	@which jq > /dev/null || (echo "'jq' command not found, please install it" && exit 1)
+
+
+# Target to check if 'oc' is available
+.PHONY: check-oc
+check-oc: ## Check if 'oc' command is available
+	@which oc > /dev/null || (echo "'oc' command not found, please install it" && exit 1)
+
+# Target to check if 'podman' is available
+.PHONY: check-podman
+check-podman: ## Check if 'podman' command is available
+	@which podman > /dev/null || (echo "'podman' command not found, please install it" && exit 1)
+
+# Target to get the pull secret from 'oc'
+.PHONY: get-pull-secret
+get-pull-secret: ## Get the pull secret from oc
+	@echo "Fetching pull secret from the cluster..."
+	@if [ ! -f "$(REGISTRY_AUTH_FILE)" ]; then \
+		echo "\$$REGISTRY_AUTH_FILE is not set. Retrieving the pull secret..."; \
+		$(MAKE) download-pull-secret; \
+		echo "Downloaded the pull secret to: $(REGISTRY_AUTH_FILE)"; \
+	else \
+		echo "$(REGISTRY_AUTH_FILE) is already present. Skipping download."; \
+	fi
+
+# Target to download the pull secret
+.PHONY: download-pull-secret
+download-pull-secret: ## Download the pull secret
+	@echo "Downloading the pull secret..."
+	$(MAKE) check-oc
+	$(MAKE) check-jq
+	oc get -n openshift-config secret/pull-secret -ojson | jq -r '.data.".dockerconfigjson"' | base64 -d | jq '.' > $(REGISTRY_AUTH_FILE)
+	@echo "Pull secret downloaded to auth file:$(REGISTRY_AUTH_FILE)"
+
+# Target to get OCP release image details
+.PHONY: get-ocp-release-image
+get-ocp-release-image: ## Get the OCP release image to use as base
+	@echo "Getting OCP release image to use as base..."
+	$(MAKE) check-oc; \
+	oc adm release info --image-for rhel-coreos > .ocp-release-image
+
+
+# Cleanup target
+.PHONY: clean
+clean: ## Cleanup build env
+
+	@echo "Removing pull .ocp-release-image and $(REGISTRY_AUTH_FILE)"
+	rm -f .ocp-release-image $(REGISTRY_AUTH_FILE)
+
+# Help target
+.PHONY: help
+help: ## Display this help message
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make [target]\n"} /^[a-zA-Z_-]+:.*##/ { printf "  %-20s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+

--- a/config/rhcos-layer/README.md
+++ b/config/rhcos-layer/README.md
@@ -1,0 +1,59 @@
+# Creating RHCOS Layer
+
+Config files to create RHCOS layered image with Kata.
+
+## With access to OCP cluster
+
+It requires access to an OCP cluster to know the base RHCOS version to use.
+
+Build standard layer with Kata upstream binaries
+
+```sh
+make build
+```
+
+Build for tdx
+
+```sh
+make TEE=tdx build
+```
+
+Build for snp
+
+```sh
+make TEE=snp build
+```
+
+## Without access to OCP cluster
+
+You can also directly build using podman or docker.
+
+- Identify the `rhel-rhcos` layer based on OCP version
+
+  You can get the `rhcos-image` details from the `release.txt` of the specific
+  release.
+  For example, the `rhel-rhcos` image for OCP 4.16.11 is
+  `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636`
+  as can be seen from the
+  [release.txt](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.16.11/release.txt)
+
+- Download the OCP pull secret from console.redhat.com
+
+- Run the following command:
+
+
+Build for tdx
+
+```sh
+podman build --authfile /tmp/pull-secret.json \
+   --build-arg OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636 \
+   -t tdx-image -f tdx/Containerfile .
+```
+
+Build for snp
+
+```sh
+podman build --authfile /tmp/pull-secret.json \
+   --build-arg OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636 \
+   -t snp-image -f snp/Containerfile .
+```

--- a/config/rhcos-layer/snp/Containerfile
+++ b/config/rhcos-layer/snp/Containerfile
@@ -1,0 +1,54 @@
+# Use 4.16 as the base
+# 4.6.11 release image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636
+
+ARG OCP_RELEASE_IMAGE
+
+FROM $OCP_RELEASE_IMAGE
+
+ARG KATA_RELEASE_VERSION=3.9.0
+
+COPY snp/centos-snp.repo /etc/yum.repos.d
+COPY snp/rhcos-coco-snp.initrd.tar.xz /tmp
+
+WORKDIR /
+
+# Install upstream Kata bits
+RUN curl -LO https://github.com/kata-containers/kata-containers/releases/download/${KATA_RELEASE_VERSION}/kata-static-${KATA_RELEASE_VERSION}-amd64.tar.xz && \
+    mkdir -p /var/opt && \
+    tar xvf kata-static-${KATA_RELEASE_VERSION}-amd64.tar.xz --strip-components=2 -C /opt && \
+    mv /opt/kata /usr/kata && \
+    echo 'd /var/opt 755 root root -' >> /usr/lib/tmpfiles.d/kata.conf && \
+    echo 'L+ /opt/kata - - - - /usr/kata' >> /usr/lib/tmpfiles.d/kata.conf
+
+
+COPY snp/crio.conf.d/ /etc/crio/crio.conf.d/
+
+# Copy the config toml to a read-write mount-point so that this can be overriden via
+# machineconfig
+RUN mkdir -p /etc/kata-containers/snp/ && \
+    cp /usr/kata/share/defaults/kata-containers/configuration-qemu-snp.toml /etc/kata-containers/snp/configuration.toml
+
+# Use OS kernel and initrd
+RUN tar xvf /tmp/rhcos-coco-snp.initrd.tar.xz -C /tmp && \
+    cp /tmp/rhcos-coco-snp.initrd /usr/kata/share/kata-containers/ && \
+    chcon --reference /usr/kata/share/kata-containers/kata-ubuntu-20.04-confidential.initrd /usr/kata/share/kata-containers/rhcos-coco-snp.initrd
+
+RUN sed -i 's|^kernel =.*|kernel = "/lib/modules/5.14.0-533.el9.x86_64/vmlinuz"|' /etc/kata-containers/snp/configuration.toml && \
+    sed -i 's|^initrd =.*|initrd = "/opt/kata/share/kata-containers/rhcos-coco-snp.initrd"|' /etc/kata-containers/snp/configuration.toml
+
+
+# Replace the existing kernel by the kernel with SEV-SNP support
+RUN rpm-ostree override replace https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-533.el9.x86_64.rpm
+
+# Install qemu
+RUN rpm-ostree install qemu-kvm
+
+# Selinux adjustments for monitor daemonset
+COPY snp/osc_monitor.cil /etc/kata-containers/osc_monitor.cil
+RUN semodule -i  /etc/kata-containers/osc_monitor.cil
+
+# Selinux adjustments to provide access to sev
+RUN setsebool -P container_use_devices 1
+
+RUN rpm-ostree cleanup -m && \
+    ostree container commit

--- a/config/rhcos-layer/snp/centos-snp.repo
+++ b/config/rhcos-layer/snp/centos-snp.repo
@@ -1,0 +1,11 @@
+[CentOS9-baseos]
+name=CentOS BaseOS
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/
+gpgcheck=0
+enabled=1
+
+[CentOS9-appstream]
+name=CentOS AppStream
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+gpgcheck=0
+enabled=1

--- a/config/rhcos-layer/snp/crio.conf.d/50-kata
+++ b/config/rhcos-layer/snp/crio.conf.d/50-kata
@@ -1,0 +1,9 @@
+[crio.runtime.runtimes.kata]
+runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+runtime_type = "vm"
+runtime_root = "/run/vc"
+runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml"
+privileged_without_host_devices = true
+allowed_annotations = [
+  "io.kubernetes.cri-o.Devices",
+]

--- a/config/rhcos-layer/snp/crio.conf.d/50-kata-snp
+++ b/config/rhcos-layer/snp/crio.conf.d/50-kata-snp
@@ -1,0 +1,10 @@
+[crio.runtime.runtimes.kata-snp]
+runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+runtime_type = "vm"
+runtime_root = "/run/vc"
+runtime_config_path = "/etc/kata-containers/snp/configuration.toml"
+privileged_without_host_devices = true
+runtime_pull_image = true
+allowed_annotations = [
+  "io.kubernetes.cri-o.Devices",
+]

--- a/config/rhcos-layer/snp/osc_monitor.cil
+++ b/config/rhcos-layer/snp/osc_monitor.cil
@@ -1,0 +1,35 @@
+(block container
+(type process)
+(type socket)
+(roletype system_r process)
+(typeattributeset domain (process ))
+(typeattributeset container_domain (process ))
+(typeattributeset svirt_sandbox_domain (process ))
+(typeattributeset mcs_constrained_type (process ))
+(typeattributeset file_type (socket ))
+(allow process socket (sock_file (create open getattr setattr read write rename link unlink ioctl lock append)))
+(allow process proc_type (file (getattr open read)))
+(allow process cpu_online_t (file (getattr open read)))
+(allow container_runtime_t process (key (create link read search setattr view write)))
+)
+
+(block net_container
+        (optional net_container_optional
+                (typeattributeset sandbox_net_domain (process))
+        )
+)
+
+
+(block osc_monitor
+    (blockinherit container)
+    (blockinherit net_container)
+    (allow process process ( capability ( chown dac_override setfcap setgid setpcap setuid )))
+
+    (allow process container_runtime_t (unix_stream_socket (connectto)))
+
+    (allow process container_var_run_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr watch write )))
+    (allow process container_var_run_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+    (allow process container_var_run_t ( fifo_file ( getattr read write append ioctl lock open )))
+    (allow process container_var_run_t ( sock_file ( ioctl append getattr open read write )))
+    (allow process container_var_run_t ( lnk_file (  ioctl lock append getattr open read write )))
+)

--- a/config/rhcos-layer/snp/test.sh
+++ b/config/rhcos-layer/snp/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+trustee_url=${trustee_url:-http://test}
+text="[hypervisor.qemu]
+kernel_params= \"agent.aa_kbc_params=cc_kbc::$trustee_url\""
+encoded_text=$(echo "$text" | base64 -w0)
+echo $encoded_text

--- a/config/rhcos-layer/standard/Containerfile
+++ b/config/rhcos-layer/standard/Containerfile
@@ -1,0 +1,31 @@
+# Use 4.16 as the base
+# 4.6.11 release image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636
+
+ARG OCP_RELEASE_IMAGE
+
+FROM $OCP_RELEASE_IMAGE
+
+ARG KATA_RELEASE_VERSION=3.13.0
+
+WORKDIR /
+
+# Install upstream Kata bits
+RUN curl -LO https://github.com/kata-containers/kata-containers/releases/download/${KATA_RELEASE_VERSION}/kata-static-${KATA_RELEASE_VERSION}-amd64.tar.xz && \
+    mkdir -p /var/opt && \
+    tar xvf kata-static-${KATA_RELEASE_VERSION}-amd64.tar.xz --strip-components=2 -C /opt && \
+    mv /opt/kata /usr/kata && \
+    echo 'd /var/opt 755 root root -' >> /usr/lib/tmpfiles.d/kata.conf && \
+    echo 'L+ /opt/kata - - - - /usr/kata' >> /usr/lib/tmpfiles.d/kata.conf
+
+
+COPY standard/crio.conf.d/ /etc/crio/crio.conf.d/
+
+# Selinux adjustments for monitor daemonset
+COPY snp/osc_monitor.cil /etc/kata-containers/osc_monitor.cil
+RUN semodule -i  /etc/kata-containers/osc_monitor.cil
+
+# Selinux adjustments to provide access to sev
+RUN setsebool -P container_use_devices 1
+
+RUN rpm-ostree cleanup -m && \
+    ostree container commit

--- a/config/rhcos-layer/standard/crio.conf.d/50-kata
+++ b/config/rhcos-layer/standard/crio.conf.d/50-kata
@@ -1,0 +1,9 @@
+[crio.runtime.runtimes.kata]
+runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+runtime_type = "vm"
+runtime_root = "/run/vc"
+runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml"
+privileged_without_host_devices = true
+allowed_annotations = [
+  "io.kubernetes.cri-o.Devices",
+]

--- a/config/rhcos-layer/standard/osc_monitor.cil
+++ b/config/rhcos-layer/standard/osc_monitor.cil
@@ -1,0 +1,35 @@
+(block container
+(type process)
+(type socket)
+(roletype system_r process)
+(typeattributeset domain (process ))
+(typeattributeset container_domain (process ))
+(typeattributeset svirt_sandbox_domain (process ))
+(typeattributeset mcs_constrained_type (process ))
+(typeattributeset file_type (socket ))
+(allow process socket (sock_file (create open getattr setattr read write rename link unlink ioctl lock append)))
+(allow process proc_type (file (getattr open read)))
+(allow process cpu_online_t (file (getattr open read)))
+(allow container_runtime_t process (key (create link read search setattr view write)))
+)
+
+(block net_container
+        (optional net_container_optional
+                (typeattributeset sandbox_net_domain (process))
+        )
+)
+
+
+(block osc_monitor
+    (blockinherit container)
+    (blockinherit net_container)
+    (allow process process ( capability ( chown dac_override setfcap setgid setpcap setuid )))
+
+    (allow process container_runtime_t (unix_stream_socket (connectto)))
+
+    (allow process container_var_run_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr watch write )))
+    (allow process container_var_run_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+    (allow process container_var_run_t ( fifo_file ( getattr read write append ioctl lock open )))
+    (allow process container_var_run_t ( sock_file ( ioctl append getattr open read write )))
+    (allow process container_var_run_t ( lnk_file (  ioctl lock append getattr open read write )))
+)

--- a/config/rhcos-layer/tdx/Containerfile
+++ b/config/rhcos-layer/tdx/Containerfile
@@ -1,0 +1,27 @@
+# Use 4.16 as the base
+# 4.6.11 release image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:31feb7503f06db4023350e3d9bb3cfda661cc81ff21cef429770fb12ae878636
+
+ARG OCP_RELEASE_IMAGE
+
+FROM $OCP_RELEASE_IMAGE
+
+COPY tdx/centos-tdx.repo /etc/yum.repos.d
+COPY tdx/kata-containers-tdx.repo /etc/yum.repos.d
+COPY tdx/kata-containers-tdx-repo.tar.xz /tmp
+
+# Extract the kata-containers local RPM repo
+RUN mkdir -p /var/cache/kata-containers-tdx-repo && \
+    tar xvJpf /tmp/kata-containers-tdx-repo.tar.xz -C /var/cache/kata-containers-tdx-repo/
+
+# Replace libibverbs for qemu-kvm-tdx. The RHCOS version is libibverbs-48 
+RUN rpm-ostree override replace https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/libibverbs-46.0-1.el9.x86_64.rpm
+RUN rpm-ostree install numactl-libs qemu-kvm-tdx
+
+#Install CentOS stream kernel
+RUN rpm-ostree override replace https://mirror.stream.centos.org/SIGs/9-stream/virt/x86_64/tdx-devel/Packages/k/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-480.el9s.x86_64.rpm
+
+# Install Kata Containers
+RUN rpm-ostree install kata-containers
+
+RUN rpm-ostree cleanup -m && \
+    ostree container commit

--- a/config/rhcos-layer/tdx/centos-tdx.repo
+++ b/config/rhcos-layer/tdx/centos-tdx.repo
@@ -1,0 +1,17 @@
+[tdx-testing]
+name=CentOS TDX Testing
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/virt/x86_64/tdx-devel/
+gpgcheck=0
+enabled=1
+
+[CentOS9-baseos]
+name=CentOS BaseOS
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/
+gpgcheck=0
+enabled=1
+
+[CentOS9-appstream]
+name=CentOS AppStream
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+gpgcheck=0
+enabled=1

--- a/config/rhcos-layer/tdx/kata-containers-tdx.repo
+++ b/config/rhcos-layer/tdx/kata-containers-tdx.repo
@@ -1,0 +1,6 @@
+[kata-containers-tdx-local-repo]
+name=Kata Containers with TDX baremetal support
+baseurl=file:///var/cache/kata-containers-tdx-repo
+enabled=1
+repo_gpgcheck=0
+gpgcheck=0


### PR DESCRIPTION
Example config files to create RHCOS layered image with Kata and using it for installation via the layered-image deployment feature of the OSC operator.

The tdx and snp images created via the configs are used for baremetal CoCo deployment
