### PR TITLE
konflux: avoid building the operator when manager.yaml is updated

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -7,7 +7,14 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "devel" && files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) && files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) && files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) && files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "devel" &&
+      files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
+      files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) &&
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      files.all.exists(path, !path.matches('config/manager/*'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -6,7 +6,14 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) && files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) && files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) && files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "devel" &&
+      files.all.exists(path, !path.matches('bundle*|.tekton/*bundle*')) &&
+      files.all.exists(path, !path.matches('must-gather*|.tekton/*must-gather*')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm*|.tekton/*podvm-builder*')) &&
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      files.all.exists(path, !path.matches('config/manager/*'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
We get automated PRs to update the digest of the images in our ClusterServiceVersion and in the manager.yaml file. These PRs are generated when one of the referenced images is updated. Now if modifying those files triggers another build, we can end up in a loop of builds/nudges.
This commit makes sure that that operator is not rebuilt when such PRs are merged.

An example PR where the operator is rebuilt can be seen in #627 