### PR TITLE
bootc: add cloud-init if provider is libvirt

### DIFF
--- a/config/peerpods/podvm/bootc/Containerfile.rhel
+++ b/config/peerpods/podvm/bootc/Containerfile.rhel
@@ -34,6 +34,11 @@ RUN if [[ "${CLOUD_PROVIDER}" == "azure" ]]; then \
     ln -s ../afterburn-checkin.service /etc/systemd/system/multi-user.target.wants/afterburn-checkin.service; \
     fi
 
+# Cloud-init is required for Libvirt
+RUN if [[ "${CLOUD_PROVIDER}" == "libvirt" ]]; then \
+    dnf install -y cloud-init && dnf clean all; \
+fi
+
 # Copy pause bundle
 COPY --from=pause /pause /pause_bundle
 


### PR DESCRIPTION
When using libvirt provider we need cloud-init to be able to inject user data.

Currently if you try to boot the qcow2 image locally, some files will be missing despite the fact your are injecting them via cloud-init.iso.