### PR TITLE
konflux: fix path in on-cel-expression

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       target_branch == "devel" &&
       files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
       files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
-      files.all.exists(path, !path.matches('config/peerpod/podvm*|.tekton/*podvm-builder*')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp: null
   labels:

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -11,7 +11,7 @@ metadata:
       target_branch == "devel" &&
       files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
       files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
-      files.all.exists(path, !path.matches('config/peerpod/podvm*|.tekton/*podvm-builder*')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp: null
   labels:


### PR DESCRIPTION
Missing 's' in peerpods made the operator rebuild when only podvm-builder files were modified.
