### PR TITLE
podvm: Modify image creation job failure

### DIFF
--- a/config/peerpods/podvm/libvirt-podvm-image-handler.sh
+++ b/config/peerpods/podvm/libvirt-podvm-image-handler.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # FILEPATH: libvirt-podvm-image-handler.sh
-
 # This script is used to create or delete libvirt qcow2 image for podvm
 # The basic assumption is that the required variables are set as environment variables in the pod
 # Typically the variables are read from configmaps and set as environment variables in the pod
@@ -249,6 +248,8 @@ function upload_libvirt_image() {
     virsh -d 0 -c "${LIBVIRT_URI}" vol-upload --vol "${LIBVIRT_VOL_NAME}" "${PODVM_IMAGE_PATH}" --pool "${LIBVIRT_POOL}" --sparse
     if [ $? -eq 0 ]; then
         echo "Uploaded the image successfully"
+    else
+        error_exit "Failed to upload image"
     fi
 }
 

--- a/config/peerpods/podvm/podvm-builder.sh
+++ b/config/peerpods/podvm/podvm-builder.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 # Function to install Azure deps
 function install_azure_deps() {
@@ -140,7 +139,10 @@ function create_podvm_image() {
 
   libvirt)
     echo "Creating Libvirt qcow2"
-    /scripts/libvirt-podvm-image-handler.sh -c
+    /scripts/libvirt-podvm-image-handler.sh -c || {
+      echo "Libvirt image creation failed"
+      exit 1
+    }
     if [ "${UPDATE_PEERPODS_CM}" == "yes" ]; then
       # Check if peer-pods-cm configmap exists
       if ! check_peer_pods_cm_exists; then


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
Currently, when the image creation step fails, the job continues executing subsequent steps and exits successfully, which leads to false positives in deployment environments.
**- What I did**
Ensured the script or job pipeline properly exits with a non-zero status code when an error occurs.
**- How to verify it**
Triggered the job with a simulated failure and verified that the job now error out on failure
```
Creating qcow2 image for libvirt provider from scratch
Cloning into '/src/cloud-api-adaptor'...
error: pathspec 'main-test' did not match any file(s) known to git
Failed to checkout the required commit
Libvirt image creation failed
```

```
oc get pods -n openshift-sandboxed-containers-operator
NAME                                           READY   STATUS                   RESTARTS   AGE
controller-manager-6f868fb9f8-ncrg5            1/1     Running                  0          7h51m
openshift-sandboxed-containers-monitor-kqpcc   1/1     Running                  3          17d
operator-metrics-server-69d95bb67d-ndwk6       1/1     Running                  8          24d
osc-caa-ds-4s9st                               1/1     Running                  4          17d
osc-podvm-image-creation-4zgps                 0/1     Error                    0          3m
peer-pods-webhook-767fc78655-68nb4             1/1     Running                  3          17d
peer-pods-webhook-767fc78655-x4nvl             1/1     Running                  3          17d
```
**- Description for the changelog**
Ensure build job exits on image creation failure to prevent false positives during deployment.
