### PR TITLE
konflux: Make description of entries more readable

### DIFF
--- a/.tekton/osc-must-gather-pull-request.yaml
+++ b/.tekton/osc-must-gather-pull-request.yaml
@@ -62,69 +62,69 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
-    - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
+    - description: Whether to enable privileged mode, should be used only with remote
         VMs
+      default: "false"
       name: privileged-nested
       type: string
-    - default:
+    - description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      default:
       - linux/x86_64
       - linux/s390x
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:

--- a/.tekton/osc-must-gather-push.yaml
+++ b/.tekton/osc-must-gather-push.yaml
@@ -59,69 +59,70 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
-    - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
+    - description: Whether to enable privileged mode, should be used only with remote
         VMs
+      default: "false"
       name: privileged-nested
       type: string
-    - default:
+    - description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      default:
       - linux/x86_64
       - linux/s390x
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      default:
       name: build-platforms
       type: array
     results:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -75,57 +75,57 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "false"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "false"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
     results:

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -72,57 +72,57 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "false"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "false"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
     results:

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -64,69 +64,69 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
-    - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
+    - description: Whether to enable privileged mode, should be used only with remote
         VMs
+      default: "false"
       name: privileged-nested
       type: string
-    - default:
+    - description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      default:
       - linux/x86_64
       - linux/s390x
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -61,69 +61,69 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
-    - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
+    - description: Whether to enable privileged mode, should be used only with remote
         VMs
+      default: "false"
       name: privileged-nested
       type: string
-    - default:
+    - description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      default:
       - linux/x86_64
       - linux/s390x
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:

--- a/.tekton/osc-podvm-builder-pull-request.yaml
+++ b/.tekton/osc-podvm-builder-pull-request.yaml
@@ -64,57 +64,57 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
     - default: "false"

--- a/.tekton/osc-podvm-builder-push.yaml
+++ b/.tekton/osc-podvm-builder-push.yaml
@@ -61,57 +61,57 @@ spec:
     - description: Source Repository URL
       name: git-url
       type: string
-    - default: ""
-      description: Revision of the Source Repository
+    - description: Revision of the Source Repository
+      default: ""
       name: revision
       type: string
     - description: Fully Qualified Output Image
       name: output-image
       type: string
-    - default: .
-      description: Path to the source code of an application's component from where
+    - description: Path to the source code of an application's component from where
         to build image.
+      default: .
       name: path-context
       type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
+    - description: Path to the Dockerfile inside the context specified by parameter
         path-context
+      default: Dockerfile
       name: dockerfile
       type: string
-    - default: "false"
-      description: Force rebuild image
+    - description: Force rebuild image
+      default: "false"
       name: rebuild
       type: string
-    - default: "false"
-      description: Skip checks against built image
+    - description: Skip checks against built image
+      default: "false"
       name: skip-checks
       type: string
-    - default: "true"
-      description: Execute the build with network isolation
+    - description: Execute the build with network isolation
+      default: "true"
       name: hermetic
       type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched by Cachi2
+      default: ""
       name: prefetch-input
       type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
+    - description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
+      default: ""
       name: image-expires-after
-    - default: "true"
-      description: Build a source image.
+    - description: Build a source image.
+      default: "true"
       name: build-source-image
       type: string
-    - default: "true"
-      description: Add built image into an OCI image index
+    - description: Add built image into an OCI image index
+      default: "true"
       name: build-image-index
       type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+    - description: Array of --build-arg values ("arg=value" strings) for buildah
+      default: []
       name: build-args
       type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    - description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      default: ""
       name: build-args-file
       type: string
     - default: "false"


### PR DESCRIPTION
Some of the entries were beginning with `- default`. This is confusing during code review [1], where you tend to read that as belonging to the previous item instead of the current one. Move `default` after description, which puts description right after `-` to avoid that problem.

[1]: https://github.com/openshift/sandboxed-containers-operator/pull/678#discussion_r2132139897