### PR TITLE
baremetal-coco: bump intel device plugin operator to 0.32.1 release

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -335,6 +335,7 @@ function deploy_intel_device_plugins() {
     pushd intel-dpo || return 1
     oc apply -f install_operator.yaml || return 1
     wait_for_deployment inteldeviceplugins-controller-manager openshift-operators || return 1
+    wait_for_service_ep_ip intel-deviceplugins-controller-manager-service openshift-operators || return 1
     oc apply -f sgx_device_plugin.yaml || return 1
     popd || return 1
 

--- a/scripts/install-helpers/baremetal-coco/intel-dpo/install_operator.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dpo/install_operator.yaml
@@ -20,4 +20,4 @@ spec:
   name: intel-device-plugins-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: intel-device-plugins-operator.v0.29.1
+  startingCSV: intel-device-plugins-operator.v0.32.1

--- a/scripts/install-helpers/baremetal-coco/intel-dpo/sgx_device_plugin.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dpo/sgx_device_plugin.yaml
@@ -6,7 +6,7 @@ kind: SgxDevicePlugin
 metadata:
   name: sgxdeviceplugin-sample
 spec:
-  image: registry.connect.redhat.com/intel/intel-sgx-plugin@sha256:e54cdf61feb0b67e330ad24d92e7fa4000953c2ec4d4300d052e032d419d5e0a
+  image: registry.connect.redhat.com/intel/intel-sgx-plugin@sha256:f2c77521c6dae6b4db1896a5784ba8b06a5ebb2a01684184fc90143cfcca7bf4
   enclaveLimit: 110
   provisionLimit: 110
   logLevel: 4


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
v0.32.1 is the latest update tested against OCP 4.18. Move to use it.

**- What I did**

**- How to verify it**

**- Description for the changelog**
Update intel-device-plugin-operator to v0.32.1