### PR TITLE
Switch to Manual installPlan for OSC operator

### DIFF
--- a/scripts/install-helpers/baremetal-coco/subs-ga.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-ga.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
For baremetal preview releases we are very particular about the OSC operator version and hence auto upgrades are not preferred.
Switch to manual approvals for operator installation


