### PR TITLE
podvm: Select subscription after Azure login

### DIFF
--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -140,6 +140,10 @@ function login_to_azure() {
         --tenant="${AZURE_TENANT_ID}" ||
         error_exit "Failed to login to Azure"
 
+    echo "Selecting subscription"
+    az account set --subscription ${AZURE_SUBSCRIPTION_ID} ||
+        error_exit "Failed to select subscription"
+
     echo "Logged in to Azure successfully"
 }
 


### PR DESCRIPTION
Experimentally, if you have multiple Azure subscription and the one you are working in is not the first one returned by `az login`, the next step in the image builder script fails creating the gallery. See details below.

This is addressed here by explicitly selecting the subcription with `az account set --subscription ${AZURE_SUBSCRIPTION_ID}`.

Fixes: #606

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

When a user has multiple Azure subscriptions and the one used for the peer pods resource group, then `az login` is not sufficient to select the correct subscription deterministically. This manifests with an error like this:

```
ERROR: (ResourceGroupNotFound) Resource group 'c3d-konflux-rg' could not be found.
145
Code: ResourceGroupNotFound
```

followed by a failure to create the gallery:

```
Creating image gallery PodVMGallery_18a5d8b1
148
ERROR: InvalidArgumentValue: Missing required field: --location
149
Failed to create Azure image gallery
```

**- What I did**

Added an explicit selection of the user subscription 👍 

```
az account set --subscription ${AZURE_SUBSCRIPTION_ID} ||
        error_exit "Failed to select subscription"
```

**- How to verify it**

For the problem to manifest, you need:

1. Two or more Azure subscription
2. The subscription where the resource group is not being the first one

Then simply starting a peer pods setup will end up with multiple instances of the `osc-podvm-image-creation` pod in `Error` state, with a problem creating the gallery as indicated above.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Select Azure subscription explicitly for users with multiple subscriptions.