### PR TITLE
podvm: mark CAA_SRC and CAA_REF as optional in the config maps

### DIFF
--- a/config/peerpods/podvm/aws-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/aws-podvm-image-cm.yaml
@@ -18,12 +18,12 @@ data:
   # Pod VM sources
   # If changing the source, then ensure the respective payload binaries are available
   # for the new source
-  CAA_SRC: "https://gitlab.cee.redhat.com/osc/midstream/cloud-api-adaptor"
-  CAA_REF: "v0.8.0-1.6"
+  #CAA_SRC: "" ## set to cloud-api-adaptor sources URL for custom podvm builds
+  #CAA_REF: "" ## set to tag/branch for the cloud-api-adaptor code to use
 
   # Booleans
   INSTALL_PACKAGES: "no"
-  DOWNLOAD_SOURCES: "no"
+  DOWNLOAD_SOURCES: "no" ## set to "yes" for custom podvm builds. Need to set CAA_SRC and CAA_REF accordingly
   CONFIDENTIAL_COMPUTE_ENABLED: "no"
   DISABLE_CLOUD_CONFIG: "true"
   ENABLE_NVIDIA_GPU: "no"

--- a/config/peerpods/podvm/aws-podvm-image-handler.sh
+++ b/config/peerpods/podvm/aws-podvm-image-handler.sh
@@ -69,12 +69,15 @@ function verify_vars() {
     [[ -z "${PODVM_DISTRO}" ]] && error_exit "PODVM_DISTRO is not set"
     [[ -z "${DISABLE_CLOUD_CONFIG}" ]] && error_exit "DISABLE_CLOUD_CONFIG is not set"
 
-    [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
-    [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+    [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
+    if [[ "${DOWNLOAD_SOURCES}" == "yes" ]]; then
+        # if DOWNLOAD_SOURCES is set, we need the CAA_SRC and CAA_REF variables
+        [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
+        [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+    fi
 
     # Ensure booleans are set
     [[ -z "${INSTALL_PACKAGES}" ]] && error_exit "INSTALL_PACKAGES is empty"
-    [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
     [[ -z "${CONFIDENTIAL_COMPUTE_ENABLED}" ]] && error_exit "CONFIDENTIAL_COMPUTE_ENABLED is empty"
     [[ -z "${DISABLE_CLOUD_CONFIG}" ]] && error_exit "DISABLE_CLOUD_CONFIG is empty"
     [[ -z "${ENABLE_NVIDIA_GPU}" ]] && error_exit "ENABLE_NVIDIA_GPU is empty"

--- a/config/peerpods/podvm/azure-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/azure-podvm-image-cm.yaml
@@ -41,12 +41,12 @@ data:
   # Pod VM sources
   # If changing the source, then ensure the respective payload binaries are available
   # for the new source
-  CAA_SRC: "https://gitlab.cee.redhat.com/osc/midstream/cloud-api-adaptor"
-  CAA_REF: "v0.8.0-1.6"
+  #CAA_SRC: "" ## set to cloud-api-adaptor sources URL for custom podvm builds
+  #CAA_REF: "" ## set to tag/branch for the cloud-api-adaptor code to use
 
   # Booleans
   INSTALL_PACKAGES: "no"
-  DOWNLOAD_SOURCES: "no"
+  DOWNLOAD_SOURCES: "no" ## set to "yes" for custom podvm builds. Need to set CAA_SRC and CAA_REF accordingly
   CONFIDENTIAL_COMPUTE_ENABLED: "no"
   DISABLE_CLOUD_CONFIG: "true"
   ENABLE_NVIDIA_GPU: "no"

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -65,12 +65,15 @@ function verify_vars() {
     [[ -z "${IMAGE_BASE_NAME}" ]] && error_exit "IMAGE_BASE_NAME is empty"
     [[ -z "${IMAGE_VERSION_MAJ_MIN}" ]] && error_exit "IMAGE_VERSION_MAJ_MIN is empty"
 
-    [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
-    [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+    [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
+    if [[ "${DOWNLOAD_SOURCES}" == "yes" ]]; then
+        # if DOWNLOAD_SOURCES is set, we need the CAA_SRC and CAA_REF variables
+        [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
+        [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+    fi
 
     # Ensure booleans are set
     [[ -z "${INSTALL_PACKAGES}" ]] && error_exit "INSTALL_PACKAGES is empty"
-    [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
     [[ -z "${CONFIDENTIAL_COMPUTE_ENABLED}" ]] && error_exit "CONFIDENTIAL_COMPUTE_ENABLED is empty"
     [[ -z "${DISABLE_CLOUD_CONFIG}" ]] && error_exit "DISABLE_CLOUD_CONFIG is empty"
     [[ -z "${ENABLE_NVIDIA_GPU}" ]] && error_exit "ENABLE_NVIDIA_GPU is empty"

--- a/config/peerpods/podvm/gcp-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/gcp-podvm-image-cm.yaml
@@ -7,8 +7,8 @@ data:
   # Pod VM sources
   # If changing the source, then ensure the respective payload binaries are available
   # for the new source
-  CAA_SRC: "https://github.com/confidential-containers/cloud-api-adaptor"
-  CAA_REF: "main"
+  #CAA_SRC: "" ## set to cloud-api-adaptor sources URL for custom podvm builds
+  #CAA_REF: "" ## set to tag/branch for the cloud-api-adaptor code to use
 
   IMAGE_BASE_NAME: "podvm-image"
   IMAGE_VERSION_MAJ_MIN: "0.0"

--- a/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
@@ -10,11 +10,11 @@ data:
   # Pod VM sources
   # If changing the source, then ensure the respective payload binaries are available
   # for the new source
-  CAA_SRC: "https://github.com/confidential-containers/cloud-api-adaptor"
-  CAA_REF: "v0.8.2"
+  #CAA_SRC: "" ## set to cloud-api-adaptor sources URL for custom podvm builds
+  #CAA_REF: "" ## set to tag/branch for the cloud-api-adaptor code to use
 
   # Booleans
-  DOWNLOAD_SOURCES: "no"
+  DOWNLOAD_SOURCES: "no" ## set to "yes" for custom podvm builds. Need to set CAA_SRC and CAA_REF accordingly
   CONFIDENTIAL_COMPUTE_ENABLED: "no"
   UPDATE_PEERPODS_CM: "yes"
 

--- a/config/peerpods/podvm/libvirt-podvm-image-handler.sh
+++ b/config/peerpods/podvm/libvirt-podvm-image-handler.sh
@@ -27,13 +27,14 @@ function verify_vars() {
 
         [[ -z "${PODVM_DISTRO}" ]] && error_exit "PODVM_DISTRO is not set"
 
-        [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
-        [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+        [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
+        if [[ "${DOWNLOAD_SOURCES}" == "yes" ]]; then
+            # if DOWNLOAD_SOURCES is set, we need the CAA_SRC and CAA_REF variables
+            [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
+            [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
+        fi
 
         [[ -z "${REDHAT_OFFLINE_TOKEN}" ]] && error_exit "Redhat token is not set"
-
-        # Ensure booleans are set
-        [[ -z "${DOWNLOAD_SOURCES}" ]] && error_exit "DOWNLOAD_SOURCES is empty"
     fi
 }
 


### PR DESCRIPTION
We are using our fork's v0.12.0-1.9 branch for this release.

Open question: what about [libvirt](https://github.com/openshift/sandboxed-containers-operator/blob/78fd45458a79c9a5de154ff5cdc0ad04a995b70e/config/peerpods/podvm/libvirt-podvm-image-cm.yaml#L13-L14)?
It's not looking at our fork, but directly upstream, and I don't know the support status for it in our OSC builds (aside from s390x). Should we update it for consistency, or is it a separate work?

Fixes: [KATA-3697](https://issues.redhat.com//browse/KATA-3697)