### PR TITLE
CSV update: use konflux repository for our images

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -378,15 +378,15 @@ spec:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
                 - name: RELATED_IMAGE_KATA_MONITOR
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.9.0
+                  value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor@sha256:1e19738be039443b1086a22c446897216e791a6cd72da5aeeb6e538f1c9aa447
                 - name: RELATED_IMAGE_CAA
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.9.0
+                  value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa@sha256:0123d325c48ad6ed051a06d97a183083ca9a5132884a055f852e7a863867400d
                 - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.9.0
+                  value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook@sha256:52c2686822cf6d1072786683357332e337184e8f0f9ae2af155ef68f5081dbbf
                 - name: RELATED_IMAGE_PODVM_BUILDER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.9.0
+                  value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder@sha256:a35214a970ce7ff2729adbdad5aa7caf202bf131fafa702dd1b006f102779f07
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.9.0
+                  value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:c282c01cb7b7d9984c5b5a4a2b434a9dff4b5b63c125bc2ae129d818696c0e29
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -394,7 +394,7 @@ spec:
                 - configMapRef:
                     name: peer-pods-cm
                     optional: true
-                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.9.0
+                image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator@sha256:7aecfb575e553ec53ccb1880e2f77bb66f48190c49372723882a3ca7d6ba315c
                 imagePullPolicy: Always
                 name: manager
                 ports:
@@ -490,7 +490,7 @@ spec:
               containers:
               - command:
                 - /metrics-server
-                image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator:v1.9.0
+                image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator@sha256:7aecfb575e553ec53ccb1880e2f77bb66f48190c49372723882a3ca7d6ba315c
                 name: metrics-server
                 ports:
                 - containerPort: 8091
@@ -556,15 +556,15 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.9.0
+  - image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor@sha256:1e19738be039443b1086a22c446897216e791a6cd72da5aeeb6e538f1c9aa447
     name: kata-monitor
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.9.0
+  - image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa@sha256:0123d325c48ad6ed051a06d97a183083ca9a5132884a055f852e7a863867400d
     name: caa
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.9.0
+  - image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook@sha256:52c2686822cf6d1072786683357332e337184e8f0f9ae2af155ef68f5081dbbf
     name: peerpods-webhook
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.9.0
+  - image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder@sha256:a35214a970ce7ff2729adbdad5aa7caf202bf131fafa702dd1b006f102779f07
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.9.0
+  - image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:c282c01cb7b7d9984c5b5a4a2b434a9dff4b5b63c125bc2ae129d818696c0e29
     name: podvm-payload
   replaces: sandboxed-containers-operator.v1.8.1
   version: 1.9.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,15 +77,15 @@ spec:
             - name: PEERPODS_NAMESPACE
               value: "openshift-sandboxed-containers-operator"
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.9.0  ## OSC_VERSION
+              value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor@sha256:1e19738be039443b1086a22c446897216e791a6cd72da5aeeb6e538f1c9aa447
             - name: RELATED_IMAGE_CAA
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9:1.9.0  ## OSC_VERSION
+              value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa@sha256:0123d325c48ad6ed051a06d97a183083ca9a5132884a055f852e7a863867400d
             - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9:1.9.0 ## OSC_VERSION
+              value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook@sha256:52c2686822cf6d1072786683357332e337184e8f0f9ae2af155ef68f5081dbbf
             - name: RELATED_IMAGE_PODVM_BUILDER
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.9.0  ## OSC_VERSION
+              value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder@sha256:a35214a970ce7ff2729adbdad5aa7caf202bf131fafa702dd1b006f102779f07
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.9.0  ## OSC_VERSION
+              value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:c282c01cb7b7d9984c5b5a4a2b434a9dff4b5b63c125bc2ae129d818696c0e29
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Changing the image references to use the konflux repo. This is a temporary measure, to validate konflux's nudging process, where the bundle file gets updated when the images are rebuilt.

We will put back the release registry URL when our release plan is set on the konflux side. Then konflux should be able to update the images with the release URL.

For reference: I am following the instructions from https://konflux-ci.dev/docs/advanced-how-tos/building-olm/#automating-updates-for-image-references-in-the-csv