### PR TITLE
azure: blob as source update

### DIFF
--- a/config/peerpods/credentials-requests/credentials_request_azure.yaml
+++ b/config/peerpods/credentials-requests/credentials_request_azure.yaml
@@ -14,3 +14,4 @@ spec:
       - role: Reader
       - role: Virtual Machine Contributor
       - role: Network Contributor
+      - role: Storage Account Contributor


### PR DESCRIPTION
Per Microsoft's announcement, starting March 15, 2025, additional permission is required when using blobs as the source for Azure Compute Gallery (ACG) images. This updates our CCO request to include the required permission.

My understanding is that the Azure job that creates the image is building the podvm based on blob (VHD), so we need to update only the CCO request.

Fixes: rhjira#[KATA-3579](https://issues.redhat.com//browse/KATA-3579)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
