### PR TITLE
baremetal-coco: Update manifests to use release 0.2.0 artefacts

### DIFF
--- a/scripts/cm-helpers/pp-cm-helper.sh
+++ b/scripts/cm-helpers/pp-cm-helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ENV_FILE=$(mktemp -t pp-cm-env-XXXX.env)
 IS_ARO=false

--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -183,13 +183,41 @@ function wait_for_runtimeclass() {
     return 1
 }
 
+# Function to wait for an installPlan to be available in specific namespace
+# This simply checks if at least a single installPlan object is available in specific namespace
+function is_installplan_available_in_ns() {
+
+    local ns=$1
+    local timeout=$CMD_TIMEOUT
+    local interval=5
+    local elapsed=0
+    local ready=0
+
+    while [ $elapsed -lt "$timeout" ]; do
+        ready=$(oc get installplan -n "$ns" -o jsonpath='{.items[0].metadata.name}')
+        if [ -n "$ready" ]; then
+            echo "InstallPlan $ready is available in namespace $ns"
+            return 0
+        fi
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+}
+
 # Function to apply the operator manifests
 function apply_operator_manifests() {
+    local installplan=""
+
     # Apply the manifests
     oc apply -f ns.yaml || return 1
     oc apply -f og.yaml || return 1
     if [[ "$GA_RELEASE" == "true" ]]; then
         oc apply -f subs-ga.yaml || return 1
+        is_installplan_available_in_ns openshift-sandboxed-containers-operator || return 1
+        # Approve the installplan
+        installplan=$(oc get installplan -n openshift-sandboxed-containers-operator -o name)
+        oc patch "$installplan" -n openshift-sandboxed-containers-operator -p '{"spec":{"approved":true}}' --type merge || return 1
     else
         oc apply -f osc_catalog.yaml || return 1
         oc apply -f subs-upstream.yaml || return 1

--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -554,7 +554,7 @@ function display_help() {
     echo "Options:"
     echo "  -t <tee_type> Specify the TEE type (tdx or snp)"
     echo "  -h Display help"
-    echo "  -m Install the image mirroring config"
+    echo "  -m Install the image mirroring config to pull required images from internal (brew) registry"
     echo "  -s Set additional cluster-wide image pull secret."
     echo "     Requires the secret to be set in PULL_SECRET_JSON environment variable"
     echo "     Example PULL_SECRET_JSON='{\"my.registry.io\": {\"auth\": \"ABC\"}}'"

--- a/scripts/install-helpers/baremetal-coco/layeredimage-cm-snp.yaml
+++ b/scripts/install-helpers/baremetal-coco/layeredimage-cm-snp.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:snp-0.1.0"
+  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:snp-0.2.0"
 kind: ConfigMap
 metadata:
   name: layered-image-deploy-cm

--- a/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
+++ b/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:tdx-0.1.0"
+  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:tdx-0.2.0"
   kernelArguments: "kvm_intel.tdx=1"
 kind: ConfigMap
 metadata:

--- a/scripts/install-helpers/baremetal-coco/nfd/nfd-cr.yaml
+++ b/scripts/install-helpers/baremetal-coco/nfd/nfd-cr.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-nfd
 spec:
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.16
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.18
     imagePullPolicy: Always
     servicePort: 12000
   workerConfig:

--- a/scripts/install-helpers/baremetal-coco/osc_catalog.yaml
+++ b/scripts/install-helpers/baremetal-coco/osc_catalog.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   displayName: OSC Upstream Operator Catalog
   sourceType: grpc
-  image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:1.8.1-3
+  image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:1.9.0-28
   updateStrategy:
     registryPoll:
       interval: 5m

--- a/scripts/install-helpers/baremetal-coco/release-0.2.0.md
+++ b/scripts/install-helpers/baremetal-coco/release-0.2.0.md
@@ -1,0 +1,24 @@
+## Release notes
+
+Following are the prerequisites
+- OCP release must be 4.18
+- At least one baremetal node supporting either AMD SNP or Intel TDX
+
+## Disconnected installs
+
+For disconnected setup, you'll need to mirror the following by creating
+an `ImageSetConfiguration`
+
+## operator packages
+
+- sandboxed-containers-operator
+- nfd
+- trustee-operator
+
+
+## Additional images
+
+- quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:snp-0.2.0
+- quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:tdx-0.2.0
+- registry.redhat.io/ubi9/ubi:latest
+- registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.18

--- a/scripts/install-helpers/baremetal-coco/subs-ga.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-ga.yaml
@@ -9,4 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.8.1  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.9.0  ## OSC_VERSION

--- a/scripts/install-helpers/baremetal-coco/subs-ga.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-ga.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
@@ -9,4 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: osc-upstream-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.8.1  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.9.0  ## OSC_VERSION


### PR DESCRIPTION
Update layered image to point to OCP 4.18 based layers Update OSC to 1.9.0

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
