### PR TITLE
Update manifests for 0.2.0

### DIFF
--- a/scripts/install-helpers/baremetal-coco/layeredimage-cm-snp.yaml
+++ b/scripts/install-helpers/baremetal-coco/layeredimage-cm-snp.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:snp-0.1.0"
+  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:snp-0.2.0"
 kind: ConfigMap
 metadata:
   name: layered-image-deploy-cm

--- a/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
+++ b/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.16:tdx-0.1.0"
+  osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:tdx-0.2.0"
   kernelArguments: "kvm_intel.tdx=1"
 kind: ConfigMap
 metadata:

--- a/scripts/install-helpers/baremetal-coco/osc_catalog.yaml
+++ b/scripts/install-helpers/baremetal-coco/osc_catalog.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   displayName: OSC Upstream Operator Catalog
   sourceType: grpc
-  image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:1.8.1-3
+  image: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:1.9.0-28
   updateStrategy:
     registryPoll:
       interval: 5m

--- a/scripts/install-helpers/baremetal-coco/subs-ga.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-ga.yaml
@@ -9,4 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.8.1  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.9.0  ## OSC_VERSION

--- a/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
@@ -9,4 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: osc-upstream-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.8.1  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.9.0  ## OSC_VERSION


### PR DESCRIPTION
Baremetal CoCo release 0.2.0 is based on OSC 1.9.0

