### PR TITLE
[WIP] Removing leftover peerpod-config references

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
-    operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
+    operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openshift/sandboxed-containers-operator
   labels:
@@ -255,7 +255,6 @@ spec:
         - apiGroups:
           - confidentialcontainers.org
           resources:
-          - peerpodconfigs
           - peerpods
           verbs:
           - create
@@ -268,14 +267,12 @@ spec:
         - apiGroups:
           - confidentialcontainers.org
           resources:
-          - peerpodconfigs/finalizers
           - peerpods/finalizers
           verbs:
           - update
         - apiGroups:
           - confidentialcontainers.org
           resources:
-          - peerpodconfigs/status
           - peerpods/status
           verbs:
           - get

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.20.1+git
-    operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org","peerpodconfigs.confidentialcontainers.org"]'
+    operators.operatorframework.io/internal-objects: '["peerpods.confidentialcontainers.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/sandboxed-containers-operator
   labels:

--- a/config/rbac/kataconfig_editor_role.yaml
+++ b/config/rbac/kataconfig_editor_role.yaml
@@ -6,11 +6,9 @@ metadata:
 rules:
 - apiGroups:
   - kataconfiguration.openshift.io
-  - peerpodconfiguration.confidentialcontainers.org
   - confidentialcontainers.org
   resources:
   - kataconfigs
-  - peerpodconfigs
   - peerpods
   verbs:
   - create
@@ -22,11 +20,9 @@ rules:
   - watch
 - apiGroups:
   - kataconfiguration.openshift.io
-  - peerpodconfiguration.confidentialcontainers.org
   - confidentialcontainers.org
   resources:
   - kataconfigs/status
-  - peerpodconfigs/status
   - peerpods/status
   verbs:
   - get

--- a/config/rbac/kataconfig_viewer_role.yaml
+++ b/config/rbac/kataconfig_viewer_role.yaml
@@ -6,23 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - kataconfiguration.openshift.io
-  - peerpodconfiguration.confidentialcontainers.org
   - confidentialcontainers.org
   resources:
   - kataconfigs
-  - peerpodconfigs
   - peerpods
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - peerpodconfiguration.confidentialcontainers.org
   - kataconfiguration.openshift.io
   - confidentialcontainers.org
   resources:
   - kataconfigs/status
-  - peerpodconfigs/status
   - peerpods/status
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -121,7 +121,6 @@ rules:
 - apiGroups:
   - confidentialcontainers.org
   resources:
-  - peerpodconfigs
   - peerpods
   verbs:
   - create
@@ -134,14 +133,12 @@ rules:
 - apiGroups:
   - confidentialcontainers.org
   resources:
-  - peerpodconfigs/finalizers
   - peerpods/finalizers
   verbs:
   - update
 - apiGroups:
   - confidentialcontainers.org
   resources:
-  - peerpodconfigs/status
   - peerpods/status
   verbs:
   - get

--- a/controllers/migrate.go
+++ b/controllers/migrate.go
@@ -21,6 +21,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	peerpodConfigCrdName = "peerpodconfig-openshift"
+)
+
 // migratePeerPodsLimit moves the PeerPodConfig "Limit" value to peer-pods-cm
 func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 	peerPodConfig := &unstructured.Unstructured{}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -75,7 +75,6 @@ const (
 	container_runtime_config_name       = "kata-crio-config"
 	extension_mc_name                   = "50-enable-sandboxed-containers-extension"
 	DEFAULT_PEER_PODS                   = "10"
-	peerpodConfigCrdName                = "peerpodconfig-openshift"
 	peerpodsMachineConfigPathLocation   = "/config/peerpods"
 	peerpodsCrioMachineConfig           = "50-kata-remote"
 	peerpodsCrioMachineConfigYaml       = "mc-50-crio-config.yaml"
@@ -105,9 +104,6 @@ const (
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use;get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update
 // +kubebuilder:rbac:groups="",resources=nodes/status,verbs=patch
-// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpodconfigs/finalizers,verbs=update
 // +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=confidentialcontainers.org,resources=peerpods/finalizers,verbs=update
@@ -1137,7 +1133,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	}
 
 	if r.kataConfig.Spec.EnablePeerPods {
-		// We are explicitly ignoring any errors in peerpodconfig and related machineconfigs removal as
+		// We are explicitly ignoring any errors in machineconfigs removal as
 		// these can be removed manually if needed and this is not in the critical path
 		// of operator functionality
 		_ = r.disablePeerPods()
@@ -1459,7 +1455,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 			err = r.enablePeerPodsMiscConfigs()
 			if err != nil {
-				r.Log.Info("Enabling peerpodconfig CR, runtimeclass etc", "err", err)
+				r.Log.Info("Enabling runtimeclass etc", "err", err)
 				// Give sometime for the error to go away before reconciling again
 				return reconcile.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 
@@ -2424,7 +2420,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMc() error {
 	return nil
 }
 
-// Create the PeerPodConfig CRDs and misc configs required for peer-pods
+// Create the misc configs required for peer-pods
 func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	// Create the CAA daemonset
 	ds := r.processDaemonsetForCAA()

--- a/must-gather/must-gather-requirements.md
+++ b/must-gather/must-gather-requirements.md
@@ -36,7 +36,7 @@ See also the [Official 1.5 documentation](https://access.redhat.com/documentatio
   - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/controller-manager-**_*_**\_logs
   - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/install-**_*_**\_logs
   - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/openshift-sandboxed-containers-monitor-**_*_**\_logs
-  - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/peerpodconfig-ctrl-caa-daemon-**_*_**\_logs
+  - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/osc-caa-ds-**_*_**\_logs
   - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/peer-pods-webhook-**_*_**\_logs
 -  OSC CRDs
   - sandboxed-containers/namespaces/openshift-sandboxed-containers-operator/**_*_**\_description

--- a/scripts/cm-helpers/pp-cm-helper.sh
+++ b/scripts/cm-helpers/pp-cm-helper.sh
@@ -202,9 +202,9 @@ function applyCM() {
        sleep 1
     done
     ${CLI} get cm peer-pods-cm -n openshift-sandboxed-containers-operator -o jsonpath='{.data}' | jq
-    if ${CLI} get ds/peerpodconfig-ctrl-caa-daemon -n openshift-sandboxed-containers-operator > /dev/null 2>&1; then
+    if ${CLI} get ds/osc-caa-ds -n openshift-sandboxed-containers-operator > /dev/null 2>&1; then
         [[ -n $YES ]] || (read -r -p "Restart DaemonSet so that CM will be taken into account? [y/N] " && [[ "$REPLY" =~ ^[Yy]$ ]]) || exit 0
-        ${CLI} set env ds/peerpodconfig-ctrl-caa-daemon -n openshift-sandboxed-containers-operator REBOOT="$(date)"
+        ${CLI} set env ds/osc-caa-ds -n openshift-sandboxed-containers-operator REBOOT="$(date)"
     fi
     echo && echo "###### Done"
 }


### PR DESCRIPTION
Finding a lot of references to peerpodconfig, but not sure is we should remove them?
Our migration process requires reading/writing (deleting) the existing object, if any, so I guess we need to keep rbac rules for it?
Putting it there as a draft, I will try in on my own, but comments are welcome.