### PR TITLE
podvm: Enable se image build for rhel with and without --no-verify

### DIFF
--- a/config/peerpods/podvm/lib.sh
+++ b/config/peerpods/podvm/lib.sh
@@ -245,6 +245,22 @@ to edit policy.conf"
             error_exit "Error: HKD is not present."
         else
             echo "$HOST_KEY_CERTS" >>"${podvm_dir}/files/HKD.crt"
+            if [[ "$SE_VERIFY" == "true" ]]; then
+               curl -o "${podvm_dir}/files/ibm-z-host-key-signing-gen2.crt" "https://www.ibm.com/support/resourcelink/api/content/public/ibm-z-host-key-signing-gen2.crt"
+               if [[ $? -ne 0 ]]; then
+                       error_exit "Error: Failed to download ibm-z-host-key-signing-gen2.crt."
+               fi
+
+               curl -o "${podvm_dir}/files/DigiCertCA.crt" "https://www.ibm.com/support/resourcelink/api/content/public/DigiCertCA.crt"
+               if [[ $? -ne 0 ]]; then
+                       error_exit "Error: Failed to download DigiCertCA.crt."
+               fi
+
+               curl -o "${podvm_dir}/files/ibm-z-host-key-gen2.crl" "https://www.ibm.com/support/resourcelink/api/content/public/ibm-z-host-key-gen2.crl"
+               if [[ $? -ne 0 ]]; then
+                       error_exit "Error: Failed to download ibm-z-host-key-gen2.crl."
+               fi
+           fi
         fi
     fi
 

--- a/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
@@ -31,6 +31,3 @@ data:
 
   # For Pre-built PodVM images.
   PODVM_IMAGE_URI: "" # eg: oci::quay.io/openshift_sandboxed_containers/libvirt-podvm-image:latest::/image/podvm.qcow2
-
-  # Name of PodVM qcow2 to be built.
-  IMAGE_NAME: "podvm-image" 

--- a/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/libvirt-podvm-image-cm.yaml
@@ -25,6 +25,12 @@ data:
 
   # To Enable SE for IBM Z
   SE_BOOT: "true"
+  
+  # To enable SE verification on IBM Z
+  SE_VERIFY: "true"
 
   # For Pre-built PodVM images.
   PODVM_IMAGE_URI: "" # eg: oci::quay.io/openshift_sandboxed_containers/libvirt-podvm-image:latest::/image/podvm.qcow2
+
+  # Name of PodVM qcow2 to be built.
+  IMAGE_NAME: "podvm-image" 

--- a/config/peerpods/podvm/libvirt-podvm-image-handler.sh
+++ b/config/peerpods/podvm/libvirt-podvm-image-handler.sh
@@ -166,6 +166,9 @@ function create_libvirt_image_from_prebuilt_artifact() {
 function create_libvirt_image_from_scratch() {
     echo "Creating qcow2 image for libvirt provider from scratch"
 
+    # Define image name 
+    export IMAGE_NAME="podvm-image"
+
     # If any error occurs, exit the script with an error message
 
     if [[ "${DOWNLOAD_SOURCES}" == "yes" ]]; then


### PR DESCRIPTION
Made changes to build RHEL SE enabled podvm image with an extra Arg of SE_VERIFY=true

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
This PR introduces an additional feature to verify and download required certificates for secure environments when the SE_VERIFY tag is set to true

**- What I did**
I added a conditional block that checks if the SE_VERIFY environment variable is set to true. If so, it performs the following actions:

Downloads the IBM Z Host Key Signing Certificate (ibm-z-host-key-signing-gen2.crt).

Downloads the DigiCert CA certificate (DigiCertCA.crt).

Downloads the IBM Z Host Key CRL (ibm-z-host-key-gen2.crl).

**- How to verify it**
Built and deploy the pod VM image.
```
[root@bastion-rr-initdata ~]# oc get pods
NAME          READY   STATUS    RESTARTS   AGE
busybox-new   1/1     Running   0          41s
```

**- Description for the changelog**
Added SE_VERIFY flag to enable downloading and verifying security certificates for secure prod environments.