### PR TITLE
config/peerpods: fix default agent policy for CoCo

### DIFF
--- a/config/peerpods/podvm/lib.sh
+++ b/config/peerpods/podvm/lib.sh
@@ -226,7 +226,7 @@ to edit policy.conf"
         echo "Setting custom agent policy to CoCo's recommended policy"
         sed 's/default ReadStreamRequest := true/default ReadStreamRequest := false/;
             s/default ExecProcessRequest := true/default ExecProcessRequest := false/' \
-            "${podvm_dir}"/files/etc/kata-opa/default-policy.rego >"${podvm_dir}"/files/etc/kata-opa/coco-default-policy.rego
+            "${podvm_dir}"/files/etc/kata-opa/allow-all.rego >"${podvm_dir}"/files/etc/kata-opa/coco-default-policy.rego
         sed -i 's/allow-all.rego/coco-default-policy.rego/g' "${podvm_dir}"/files/etc/tmpfiles.d/policy.conf || error_exit "Failed to edit policy.conf"
 	echo "~~~ Fallback default policy is set to: ~~~" && cat "${podvm_dir}"/files/etc/kata-opa/coco-default-policy.rego
     fi


### PR DESCRIPTION
Fixes: rhjira#[KATA-3709](https://issues.redhat.com//browse/KATA-3709)

**- Description of the problem which is fixed/What is the use case**

The default Kata agent policy for CoCo isn't working, meaning that if the user don't pass the `policy.rego` policy file via initdata then the pod crashes on start.

**- What I did**

/etc/kata-opa/default-policy.rego is a symlink; sed'ing and copying it to /etc/kata-opa/coco-default-policy.rego results on an empty file. This changed to use the /etc/kata-opa/allow-all.rego, which is a standard file, as the baseline for the coco default policy.

**- How to verify it**

I tested on the downstream OSC 1.9.0 build on Azure. The process to verify is complicated and still not documented, in summary:

* Deleted the current podvm image, like:
```
base_url="https://raw.githubusercontent.com/openshift/sandboxed-containers-operator/refs/heads/devel/config/peerpods/podvm"
AZURE_IMAGE_ID=$(oc get cm/peer-pods-cm -n openshift-sandboxed-containers-operator -o jsonpath='{.data.AZURE_IMAGE_ID}')
oc delete --ignore-not-found=true job/osc-podvm-image-deletion -n openshift-sandboxed-containers-operator
curl -s "${base_url}/osc-podvm-delete-job.yaml" | \
       yq e '.spec.template.spec.containers[0].env = [{"name": "IMAGE_ID", "value": "'$AZURE_IMAGE_ID'"}]' | \
       oc apply -f -
```

* Created a new podvm builder image from the following containerfile and push to quay.io:

```
osc-podvm-builder.containerfile 
FROM brew.registry.redhat.io/rh-osbs/openshift-sandboxed-containers-podvm-builder:1.9.0

COPY lib.sh /scripts/lib.sh
```

