### PR TITLE
podvm: fix umoci checkout on s390x

### DIFF
--- a/config/peerpods/podvm/libvirt-podvm-image-handler.sh
+++ b/config/peerpods/podvm/libvirt-podvm-image-handler.sh
@@ -370,8 +370,9 @@ function install_packages() {
 
     if [ "${ARCH}" == "s390x" ]; then
         # Build umoci from source for s390x as there are no prebuilt binaries
+        UMOCI_VERSION="v0.5.0"
         mkdir -p umoci
-        git clone https://github.com/opencontainers/umoci.git
+        git clone --depth 1 --single-branch https://github.com/opencontainers/umoci.git -b "${UMOCI_VERSION}"
         cd umoci || error_exit "Failed to change directory to umoci"
         make
         cp -pr umoci /usr/local/bin/


### PR DESCRIPTION
Updating umoci to checkout to a version rather than the main branch to fix an issue seen with a latest PR merge on the umoci main branch.

Fixes: https://issues.redhat.com/browse/KATA-3840

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Image pull on s390x is failing because of the latest umoci changes.

In osc image pull job, the umoci version used is the main branch rather than a version here – https://github.com/openshift/sandboxed-containers-operator/blob/devel/config/peerpods/podvm/libvirt-podvm-image-handler.sh#L374

This PR with umoci which merged early today is causing this failures: https://github.com/opencontainers/umoci/pull/572/files


**- What I did**
Checking out to a version, reference of the version taken from upstream -- https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/versions.yaml#L41


**- How to verify it**
Manually verified it and ran a job as well
```
UMOCI_VERSION="v0.4.7"
git clone --depth 1 --single-branch https://github.com/opencontainers/umoci.git -b "${UMOCI_VERSION}"
Cloning into 'umoci'...
remote: Enumerating objects: 1175, done.
remote: Counting objects: 100% (1175/1175), done.
remote: Compressing objects: 100% (968/968), done.
remote: Total 1175 (delta 241), reused 512 (delta 121), pack-reused 0 (from 0)
Receiving objects: 100% (1175/1175), 2.58 MiB | 3.05 MiB/s, done.
Resolving deltas: 100% (241/241), done.
Note: switching to '17f38511d61846e2fb8ec01a1532f3ef5525e71d'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updating umoci to checkout to a version rather than the main branch on s390x
