### PR TITLE
Enable hermetic build for operator

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -27,6 +27,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -96,7 +98,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -24,6 +24,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -93,7 +95,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,6 @@ COPY controllers controllers/
 # See comments in the script itself for more details.
 COPY controller-gen bin/controller-gen-v0.17.2
 
-RUN go mod download
-# needed for docker build but not for local builds
-RUN go mod vendor
-
 RUN make build
 
 # Use OpenShift base image

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ COPY api api/
 COPY config config/
 COPY controllers controllers/
 
+# Copy our controller-gen script to work around hermetic build issues
+# See comments in the script itself for more details.
+COPY controller-gen bin/controller-gen-v0.17.2
+
 RUN go mod download
 # needed for docker build but not for local builds
 RUN go mod vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,16 @@ COPY controllers controllers/
 
 # Copy our controller-gen script to work around hermetic build issues
 # See comments in the script itself for more details.
-COPY controller-gen bin/controller-gen-v0.17.2
+COPY controller-gen bin/
 
-RUN make build
+# get the version of controller-gen in an env variable for reusing
+RUN echo "export CONTROLLER_TOOLS_VERSION=$(grep controller-tools go.mod | awk '{print $2}')" > controller-tools-ver
+
+# rename the script to use the same version as defined in our go.mod file
+RUN . ./controller-tools-ver && mv bin/controller-gen bin/controller-gen-$CONTROLLER_TOOLS_VERSION
+
+# make sure 'make' uses the right version of controller-gen
+RUN . ./controller-tools-ver && make build
 
 # Use OpenShift base image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1741850109

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
-CONTROLLER_TOOLS_VERSION ?= v0.17.2
+CONTROLLER_TOOLS_VERSION ?= v0.17.2 # this is overriden by our Dockerfile for container builds
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.59.1
 

--- a/controller-gen
+++ b/controller-gen
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This is a hack to enable hermetic builds for the operator.
+# Rather than installing controller-gen, we declare it as a dependency in the
+# go.mod file. Cachi2/Hermeto will then get the sources as part of the prefetch
+# phase.
+# Once the sources are in, we can use "go run" to build and run the tool from
+# its sources, without needing access to the network.
+#
+# In order to keep the Makefile untouched (as it is partly generated from
+# operator-sdk), we put this script in the location where the Makefile expect
+# to find controller-gen.
+# Makefile will then NOT install the tool, and just run the script instead.
+
+go run sigs.k8s.io/controller-tools/cmd/controller-gen $@


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
Enable hermetic build for the controller manager.

**- What I did**
gomod dependencies are managed by cachi2/Hermeto, enabling it is pretty simple.
I had to work around the controller-gen problem (again). Taking inspiration from the way we do it in CPaaS, but trying to avoid using different Dockerfile/Makefile for local and CI builds.

I'm adding a new script that `make` will use in place of the regular controller-gen. This script uses "go run" to run the tool.
In the context of a local build, this results in downloading/building the file as usual.
In the context of a hermetic build, with the dependencies pre-fetched, it will build the tool based on the prefetched sources.


**- How to verify it**
For a local build: run `podman build .`
For CI: the Konflux task in this PR must pass.
You can look at the logs too:
- the "prefetch" step must pass and show that go dependencies were fetched
- the "build" step must have the line:
```
Build will be executed with network isolation
```

Fixes: [KATA-3796](https://issues.redhat.com//browse/KATA-3796)
