### PR TITLE
tests: add mirrors for konflux images

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,61 @@
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: osc-registry
+spec:
+  imageTagMirrors:
+    - mirrors:
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
+    - mirrors:
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: osc-registry
+spec:
+  imageDigestMirrors:
+    - mirrors:
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
+    - mirrors:
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle


### PR DESCRIPTION
Konflux images are located in quay.io/redhat-user-workloads/ose-osc-tenant/[...] but our bundle references images from registry.redhat.io.

To be able to test our bundle with unreleased images, we need to set some mirrors in the test cluster to check the images from quay instead of registry.redhat.io.

This yaml provides the required mirrors, and needs to be applied to the test cluster.
