### PR TITLE
konflux: avoid rebuilding images every time something is changed

### DIFF
--- a/.tekton/osc-must-gather-push.yaml
+++ b/.tekton/osc-must-gather-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && ( "must-gather/***".pathChanged() || ".tekton/osc-must-gather-push.yaml".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-podvm-builder-push.yaml
+++ b/.tekton/osc-podvm-builder-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && ( "config/peerpods/podvm/***".pathChanged() || ".tekton/osc-podvm-builder-push.yaml".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
When a build occurs and one of the images of our operator is rebuilt, the bundle is updated with a PR from Konflux with the nudge mechanism. Merging this PR must NOT trigger rebuilds, otherwise we end up in a loop of build/nudges.
This situation happens with the podvm-builder image.

This commit adds a filter on the "on-push" pipeline to rebuild the podvm-builder image only when some of its own files were modified.

I'm also adding the same rule on the must-gather image, even if it is not part of the operator's CSV file and doesn't cause such a loop - it just doesn't make sense to rebuild it eveytime something changes in the repo.
