### PR TITLE
podvm: use pause bundle from payload image

### DIFF
--- a/config/peerpods/podvm/.dockerignore
+++ b/config/peerpods/podvm/.dockerignore
@@ -1,1 +1,0 @@
-bootc/output/

--- a/config/peerpods/podvm/bootc/Containerfile.rhel
+++ b/config/peerpods/podvm/bootc/Containerfile.rhel
@@ -1,15 +1,5 @@
-# build pause
-FROM registry.k8s.io/pause:3.9 as pause-bin
-
-FROM registry.redhat.io/ubi9/ubi-minimal:9.5 as pause
-RUN curl -L https://github.com/opencontainers/umoci/releases/download/v0.4.7/umoci.amd64 -o /usr/bin/umoci && chmod +x /usr/bin/umoci
-RUN umoci init --layout pause && umoci new --image pause:k8s
-RUN umoci config --image pause:k8s --config.entrypoint=/pause --author="OSC"
-RUN umoci unpack --rootless --image pause:k8s /pause
-COPY --from=pause-bin /pause /pause/rootfs/pause
-
 # Get payload
-FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.8.0-6 as payload
+FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.10.0 as payload
 
 # Build bootc rhel podvm
 FROM registry.redhat.io/rhel9/rhel-bootc:9.5-1738698007 as podvm-bootc
@@ -39,13 +29,12 @@ RUN if [[ "${CLOUD_PROVIDER}" == "libvirt" ]]; then \
     dnf install -y cloud-init && dnf clean all; \
 fi
 
-# Copy pause bundle
-COPY --from=pause /pause /pause_bundle
-
-# Extract podvm binaries
+# Extract podvm binaries and pause bundle
 COPY --from=payload /podvm-binaries.tar.gz /podvm-binaries.tar.gz
-RUN tar -xzvf podvm-binaries.tar.gz -C /
-RUN sed -i 's#What=/kata-containers#What=/var/kata-containers#g' /etc/systemd/system/run-kata\\x2dcontainers.mount
+COPY --from=payload /pause-bundle.tar.gz /pause-bundle.tar.gz
+RUN tar -xzvf podvm-binaries.tar.gz -C / && rm /podvm-binaries.tar.gz && \
+    tar -xzvf pause-bundle.tar.gz -C / && rm /pause-bundle.tar.gz && \
+    sed -i 's#What=/kata-containers#What=/var/kata-containers#g' /etc/systemd/system/run-kata\\x2dcontainers.mount
 
 # a workaround to set podvm-bootc as default target
 FROM podvm-bootc as default-target


### PR DESCRIPTION
As pause bundle is now included in the payload image as pause-bundle.tar.xz also rename the function to better reflect its current behavior of just extracting the bundle from the payload.

This change depend on https://github.com/openshift/cloud-api-adaptor/pull/59 and need to be tested together 