### PR TITLE
Allow to override extension name

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -495,6 +495,11 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() string {
 	// send in "kata-containers".
 	// Both are later send to rpm-ostree for installation.
 	//
+	extension := os.Getenv("SANDBOXED_CONTAINERS_EXTENSION")
+	if len(extension) != 0 {
+		return extension
+	}
+
 	clusterVersion := &configv1.ClusterVersion{}
 	r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 


### PR DESCRIPTION
PR #492 was too optimistic. The heuristic to discriminate OCP and OKD is fragile and doesn't work in some CI environments.

Reintroduce a way to enforce the name with an environment variable until we find a more robust way to handle the extension. This is a temporary workaround. It is not documented on purpose.

It just requires to add `SANDBOXED_CONTAINERS_EXTENSION` to the `env` section of the controller manager in the CSV as shown below :

                env:
                - name: SANDBOXED_CONTAINERS_EXTENSION
                  value: sandboxed-containers
                - name: PEERPODS_NAMESPACE
                  value: openshift-sandboxed-containers-operator
