### PR TITLE
Re-Create the cloud-api-daemonset

### DIFF
--- a/config/manifests/extension-crds/kustomization.yaml
+++ b/config/manifests/extension-crds/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- confidentialcontainers.org_peerpodconfigs.yaml
 - confidentialcontainers.org_peerpods.yaml

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -391,6 +391,16 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA() *appsv1.DaemonS
 								RunAsUser:  &runAsUser,
 							},
 							Command: []string{"/usr/local/bin/entrypoint.sh"},
+							Env: []corev1.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{


### PR DESCRIPTION
It has been removed when we dropped the code for peerpod config management.
Also removing a left over reference to peerpod config in kustomize script.

Note: this was done by copying the code [from cloud-api-adaptor](https://github.com/confidential-containers/cloud-api-adaptor/blob/6c159d568a29b25c548cd48b4de35f0196f751b3/src/peerpodconfig-ctrl/controllers/peerpodconfig_controller.go#L133) that used to create it, and was removed.

I'm doing creation/deletion at the places where we used to create/delete the peerpod config, so that it doesn't change behavior.


