### PR TITLE
konflux: fix build triggers for the operator

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -10,11 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      files.all.exists(path, !path.matches('config/manager/.*'))
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -10,11 +10,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "devel" &&
-      !files.all.exists(path, path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
-      !files.all.exists(path, path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      !files.all.exists(path, path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      !files.all.exists(path, path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      !files.all.exists(path, path.matches('config/manager/.*'))
+      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      files.all.exists(path, !path.matches('config/manager/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -9,11 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      files.all.exists(path, !path.matches('config/manager/.*'))
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -9,11 +9,11 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "devel" &&
-      !files.all.exists(path, path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
-      !files.all.exists(path, path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      !files.all.exists(path, path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      !files.all.exists(path, path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
-      !files.all.exists(path, path.matches('config/manager/.*'))
+      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$')) &&
+      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*')) &&
+      files.all.exists(path, !path.matches('config/manager/.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
- reverts commit f7b50dfbe70cb3b519458a8cbb0dd4f01a46b6b1.
  This change seems to block any build of the operator. We have to rethink it.
- Modify the filters so that all files modified as part of a bundle update are checked in the same "matches" command.

I think this is why we are still triggering the build of the operator on bundle updates:
When we get a PR for updating the bundle, both the CSV and manager.yaml gets modified.
The first filter (on bundle/.*) will return true because it doesn't match the config/manager/manager.yaml file.
The last filter (on config/manager/.*) will also return true, because it doesn't match the CSV file modification (under bundle/manifest/.*).
The result is that the operator build is triggered.

If I want the operator to skip building when the bundle is updated, I need both filters to be in the same "matches" command.
