### PR TITLE
Check the existence of the PeerPodConfig CRD

### DIFF
--- a/controllers/migrate.go
+++ b/controllers/migrate.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,6 +34,10 @@ func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 	}, peerPodConfig)
 
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			r.Log.Info("PeerPodConfig CRD is unknown, skipping migration")
+			return nil
+		}
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("No PeerPodConfig found, skipping migration")
 			return nil


### PR DESCRIPTION
PR #533 added some logic to move away from the PeerPodConfig CRD. Unfortunately it doesn't cope with the case where the CRD doesn't exist at all in the cluster. This causes the controller to enter a reconcile failure loop with the following error.

Failed to migrate PeerPodConfig limit	{"err": "no matches for
 kind \"PeerPodConfig\" in version \"confidentialcontainers.org/v1alpha1\""}

If the CRD isn't defined, no need to migrate obviously.

Fast path fix without a jira :wink: