### PR TITLE
Update Intel TDX deps for 0.2.0

### DIFF
--- a/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
@@ -88,7 +88,7 @@ spec:
         kubernetes.io/hostname: ${PCCS_NODE}
       initContainers:
        - name: init-seclabel
-         image: quay.io/openshift_sandboxed_containers/init-seclabel:0.2.0
+         image: registry.access.redhat.com/ubi9/ubi:latest
          command: ["sh", "-c", "chcon -Rt container_file_t /var/cache/pccs"]
          volumeMounts:
          - name: host-database

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
@@ -88,7 +88,7 @@ spec:
         kubernetes.io/hostname: ${PCCS_NODE}
       initContainers:
        - name: init-seclabel
-         image: quay.io/openshift_sandboxed_containers/init-seclabel:latest
+         image: quay.io/openshift_sandboxed_containers/init-seclabel:0.2.0
          command: ["sh", "-c", "chcon -Rt container_file_t /var/cache/pccs"]
          volumeMounts:
          - name: host-database
@@ -99,7 +99,7 @@ spec:
            privileged: true  # Required for chcon to work on host files
       containers:
         - name: pccs
-          image: quay.io/openshift_sandboxed_containers/dcap/pccs:1.21
+          image: quay.io/openshift_sandboxed_containers/dcap/pccs:0.2.0
           ports:
             - containerPort: 8042
               name: pccs-port

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tdx-qgs
-          image: quay.io/openshift_sandboxed_containers/dcap/tdx-qgs:1.21
+          image: quay.io/openshift_sandboxed_containers/dcap/tdx-qgs:0.2.0
           workingDir: /opt/intel/tdx-qgs
           securityContext:
             readOnlyRootFilesystem: true

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/registration-ds.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/registration-ds.yaml.in
@@ -36,7 +36,7 @@ spec:
           - name: efivars
             mountPath: /sys/firmware/efi/efivars
         workingDir: "/opt/intel/sgx-pck-id-retrieval-tool/"
-        image: quay.io/openshift_sandboxed_containers/dcap/dcap-registration-flow:latest
+        image: quay.io/openshift_sandboxed_containers/dcap/dcap-registration-flow:0.2.0
         imagePullPolicy: IfNotPresent
         envFrom:
         - secretRef:


### PR DESCRIPTION
Update qgs, pccs, dcap-registration-flow and init-seclabel to use 0.2.0 tag
