### PR TITLE
gcp: fixes image deletion

### DIFF
--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -30,6 +30,8 @@ spec:
               value: "" # Set this to the azure image id to delete
             - name: LIBVIRT_IMAGE_ID
               value: "" # Set this to the libvirt image id to delete
+            - name: IMAGE_NAME
+              value: "" # Set this to the gcp image name to delete
           envFrom:
             - secretRef:
                 name: peer-pods-secret

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -318,7 +318,7 @@ func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, er
 			})
 		} else if r.provider == GCPProvider {
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name:  "IMAGE_ID",
+				Name:  "IMAGE_NAME",
 				Value: imageId,
 			})
 		} else if r.provider == LibvirtProvider {


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

When kata config is deleted the leftover image should be deleted. Currently is not working because the expected name is IMAGE_NAME not IMAGE_ID.

Fixes rhjira#[KATA-3787](https://issues.redhat.com//browse/KATA-3787)

**- What I did**

Used the right key "IMAGE_NAME" instead of IMAGE_ID.

**- How to verify it**

1. Deploy the operator + GCP configured
2. Wait for the image job creation to populate the image
3. Delete kataconfig
4. Check for pods osc-podvm-image-deletion-* logs if deletion was complete.

**- Description for the changelog**
GCP: Fixed issue with image leftover when deleting kataconfig