* Replaced the builder image in [osc-podvm-create-job.yaml]](https://github.com/openshift/sandboxed-containers-operator/blob/devel/config/peerpods/podvm/osc-podvm-create-job.yaml) and applied it:
```
oc apply -f osc-podvm-create-job.yaml]
```
* Wait the job that re-creates the podvm image finish. Reboot the caa daemonset.
* Created the following pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-unsigned
  annotations:
    io.katacontainers.config.runtime.cc_init_data: YWxnb3JpdGhtID0gInNoYTI1NiIKdmVyc2lvbiA9ICIwLjEuMCIKCltkYXRhXQoiYWEudG9tbCIgPSAnJycKW3Rva2VuX2NvbmZpZ3NdClt0b2tlbl9jb25maWdzLmNvY29fYXNdCnVybCA9ICdodHRwOi8va2JzLXNlcnZpY2UudHJ1c3RlZS1vcGVyYXRvci1zeXN0ZW06ODA4MCcKClt0b2tlbl9jb25maWdzLmtic10KdXJsID0gJ2h0dHA6Ly9rYnMtc2VydmljZS50cnVzdGVlLW9wZXJhdG9yLXN5c3RlbTo4MDgwJwpjZXJ0ID0gIiIiCiIiIgonJycKCiJjZGgudG9tbCIgID0gJycnCnNvY2tldCA9ICd1bml4Oi8vL3J1bi9jb25maWRlbnRpYWwtY29udGFpbmVycy9jZGguc29jaycKY3JlZGVudGlhbHMgPSBbXQoKW2tiY10KbmFtZSA9ICdjY19rYmMnCnVybCA9ICdodHRwOi8va2JzLXNlcnZpY2UudHJ1c3RlZS1vcGVyYXRvci1zeXN0ZW06ODA4MCcKCicnJwo=
spec:
  runtimeClassName: kata-remote
  containers:
    - name: test-container
      image: quay.io/prometheus/busybox:latest
      imagePullPolicy: Always
      command:
        - sleep
        - "infinity"
```
* Noticed that on the initdata field (in base64) I'm not passing a `policy.rego`. See the initdata decoded:
```
algorithm = "sha256"
version = "0.1.0"

[data]
"aa.toml" = '''
[token_configs]
[token_configs.coco_as]
url = 'http://kbs-service.trustee-operator-system:8080'

[token_configs.kbs]
url = 'http://kbs-service.trustee-operator-system:8080'
cert = """
"""
'''

"cdh.toml"  = '''
socket = 'unix:///run/confidential-containers/cdh.sock'
credentials = []

[kbc]
name = 'cc_kbc'
url = 'http://kbs-service.trustee-operator-system:8080'

'''
```

* I didn't mention that I tweaked the podvm image creation to produce a image where sshd is enabled so I could connect to the running podvm. Then I checked the files and symlink are correct now:

```
[peerpod@podvm-test-unsigned-0ccb264d ~]$ ls /etc/kata-opa/
allow-all-except-exec-process.rego  coco-default-policy.rego            disallow-all-except-setpolicy.rego  
allow-all.rego                      default-policy.rego                 
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /etc/kata-opa/coco-default-policy.rego 
package agent_policy

default AddARPNeighborsRequest := true
default AddSwapRequest := true
default CloseStdinRequest := true
default CopyFileRequest := true
default CreateContainerRequest := true
default CreateSandboxRequest := true
default DestroySandboxRequest := true
default ExecProcessRequest := false
default GetMetricsRequest := true
default GetOOMEventRequest := true
default GuestDetailsRequest := true
default ListInterfacesRequest := true
default ListRoutesRequest := true
default MemHotplugByProbeRequest := true
default OnlineCPUMemRequest := true
default PauseContainerRequest := true
default PullImageRequest := true
default ReadStreamRequest := false
default RemoveContainerRequest := true
default RemoveStaleVirtiofsShareMountsRequest := true
default ReseedRandomDevRequest := true
default ResumeContainerRequest := true
default SetGuestDateTimeRequest := true
default SetPolicyRequest := true
default SignalProcessRequest := true
default StartContainerRequest := true
default StartTracingRequest := true
default StatsContainerRequest := true
default StopTracingRequest := true
default TtyWinResizeRequest := true
default UpdateContainerRequest := true
default UpdateEphemeralMountsRequest := true
default UpdateInterfaceRequest := true
default UpdateRoutesRequest := true
default WaitProcessRequest := true
default WriteStreamRequest := true
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /etc/kata-opa/coco-default-policy.rego | grep false
default ExecProcessRequest := false
default ReadStreamRequest := false
[peerpod@podvm-test-unsigned-0ccb264d ~]$ ls -l /etc/kata-opa/
total 16
-rw-r--r--. 1 1000 1000 1361 Mar 19 12:50 allow-all-except-exec-process.rego
-rw-r--r--. 1 1000 1000 1359 Mar 19 12:50 allow-all.rego
-rw-r--r--. 1 1000 1000 1361 Mar 20 22:16 coco-default-policy.rego
lrwxrwxrwx. 1 1000 1000   24 Mar 19 13:07 default-policy.rego -> /run/peerpod/policy.rego
-rw-r--r--. 1 1000 1000 1395 Mar 19 12:50 disallow-all-except-setpolicy.rego
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /run/peerpod/policy.rego
package agent_policy

default AddARPNeighborsRequest := true
default AddSwapRequest := true
default CloseStdinRequest := true
default CopyFileRequest := true
default CreateContainerRequest := true
default CreateSandboxRequest := true
default DestroySandboxRequest := true
default ExecProcessRequest := false
default GetMetricsRequest := true
default GetOOMEventRequest := true
default GuestDetailsRequest := true
default ListInterfacesRequest := true
default ListRoutesRequest := true
default MemHotplugByProbeRequest := true
default OnlineCPUMemRequest := true
default PauseContainerRequest := true
default PullImageRequest := true
default ReadStreamRequest := false
default RemoveContainerRequest := true
default RemoveStaleVirtiofsShareMountsRequest := true
default ReseedRandomDevRequest := true
default ResumeContainerRequest := true
default SetGuestDateTimeRequest := true
default SetPolicyRequest := true
default SignalProcessRequest := true
default StartContainerRequest := true
default StartTracingRequest := true
default StatsContainerRequest := true
default StopTracingRequest := true
default TtyWinResizeRequest := true
default UpdateContainerRequest := true
default UpdateEphemeralMountsRequest := true
default UpdateInterfaceRequest := true
default UpdateRoutesRequest := true
default WaitProcessRequest := true
default WriteStreamRequest := true
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /run/peerpod/policy.rego | grep false
default ExecProcessRequest := false
default ReadStreamRequest := false
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /run/peerpod/
aa.toml          auth.json        cdh.toml         daemon.json      initdata         initdata.digest  policy.rego      
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /run/peerpod/initdata
YWxnb3JpdGhtID0gInNoYTI1NiIKdmVyc2lvbiA9ICIwLjEuMCIKCltkYXRhXQoiYWEudG9tbCIgPSAnJycKW3Rva2VuX2NvbmZpZ3NdClt0b2tlbl9jb25maWdzLmNvY29fYXNdCnVybCA9ICdodHRwOi8va2JzLXNlcnZpY2UudHJ1c3RlZS1vcGVyYXRvci1zeXN0ZW06ODA4MCcKClt0b2tlbl9jb25maWdzLmtic10KdXJsID0gJ2h0dHA6Ly9rYnMtc2VydmljZS50cnVzdGVlLW9wZXJhdG9yLXN5c3RlbTo4MDgwJwpjZXJ0ID0gIiIiCiIiIgonJycKCiJjZGgudG9tbCIgID0gJycnCnNvY2tldCA9ICd1bml4Oi8vL3J1bi9jb25maWRlbnRpYWwtY29udGFpbmVycy9jZGguc29jaycKY3JlZGVudGlhbHMgPSBbXQoKW2tiY10KbmFtZSA9ICdjY19rYmMnCnVybCA9ICdodHRwOi8va2JzLXNlcnZpY2UudHJ1c3RlZS1vcGVyYXRvci1zeXN0ZW06ODA4MCcKCicnJwo=
[peerpod@podvm-test-unsigned-0ccb264d ~]$ cat /run/peerpod/initdata | base64 -d
algorithm = "sha256"
version = "0.1.0"

[data]
"aa.toml" = '''
[token_configs]
[token_configs.coco_as]
url = 'http://kbs-service.trustee-operator-system:8080'

[token_configs.kbs]
url = 'http://kbs-service.trustee-operator-system:8080'
cert = """
"""
'''

"cdh.toml"  = '''
socket = 'unix:///run/confidential-containers/cdh.sock'
credentials = []

[kbc]
name = 'cc_kbc'
url = 'http://kbs-service.trustee-operator-system:8080'

'''
```
