### PR TITLE
konflux: update CSV references to match the latest snapshot

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -389,7 +389,7 @@ spec:
                 - name: RELATED_IMAGE_PODVM_BUILDER
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:d635d2e688982986f6942b19948e0a874b093957045335c1009f0765aa9bd42e
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:0b6e261b2dfb58ea1fc63682d893a73e1e68456509caa601d3f422e310ab856d
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:cacdcb85e4f421b394765fd4632e6accf53ab6dcf78afd285a1a56bc863dc714
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -544,7 +544,7 @@ spec:
     name: peerpods-webhook
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:d635d2e688982986f6942b19948e0a874b093957045335c1009f0765aa9bd42e
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:0b6e261b2dfb58ea1fc63682d893a73e1e68456509caa601d3f422e310ab856d
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:cacdcb85e4f421b394765fd4632e6accf53ab6dcf78afd285a1a56bc863dc714
     name: podvm-payload
   replaces: sandboxed-containers-operator.v1.8.1
   version: 1.9.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -86,7 +86,7 @@ spec:
             - name: RELATED_IMAGE_PODVM_BUILDER
               value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:d635d2e688982986f6942b19948e0a874b093957045335c1009f0765aa9bd42e
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:0b6e261b2dfb58ea1fc63682d893a73e1e68456509caa601d3f422e310ab856d
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:cacdcb85e4f421b394765fd4632e6accf53ab6dcf78afd285a1a56bc863dc714
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Since we didn't get bundle updates through nudges in konflux in a while, there is a mismatch between the reference we have in the CSV and the image used in the latest build (snapshot) of Konflux.

Because of that, the image is not reachable and we get a failure for the release process.

Rather that waiting for the next push to podvm-payload to get a nudge, I'm fixing it by copying the SHA that I can see in the latest release snapshot that raised a failure for podvm-payload.
