### PR TITLE
kata installation should not watch the 'worker' MCP state

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1267,7 +1267,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.setInProgressConditionToInstalling()
 	}
 
-	isInstallationInProgress := r.isMcpUpdating(machinePool) || (!isConvergedCluster && r.isMcpUpdating("worker"))
+	isInstallationInProgress := r.isMcpUpdating(machinePool)
 
 	// Create kata-oc MCP only if it's not a converged cluster
 	if !isConvergedCluster {
@@ -1318,11 +1318,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 	r.Log.Info("MCP updating state", "MCP name", machinePool, "is updating", isKataMcpUpdating)
 
 	isMcoUpdating := isKataMcpUpdating
-	if !isConvergedCluster {
-		isWorkerUpdating := r.isMcpUpdating("worker")
-		r.Log.Info("MCP updating state", "MCP name", "worker", "is updating", isWorkerUpdating)
-		isMcoUpdating = isKataMcpUpdating || isWorkerUpdating
-	}
 
 	if isMcoUpdating && r.getInProgressConditionValue() == corev1.ConditionFalse {
 		r.setInProgressConditionToUpdating()

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1267,8 +1267,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		r.setInProgressConditionToInstalling()
 	}
 
-	isInstallationInProgress := r.isMcpUpdating(machinePool)
-
 	// Create kata-oc MCP only if it's not a converged cluster
 	if !isConvergedCluster {
 		labelingChanged, err := r.updateNodeLabels()
@@ -1282,6 +1280,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		if labelingChanged {
 			r.Log.Info("node labels updated")
 
+			isInstallationInProgress := r.isMcpUpdating(machinePool)
 			if !isInstallationInProgress {
 				r.Log.Info("Starting to wait for MCO to start")
 				r.kataConfig.Status.WaitingForMcoToStart = true
@@ -1314,10 +1313,8 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 		}
 	}
 
-	isKataMcpUpdating := r.isMcpUpdating(machinePool)
-	r.Log.Info("MCP updating state", "MCP name", machinePool, "is updating", isKataMcpUpdating)
-
-	isMcoUpdating := isKataMcpUpdating
+	isMcoUpdating := r.isMcpUpdating(machinePool)
+	r.Log.Info("MCP updating state", "MCP name", machinePool, "is updating", isMcoUpdating)
 
 	if isMcoUpdating && r.getInProgressConditionValue() == corev1.ConditionFalse {
 		r.setInProgressConditionToUpdating()


### PR DESCRIPTION
When the MCO migrates nodes between pools, the target pool enters the Updating state and has nodes gradually added to it as they are updated and rebooted while the source pool is drained by simply setting its machine count to the desired value at once and never leaves the Updated state.

Because the "worker" pool is the source pool in kata installation, it follows that nothing can be gained by watching its status.

Normally it doesn't hurt either but if "worker" is Updating already for some unrelated reason when kata installation is starting, it throws off the isInstallationInProgress detection and thus the whole installation flow.
