### PR TITLE
must-gather: updates for the Dockerfile

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,9 +1,9 @@
 FROM quay.io/openshift/origin-must-gather:latest as builder
 
-FROM centos:7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 
- # For gathering data from nodes
-RUN yum update -y && yum install iproute tcpdump pciutils util-linux nftables rsync -y && yum clean all
+# For gathering data from nodes
+RUN microdnf update -y && microdnf install tar rsync -y && microdnf clean all
 
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 


### PR DESCRIPTION
The Dockerfile for the must-gather image is very outdated. It actually fails to build because it's still based on centos:7, which repositories are not available anymore.

Since it doesn't seem to be used, I am suggesting these changes, which gets closer to what we actually need to release in Openshift.

Changes include:
- use ubi9 minimal for the base image
- do not install additional tools - they're not referenced by our gathering scripts, and they've never been installed in our currently released images.

NOTE: this Dockerfile will then be used by our Konflux instance to build the must-gather image.
