### PR TITLE
docker build: make the build as user root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-# Use OpenShift golang builder image
-# These images needs to be synced with the images in the Makefile.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7 AS builder
 
+USER root
 WORKDIR /workspace
 
 COPY Makefile Makefile


### PR DESCRIPTION
When building with docker, the Dockerfile works fine. But it fails with podman, with a permission denied error. This is done on purpose, and requires either to build in a folder where the default user has permissions to write (like the $HOME folder), or to explicitely make the build as root.

We are using the later option here.

Also removing obsolete comments at the beginning of the Dockerfile.
