### PR TITLE
podvm: Restrict Azure image version is a 32-bit integer

### DIFF
--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -753,7 +753,12 @@ func (r *ImageGenerator) createImageConfigMapFromFile() error {
 	imageVersion := "0.0.1"
 	clusterIdInt, err := strconv.ParseUint(r.clusterId, 16, 32)
 	if err == nil {
-		imageVersion = fmt.Sprintf("%d.0.1", clusterIdInt)
+		// Ensure the version number is within Azure's allowed range (32-bit integer 0-2,147,483,647)
+		// Ref: https://learn.microsoft.com/en-us/rest/api/compute/gallery-image-versions/create-or-update
+		const maxVersionNumber = 2147483647
+		majorVersion := clusterIdInt % (maxVersionNumber + 1)
+		imageVersion = fmt.Sprintf("%d.0.1", majorVersion)
+		igLogger.Info("Using cluster ID based image version", "cluster_id", r.clusterId, "image_version", imageVersion)
 	} else {
 		igLogger.Info("clusterId is not a valid hex number, using default version")
 	}


### PR DESCRIPTION
The Azure image version is of the form Major(int).Minor(int).Patch(int) format, where int is between 0 and 2,147,483,647 (inclusive). The previous code converted the cluster ID (which is in hex format) directly to an integer and used it as the major version number. However the converted value could be too large resulting in image creation failure. This change limits the major version to the max signed int value.  As for the Minor and Patch values, we use a fixed value of 0.1

Fixes: #[KATA-3741](https://issues.redhat.com//browse/KATA-3741)


