### PR TITLE
konflux: operator build triggers

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -10,11 +10,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
-      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      files.all.exists(path, !path.matches('config/manager/.*'))
+      !files.all.exists(path, path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      !files.all.exists(path, path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+      !files.all.exists(path, path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+      !files.all.exists(path, path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      !files.all.exists(path, path.matches('config/manager/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -9,11 +9,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
-      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      files.all.exists(path, !path.matches('config/manager/.*'))
+      !files.all.exists(path, path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      !files.all.exists(path, path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+      !files.all.exists(path, path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+      !files.all.exists(path, path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      !files.all.exists(path, path.matches('config/manager/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
Modify the on-cel-expressions to fix triggering issues.
We need to prevent the operator from building on changes to the bundle, as otherwise we have a loop of builds/updates.
