### PR TITLE
docker build: Use digit tag for Dockerfile UBI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go mod vendor
 RUN make build
 
 # Use OpenShift base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 COPY --from=builder /workspace/bin/metrics-server .


### PR DESCRIPTION
In order to improve the images update handling and utilize Konflux bot's automated image tags update functionality (e.g., https://github.com/openshift/sandboxed-containers-operator/pull/507), which depends on using digit tags for images, it was decided to replace the latest tag with a digit-based tag for the UBI image in the Dockerfile.

**- Description of the problem which is fixed/What is the use case**
Changing the ubi9/ubi-minimal image to from 'latest' to '9.5-xyz'

**- Description for the changelog**
Using digit tag for Dockerfile UBI image