### PR TITLE
podvm-builder: fix the location of cloud-api-adaptor sources

### DIFF
--- a/config/peerpods/podvm/Dockerfile.podvm-builder
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder
@@ -47,7 +47,7 @@ RUN if [[ -n "$CERT_RPM" ]] ; then \
     fi
 
 
-COPY cloud-api-adaptor /src/
+COPY cloud-api-adaptor /src/cloud-api-adaptor
 
 ADD podvm-builder.sh /podvm-builder.sh
 


### PR DESCRIPTION
The COPY operation is putting the sources directly under /src. We want it to create a subfolder instead.
