### PR TITLE
podvm: Check for pre-existing image before image creation

### DIFF
--- a/config/peerpods/podvm/aws-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/aws-podvm-image-cm.yaml
@@ -9,7 +9,11 @@ data:
 
   # Image
   AMI_BASE_NAME: "podvm-image"
-  AMI_VERSION_MAJ_MIN: "0.0"
+  # Must be in Major(int).Minor(int).Patch(int) format. Not mandatory for AWS, but
+  # for consistency sake with Azure
+  # When deployed from operator, update the AMI_VERSION to something like
+  # "$clusterid.0.1"
+  AMI_VERSION: "0.0.1"
   AMI_VOLUME_SIZE: "30"
 
   # Packer Instance type

--- a/config/peerpods/podvm/azure-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/azure-podvm-image-cm.yaml
@@ -33,7 +33,10 @@ data:
 
   # Image
   IMAGE_BASE_NAME: "podvm-image"
-  IMAGE_VERSION_MAJ_MIN: "0.0"
+  # Must be in Major(int).Minor(int).Patch(int) format
+  # When deployed from operator, update the IMAGE_VERSION to something like
+  # "$clusterid.0.1"
+  IMAGE_VERSION: "0.0.1"
 
   # Packer VM size
   VM_SIZE: "Standard_D2as_v5"

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -63,7 +63,7 @@ function verify_vars() {
 
     # Ensure that the image variables are set
     [[ -z "${IMAGE_BASE_NAME}" ]] && error_exit "IMAGE_BASE_NAME is empty"
-    [[ -z "${IMAGE_VERSION_MAJ_MIN}" ]] && error_exit "IMAGE_VERSION_MAJ_MIN is empty"
+    [[ -z "${IMAGE_VERSION}" ]] && error_exit "IMAGE_VERSION is empty"
 
     [[ -z "${CAA_SRC}" ]] && error_exit "CAA_SRC is empty"
     [[ -z "${CAA_REF}" ]] && error_exit "CAA_REF is empty"
@@ -98,14 +98,11 @@ function add_azure_repositories() {
     echo "Azure yum repositories added successfully"
 }
 
-function set_image_version_and_name() {
-    # Set the image version
-    # It should follow the Major(int).Minor(int).Patch(int)
-    IMAGE_VERSION="${IMAGE_VERSION_MAJ_MIN}.$(date +'%Y%m%d%S')"
-    export IMAGE_VERSION
+function set_image_name() {
 
     # Set the image name
     IMAGE_NAME="${IMAGE_BASE_NAME}-${IMAGE_VERSION}"
+    echo "Image name: ${IMAGE_NAME}"
     export IMAGE_NAME
 }
 
@@ -245,8 +242,6 @@ function create_image_using_packer() {
     # If any error occurs, exit the script with an error message
     # The variables are set before calling the function
 
-    # Set the image version and name
-    set_image_version_and_name
     # Set the base image details
 
     if [[ "${PODVM_DISTRO}" != "rhel" ]]; then
@@ -273,6 +268,10 @@ function create_image_using_packer() {
         error_exit "Failed to change directory to ${CAA_SRC_DIR}/azure/image"
     packer init "${PODVM_DISTRO}"/
     make BINARIES= PAUSE_BUNDLE= image
+
+    # Check if make resulted in error
+    return_code=$?
+    [[ "$return_code" -ne 0 ]] && error_exit "Failed to create Azure image using packer"
 
     # Wait for the image to be created
 
@@ -368,6 +367,22 @@ function create_image() {
     echo "Creating Azure image"
     # If any error occurs, exit the script with an error message
 
+    # Set the image version and name
+    set_image_name
+
+    image_exists
+    image_status=$?
+
+    if [[ "${image_status}" -eq 0 ]]; then
+        echo "Image exists. Skipping creation"
+        return
+    elif [[ "${image_status}" -eq 2 ]]; then
+        echo "Deleting image version, before recreating"
+        delete_image_version
+    fi
+
+    echo "Image does not exist. Proceeding to create the image"
+
     # Install packages if INSTALL_PACKAGES is set to yes
     if [[ "${INSTALL_PACKAGES}" == "yes" ]]; then
         # Add Azure yum repositories
@@ -387,7 +402,7 @@ function create_image() {
         create_azure_image_from_prebuilt_artifact
     fi
 
-    # Get the image id of the newly created image.
+    # Get the image id
     # This will set the IMAGE_ID variable
     get_image_id
 
@@ -424,9 +439,6 @@ function create_azure_image_from_scratch() {
 
 function create_azure_image_from_prebuilt_artifact() {
     echo "Creating Azure image from prebuilt artifact"
-
-    # Set the IMAGE_VERSION and IMAGE_NAME
-    set_image_version_and_name
 
     echo "Pulling the podvm image from the provided path"
     image_src="/tmp/image"
@@ -716,6 +728,54 @@ function delete_image_using_id() {
     delete_cm_annotation LATEST_IMAGE_ID
 
     echo "Azure image deleted successfully"
+}
+
+# Function to check if image already exists
+# This checks if IMAGE_VERSION and IMAGE_ID already exist in Azure
+# and the LATEST_IMAGE_ID annotation is set in the peer-pods-cm configmap
+# 0: Image exists and matches
+# 1: Image does not exist
+# 2: Image mismatch (caller should delete Image)
+# The required variables are assumed to be set
+function image_exists() {
+
+    local image_id
+    # Get the image id
+    image_id=$(az sig image-version show --resource-group "${AZURE_RESOURCE_GROUP}" \
+        --gallery-name "${IMAGE_GALLERY_NAME}" \
+        --gallery-image-definition "${IMAGE_DEFINITION_NAME}" \
+        --gallery-image-version "${IMAGE_VERSION}" \
+        --query "id" --output tsv)
+
+    img_return_code=$?
+
+    # Get the latest image id from the peer-pods-cm configmap
+    local latest_image_id
+    latest_image_id=$(kubectl get configmap peer-pods-cm -n openshift-sandboxed-containers-operator -o jsonpath='{.metadata.annotations.LATEST_IMAGE_ID}')
+
+    # Handle Azure command failure
+    if [[ "${img_return_code}" -ne 0 ]]; then
+        error_exit "Error querying Azure for Image."
+    fi
+
+    # Case 1: Image exists and matches the configmap
+    if [[ "${image_id}" == "${latest_image_id}" ]]; then
+        echo "Image (${image_id}) is up-to-date in configmap."
+        return 0
+    # Case 2: No Image in Azure and no record in the configmap
+    elif [[ -z "${image_id}" && -z "${latest_image_id}" ]]; then
+        echo "No Image found in Azure, and no record in configmap."
+        return 1
+    # Case 3: Image missing in Azure but present in configmap
+    elif [[ -z "${image_id}" && -n "${latest_image_id}" ]]; then
+        echo "No Image found in Azure, but configmap has record (${latest_image_id}). Image might have been deleted."
+        return 1
+    # Case 4: Image exists in Azure but does not match configmap.
+    else
+        echo "Image mismatch: Azure Image (${image_id}) differs from ConfigMap Image (${latest_image_id})."
+        return 2 # Caller should delete Azure image version and recreate
+    fi
+
 }
 
 # display help message

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -239,6 +239,13 @@ function create_image_definition() {
 function create_image_using_packer() {
     echo "Creating Azure image using packer"
 
+    echo "Deleting any leftover managed image (${IMAGE_NAME}) due to abrupt exit of packer build"
+    # This will be of the form
+    # /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/images/<image-name>
+    # Note that this is not tied to gallery
+    # We ignore any errors here.
+    az image delete --name "${IMAGE_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" || true
+
     # If any error occurs, exit the script with an error message
     # The variables are set before calling the function
 
@@ -377,7 +384,7 @@ function create_image() {
         echo "Image exists. Skipping creation"
         return
     elif [[ "${image_status}" -eq 2 ]]; then
-        echo "Deleting image version, before recreating"
+        echo "Deleting image version (${IMAGE_VERSION}), before recreating"
         delete_image_version
     fi
 
@@ -568,7 +575,7 @@ function upload_vhd_image() {
 # Function to delete a specific image version from Azure
 
 function delete_image_version() {
-    echo "Deleting Azure image version"
+    echo "Deleting Azure image version (${IMAGE_VERSION})"
     # If any error occurs, exit the script with an error message
 
     # Delete the image version
@@ -578,7 +585,7 @@ function delete_image_version() {
         --gallery-image-version "${IMAGE_VERSION}" ||
         error_exit "Failed to delete the image version"
 
-    echo "Azure image version deleted successfully"
+    echo "Azure image version (${IMAGE_VERSION}) deleted successfully"
 }
 
 # Function delete all image versions from Azure image-definition
@@ -731,7 +738,7 @@ function delete_image_using_id() {
 }
 
 # Function to check if image already exists
-# This checks if IMAGE_VERSION and IMAGE_ID already exist in Azure
+# This checks if IMAGE_VERSION exist in Azure
 # and the LATEST_IMAGE_ID annotation is set in the peer-pods-cm configmap
 # 0: Image exists and matches
 # 1: Image does not exist

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -691,9 +691,17 @@ function delete_image_gallery() {
     delete_image_definition
 
     # Delete the image gallery
-    az sig delete --resource-group "${AZURE_RESOURCE_GROUP}" \
-        --gallery-name "${IMAGE_GALLERY_NAME}" ||
-        error_exit "Failed to delete the image gallery"
+    #az sig delete --resource-group "${AZURE_RESOURCE_GROUP}" \
+    #    --gallery-name "${IMAGE_GALLERY_NAME}" ||
+    #    error_exit "Failed to delete the image gallery"
+
+    # Sometimes the delete fails with teh following command:
+    # "ERROR: (CannotDeleteResource) Cannot delete resource while nested resources exist"
+    # This could be temporary due to image definition deletion not being immediate
+    # Hence add retry logic to delete the image gallery
+
+    retry_command az sig delete --resource-group "${AZURE_RESOURCE_GROUP}" --gallery-name "${IMAGE_GALLERY_NAME}" ||
+        echo "Failed to delete the image gallery."
 
     # Remove the image gallery annotation from peer-pods-cm configmap
     delete_image_gallery_annotation_from_peer_pods_cm

--- a/config/peerpods/podvm/gcp-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/gcp-podvm-image-cm.yaml
@@ -11,6 +11,10 @@ data:
   CAA_REF: "main"
 
   IMAGE_BASE_NAME: "podvm-image"
+  # Must be in Major(int).Minor(int).Patch(int) format
+  # When deployed from operator, update the IMAGE_VERSION to something like
+  # "$clusterid-0-1"
+  IMAGE_VERSION: "0-0-1"
 
   # Booleans
   INSTALL_PACKAGES: "no"

--- a/config/peerpods/podvm/gcp-podvm-image-handler.sh
+++ b/config/peerpods/podvm/gcp-podvm-image-handler.sh
@@ -28,6 +28,7 @@ function verify_vars() {
 
     # From gcp-podvm-image-cm:
     "IMAGE_BASE_NAME"
+    "IMAGE_VERSION"
     "INSTALL_PACKAGES"
     "DISABLE_CLOUD_CONFIG"
 
@@ -101,10 +102,7 @@ function create_image() {
   echo "GCP image created successfully"
 }
 
-function set_image_version_and_name() {
-  IMAGE_VERSION="$(date +'%Y%m%d%S')"
-  export IMAGE_VERSION
-
+function set_image_name() {
   # Set the image name
   IMAGE_NAME="${IMAGE_BASE_NAME}-${IMAGE_VERSION}"
   export IMAGE_NAME
@@ -113,8 +111,8 @@ function set_image_version_and_name() {
 function create_image_from_prebuilt_artifact() {
   echo "Creating GCP image from prebuilt artifact"
 
-  # Set the IMAGE_VERSION and IMAGE_NAME
-  set_image_version_and_name
+  # Set the IMAGE_NAME
+  set_image_name
 
   echo "Pulling the podvm image from the provided path"
   image_src="/tmp/image"

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -35,6 +35,10 @@ spec:
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # gcp-podvm-image-handler.sh script under /scripts/gcp-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
+          lifecycle: 
+            preStop: 
+              exec: 
+                command: ["/scripts/packer-resource-cleanup.sh"]
           securityContext: # TODO: evaluate if these are actually needed
             privileged: true
             allowPrivilegeEscalation: true
@@ -77,7 +81,8 @@ spec:
               readOnly: true
             - name: store-volume
               mountPath: /store
-
+      # Default is 30s which is too less for the preStop hook to fully execute        
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: payload
           emptyDir: {}

--- a/config/peerpods/podvm/packer-resource-cleanup.sh
+++ b/config/peerpods/podvm/packer-resource-cleanup.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -e
+
+CLOUD_PROVIDER=${CLOUD_PROVIDER:-"azure"}
+
+# Define log file path
+# This needs to be the PID 1 stdout, which is what is read by `kubectl logs`
+# This log will be available in the pod logs
+LOG_FILE=${LOG_FILE:-"/proc/1/fd/1"}
+
+# Function to log messages with timestamp
+function log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >>"$LOG_FILE"
+}
+
+
+function azure_cleanup() {
+    # Capture Packer created VM names in an array
+    log "Deleting Packer VMs"
+    mapfile -t vm_names < <(az vm list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?osProfile.adminUsername=='packer' && starts_with(osProfile.computerName, 'pkrvm')].name" --output tsv)
+
+    # Log the captured VM names
+    for vm in "${vm_names[@]}"; do
+        log "Captured VM: $vm"
+    done
+
+    # Check if any VMs were found
+    if [ ${#vm_names[@]} -eq 0 ]; then
+        log "No VMs found matching the criteria."
+    else
+        # Loop through the array and delete each VM
+        for vm in "${vm_names[@]}"; do
+            log "Deleting VM: $vm"
+            az vm delete --name "$vm" --resource-group "$AZURE_RESOURCE_GROUP" --yes >>"$LOG_FILE" 2>&1
+        done
+    fi
+
+    log "Disassociating and Deleting Packer Public IPs..."
+    mapfile -t public_ip_names < <(az network public-ip list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?starts_with(name, 'pkrip')].name" --output tsv)
+
+    # Log the captured Public IP names
+    for public_ip_name in "${public_ip_names[@]}"; do
+        log "Captured Public IP: $public_ip_name"
+    done
+
+    for public_ip_name in "${public_ip_names[@]}"; do
+        # Get the public IP ID dynamically
+        public_ip_id=$(az network public-ip show --name "$public_ip_name" --resource-group "$AZURE_RESOURCE_GROUP" --query "id" --output tsv)
+
+        if [[ -z "$public_ip_id" ]]; then
+            log "Skipping $public_ip_name as it has no associated ID."
+            continue
+        fi
+
+        # Find the NIC associated with this Public IP
+        nic_name=$(az network nic list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?ipConfigurations[?publicIPAddress.id=='$public_ip_id']].name" --output tsv)
+
+        if [[ -n "$nic_name" ]]; then
+            log "Disassociating Public IP $public_ip_name from NIC $nic_name..."
+            az network nic ip-config update --name ipconfig --nic-name "$nic_name" --resource-group "$AZURE_RESOURCE_GROUP" --remove publicIPAddress >>"$LOG_FILE" 2>&1
+        fi
+
+        log "Deleting Public IP: $public_ip_name"
+        az network public-ip delete --name "$public_ip_name" --resource-group "$AZURE_RESOURCE_GROUP" >>"$LOG_FILE" 2>&1
+    done
+
+    log "Deleting Packer Network Interfaces..."
+    mapfile -t nics < <(az network nic list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?starts_with(name, 'pkrni')].name" --output tsv)
+
+    # Log the captured NIC names
+    for name in "${nics[@]}"; do
+        log "Captured NIC: $name"
+    done
+
+    for name in "${nics[@]}"; do
+        log "Deleting NIC: $name"
+        az network nic delete --name "$name" --resource-group "$AZURE_RESOURCE_GROUP" >>"$LOG_FILE" 2>&1
+    done
+
+    log "Deleting Packer disks..."
+    mapfile -t disks < <(az disk list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?starts_with(name, 'pkrdisk')].name" --output tsv)
+
+    # Log the captured Disk names
+    for name in "${disks[@]}"; do
+        log "Captured Disk: $name"
+    done
+
+    for name in "${disks[@]}"; do
+        log "Deleting Disk: $name"
+        az disk delete --name "$name" --resource-group "$AZURE_RESOURCE_GROUP" --yes >>"$LOG_FILE" 2>&1
+    done
+
+    log "Deleting Packer Virtual Networks..."
+    mapfile -t vnets < <(az network vnet list --resource-group "$AZURE_RESOURCE_GROUP" --query "[?starts_with(name, 'pkrvn')].name" --output tsv)
+    for vnet in "${vnets[@]}"; do
+        log "Deleting VNet: $vnet (this will also remove subnets)"
+        az network vnet delete --name "$vnet" --resource-group "$AZURE_RESOURCE_GROUP" >>"$LOG_FILE" 2>&1
+    done
+}
+
+# Log the start of the script
+log "Starting Packer resource cleanup script."
+
+# Execute cleanup if CLOUD_PROVIDER==azure
+if [ "$CLOUD_PROVIDER" == "azure" ]; then
+    azure_cleanup
+else
+    log "Cleanup not supported for CLOUD_PROVIDER: $CLOUD_PROVIDER"
+fi
+
+log "cleanup hook completed."


### PR DESCRIPTION
For OSC, we expect only one image to be created by the operator. The IMAGE_VERSION (for Azure) or AMI_VERSION (for AWS) uses clusterID as the unique id.  This helps to check if the image already exists before recreating the image again.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
