### PR TITLE
Podvm builder dockerfile

### DIFF
--- a/config/peerpods/podvm/Dockerfile.podvm-builder.openshift
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder.openshift
@@ -1,0 +1,40 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1736404036
+
+# azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
+# aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
+# sources for cloud-api-adaptor under /src/cloud-api-adaptor
+# The podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
+# Binaries like kubectl, packer and yq under /usr/local/bin will be installed by the scripts
+
+
+LABEL kata_src=https://github.com/kata-containers/kata-containers
+LABEL kata_src_commit=stable-3.7
+
+ARG ORG_ID
+ARG ACTIVATION_KEY
+
+RUN mkdir -p /scripts
+
+ADD lib.sh libvirt-podvm-image-handler.sh aws-podvm-image-handler.sh azure-podvm-image-handler.sh /scripts/
+
+RUN /scripts/azure-podvm-image-handler.sh -- install_rpms
+
+ARG CAA_SRC=https://github.com/confidential-containers/cloud-api-adaptor
+ARG CAA_REF=main
+ARG CERT_RPM
+
+
+ENV CAA_SRC=$CAA_SRC
+ENV CAA_REF=$CAA_REF
+ENV CERT_RPM=$CERT_RPM
+
+RUN if [[ -n "$CERT_RPM" ]] ; then \
+    dnf install -y $CERT_RPM ; \
+    fi
+
+
+RUN git clone ${CAA_SRC} -b ${CAA_REF} /src/cloud-api-adaptor
+
+ADD podvm-builder.sh /podvm-builder.sh
+
+ENTRYPOINT ["/podvm-builder.sh"]

--- a/config/peerpods/podvm/Dockerfile.podvm-builder.openshift
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder.openshift
@@ -7,8 +7,8 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5-1736404036
 # Binaries like kubectl, packer and yq under /usr/local/bin will be installed by the scripts
 
 
-LABEL kata_src=https://github.com/kata-containers/kata-containers
-LABEL kata_src_commit=stable-3.7
+LABEL kata_src=https://github.com/openshift/kata-containers
+LABEL kata_src_commit=osc-release
 
 ARG ORG_ID
 ARG ACTIVATION_KEY
@@ -19,8 +19,8 @@ ADD lib.sh libvirt-podvm-image-handler.sh aws-podvm-image-handler.sh azure-podvm
 
 RUN /scripts/azure-podvm-image-handler.sh -- install_rpms
 
-ARG CAA_SRC=https://github.com/confidential-containers/cloud-api-adaptor
-ARG CAA_REF=main
+ARG CAA_SRC=https://github.com/openshift/cloud-api-adaptor
+ARG CAA_REF=osc-release
 ARG CERT_RPM
 
 


### PR DESCRIPTION
Creating a new Dockerfile dedicated to building the podvm-builder image in Konflux.
It seems we can't use the existing Dockerfile as it is, because of the subscription
management done in Konflux.
(see PR https://github.com/openshift/sandboxed-containers-operator/pull/516)

This Dockerfile is a clean copy of Dockerfile.podvm-builder, with the subscription
lines removed.
Also updating the source references to kata and cloud-api-adaptor to point to our forks under the Openshift org.