### PR TITLE
fix: correct behaviour of labelling script

### DIFF
--- a/scripts/install-helpers/baremetal-coco/README.md
+++ b/scripts/install-helpers/baremetal-coco/README.md
@@ -65,7 +65,7 @@ The deployment sequence is described below:
   
   ```sh
   export NODENAME=<node>
-  oc label $NODE_NAME coco_bm=true
+  oc label node $NODENAME coco_bm=true
   export BM_NODE_LABEL="coco_bm=true"
   ```
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
The Readme for the bare metal install script was incorrect. it did not provide the object type (a node) when trying to label the object
**- What I did**
Corrected the script in the readme
**- How to verify it**
Tested locally using oc against any cluster (e.g can be crc etc)
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated bare metal installation helper scripts documentation correcting example code.

