### PR TITLE
Avoid unneeded rebuilds

### DIFF
--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -8,8 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "devel" &&
+      files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "push" &&
+      target_branch == "devel" &&
+      files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -7,8 +7,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "devel" &&
+      files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
+      files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
+      files.all.exists(path, !path.matches('config/peerpod/podvm*|.tekton/*podvm-builder*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -6,8 +6,12 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "push" &&
+      target_branch == "devel" &&
+      files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
+      files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
+      files.all.exists(path, !path.matches('config/peerpod/podvm*|.tekton/*podvm-builder*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
Modify the tekton files to avoid rebuilds in some situations:

Bundle: rebuild only if the bundle files are modified
Operator: rebuild only if the modification is not on the bundle, must-gather or podvm-builder files.
