### PR TITLE
gcp: PODVM_IMAGE_NAME is the right name

### DIFF
--- a/config/peerpods/podvm/podvm-builder.sh
+++ b/config/peerpods/podvm/podvm-builder.sh
@@ -134,7 +134,7 @@ function create_podvm_image() {
 
       # Update peer-pods-cm configmap with the IMAGE_ID value
       echo "Updating peer-pods-cm configmap with IMAGE_ID=${IMAGE_ID}"
-      kubectl patch configmap peer-pods-cm -n openshift-sandboxed-containers-operator --type merge -p "{\"data\":{\"PODVM_IMAGE_ID\":\"${IMAGE_ID}\"}}"
+      kubectl patch configmap peer-pods-cm -n openshift-sandboxed-containers-operator --type merge -p "{\"data\":{\"PODVM_IMAGE_NAME\":\"${IMAGE_ID}\"}}"
     fi
     ;;
 


### PR DESCRIPTION
The annotation is LATEST_IMAGE_ID but the configmap value is _NAME. I would prefer to not touch on the metadata now, since the metadata.annotation is the same for all providers.

