### PR TITLE
Make a test catalog

### DIFF
--- a/.tekton/osc-fbc-test-fbc-pull-request.yaml
+++ b/.tekton/osc-fbc-test-fbc-pull-request.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/sandboxed-containers-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "pull_request" &&
+      target_branch == "devel" &&
+      files.all.exists(path, path.matches('.tekton/fbc-pipeline.yaml$|.tekton/osc-fbc-test-fbc-.*.yaml$|fbc/test-fbc/Dockerfile$|fbc/test-fbc/.*/catalog.json$'))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: osc-fbc-test-fbc
+    appstudio.openshift.io/component: osc-fbc-test-fbc
+    pipelines.appstudio.openshift.io/type: build
+  name: osc-fbc-test-fbc-on-pull-request
+  namespace: ose-osc-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-fbc-test-fbc:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/s390x
+  - name: path-context
+    value: fbc/test-fbc
+  - name: dockerfile
+    value: fbc/test-fbc/Dockerfile
+  pipelineRef:
+    params:
+    - name: name
+      value: fbc-builder
+    - name: bundle
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:devel@sha256:0bd24df76558d712c30ff5f702e09423923432a228c5a68d5edfe7f49c75dc9b
+    - name: kind
+      value: pipeline
+    resolver: bundles
+  taskRunTemplate: {}
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/osc-fbc-test-fbc-push.yaml
+++ b/.tekton/osc-fbc-test-fbc-push.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/sandboxed-containers-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression:
+      event == "push" &&
+      target_branch == "devel" &&
+      files.all.exists(path, path.matches('.tekton/fbc-pipeline.yaml$|.tekton/osc-fbc-test-fbc-.*.yaml$|fbc/test-fbc/Dockerfile$|fbc/test-fbc/.*/catalog.json$'))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: osc-fbc-test-fbc
+    appstudio.openshift.io/component: osc-fbc-test-fbc
+    pipelines.appstudio.openshift.io/type: build
+  name: osc-fbc-test-fbc-on-push
+  namespace: ose-osc-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-fbc-test-fbc:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/s390x
+  - name: path-context
+    value: fbc/test-fbc
+  - name: dockerfile
+    value: fbc/test-fbc/Dockerfile
+  pipelineRef:
+    params:
+    - name: name
+      value: fbc-builder
+    - name: bundle
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:devel@sha256:0bd24df76558d712c30ff5f702e09423923432a228c5a68d5edfe7f49c75dc9b
+    - name: kind
+      value: pipeline
+    resolver: bundles
+  taskRunTemplate: {}
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/fbc/render.sh
+++ b/fbc/render.sh
@@ -32,11 +32,13 @@ do
     yq -i ".entries[0].icon.base64data = \"$(cat ../$ICON_BASE64)\"" "$TEMPLATE_NAME"
 
     # enable migrate params for OCP 4.17 and onwards
-    OCP_VERSION_NUMERAL=$(echo $OCP_VERSION | grep -o -E '[0-9.]+')
-    if [ "`echo "${OCP_VERSION_NUMERAL} > 4.16" | bc`" -eq 1 ]; then
-        MIGRATE_PARAM="--migrate-level bundle-object-to-csv-metadata"
-    else
-        MIGRATE_PARAM=""
+    # skip the check for test-fbc, assuming it is always using the latest version
+    MIGRATE_PARAM="--migrate-level bundle-object-to-csv-metadata"
+    if [ "$OCP_VERSION" != "test-fbc" ]; then
+        OCP_VERSION_NUMERAL=$(echo $OCP_VERSION | grep -o -E '[0-9.]+')
+        if [ "`echo "${OCP_VERSION_NUMERAL} < 4.17" | bc`" -eq 1 ]; then
+            MIGRATE_PARAM=""
+        fi
     fi
 
     # Render that template. It's what we're here for.

--- a/fbc/test-fbc/Dockerfile
+++ b/fbc/test-fbc/Dockerfile
@@ -1,0 +1,22 @@
+# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19 as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD catalog/ /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/fbc/test-fbc/Dockerfile
+++ b/fbc/test-fbc/Dockerfile
@@ -1,9 +1,17 @@
 # The builder image is expected to contain
 # /bin/opm (with serve subcommand)
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19 as builder
+USER root
+
+WORKDIR /workdir
+ADD render.sh icon.png ./
+COPY test-fbc ./test-fbc
+
+RUN dnf install -y go && go install github.com/mikefarah/yq/v4@v4.35.1
+RUN PATH=/root/go/bin:$PATH ./render.sh test-fbc
 
 # Copy FBC root into image at /configs and pre-populate serve cache
-ADD catalog/ /configs
+RUN cp -r test-fbc/catalog/ /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19

--- a/fbc/test-fbc/catalog-template.yaml
+++ b/fbc/test-fbc/catalog-template.yaml
@@ -1,0 +1,18 @@
+---
+entries:
+  - defaultChannel: stable
+    icon:
+      base64data: ""
+      mediatype: image/png
+    name: sandboxed-containers-operator
+    schema: olm.package
+  - entries:
+      - name: sandboxed-containers-operator.v1.10.0
+        replaces: sandboxed-containers-operator.v1.9.0
+        skipRange: '>=1.1.0 <1.10.0'
+    name: stable
+    package: sandboxed-containers-operator
+    schema: olm.channel
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:23eb79b96ef69c351b5bcb81bae0524e87aa964047759fbfe92d57b59d90cee2
+    schema: olm.bundle
+schema: olm.template.basic

--- a/fbc/test-fbc/catalog/sandboxed-containers-operator/catalog.json
+++ b/fbc/test-fbc/catalog/sandboxed-containers-operator/catalog.json
@@ -1,0 +1,170 @@
+{
+    "schema": "olm.package",
+    "name": "sandboxed-containers-operator",
+    "defaultChannel": "stable",
+    "icon": {
+        "base64data": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAgAElEQVR4nO3dX2xVZb7/8VWtoKC0xMQfP9BfC0NoSEbbymQycYSWGx1vaHE05hhMS9RELoQyZCInMaEkJoOZGIpeMBeattF4MtGRXW4cvaGFGTOZDLbgJKSGI+1ROBwTQ8scEATtL59lF7MH27LXs55n/X2/kh3mT3e79trw2U+/z3d9V9XU1JQHAMi/m3iPAaAYCHwAKAgCHwAKgsAHgIIg8AGgIAh8ACgIAh8ACoLAB4CCIPABoCCqeaPd2Llz54MXL178yblz51ouX768+OzZsw0XLly4VT/s448/rs3hSwZCuf/++yf09QsXLry0ZMmS0fnz559bvHjx0IIFC/62Z8+eP3E27WO0ggVbt27tUrB/+eWX946Pjy8dHR29LfMvCkhYQ0PD13V1dWdqamq+WLJkSenVV1/t4T2JhsAP6cUXX6z76quvnjtz5swvRkdHGwh3ID76EGhoaBhdunTpH++8887fvfTSS+Oc/soR+BXYsWPHE59//vmW48eP/5SAB9JDHwD33XffX++55579r7zyyu95a+ZG4M9CIX/y5MmdR48e/fHp06fZ6wBSbtmyZVfXrFnz95UrV+4h/GdG4JfRRutnn3320kcfffRzQh7ILoX/Aw888OcVK1a8yAbwPxH4nuc9/fTTr4+MjPyS7hkgf9QN1NTU9Ic33njjmaK/vYUNfG2+fvrpp/2s5oFiCFb9q1at6ijqZm/hAl9lmxMnTrw2ODjYeP78+aoUHBKAGC1atGiqtbX12OrVq58vWrmnMIGvoB8eHu778MMPf5SCwwGQAg899NB/Njc3dxYl+HMf+EHp5p133mlJweEASKHHH398qBClHgV+Xh+bNm06sGjRou/0Mnnw4MFjroeyQpmR50zM5Qpfow7ee++936Z1M7ampsZramqa8f9rbW2N/XgAVwYHB2f8ziMjI97k5GQqz7s2dx999NFf53GUQ64CX+Wbw4cP/+XIkSNLkj6WxsZGr76+3g92PWpra6/9CeB7ExMTfvgHf+oxNjbmHTt2LPEztHbt2rPr1q37WZ7KPLkJ/KeeeurAwYMH25LovKmrq/NX5kG4s0oHotNvB8GHgP7z+Hj8uauOng0bNgy8+eabG/PwlmY+8LWqf//990fivmiqra3ND/b29nZ/JQ/ALa38S6WSH/4DAwOxnm1dvPXII480ZX21n+nA37Jly2/efvvtF+JY1avurnAPHgCSpfAPHnHsB2i1/+STT768f//+f8/qW5/JwNeq/pNPPikdPHhw5p1Pi7SSV8B3dnbG+RIBhNDX1+cHfxwr/w0bNozce++97Vlc7Wcu8HUBValU+tDlmGKt5ru6uvyQp1wDZIfKPgr/np4ep6t+jWVub29/KHMXbGWph/S55577jcu++rq6uqne3t4pANmnf8v6N+0qL5RFyqQsZWhmDlQXRLh641paWqYOHDjAP3Egh/RvW//GXeVHli7WykRJ5+GHHz7pYgaO2in16x9tlED+qbtHZVoX7Z2ayfPBBx+sTPtJvCkFxzArbc6uWbPmnO2wV42+t7fXr/cR9kAx6N+6/s3r374ywCZllLJKmZXmk5naFb5O3LvvvnvC9ubsrl27/A1ZrngFiktX9mpjd/fu3VbPgTZzH3vssdVp7eBJZeC76MRpaWnx3+DZZtgAKB5dxasF4NDQkLXXnuoOnrRtKvzqV796wmYnTk1NzdTevXvZiwMwK2WEssJmB4+yjE3bOezYseOJ119//T9sXTmrAWa6GINeegA3ovq+LrK0NbhNV+Y+88wz//bKK6/8Pi0nPzWbtirj2Ax71er16xphD6ASygplhrLDBmWZMk3ZlpY3IBUrfJsbtNp916qe7hsAptTCqdW+jat107SRm3jg2wx7lXD0RtGBAyAqdfJo4WijxJOW0E+8pKPRxjbCvqOjw/91jLAHYIOyRJmibIlKGaesS/qNSTTwdQWtjTn2qrnpilkAsE3ZYqOur6xT5iX5BiUW+LpDlY0raHXVXHd3t52DAoAZKGOUNVEp85R9SZ3jRAJfNy556623It1FJBiPwJx6AHFQ1tgYy6DsUwYm8abFvmmrFqX9+/cfjtJ+qROuzVmumgUQN9X1tZkbpYNHPfpbtmxZF/fVuLGu8NWRo5EJhD2ArFL2KIOirPSVgcrCuIetxRr4ui1hlI4cwh5AGtgIfWWhMjHOlxNb4KtmFfUetAw/A5AWyiJlUhTKxDjr+bEEvn5tefvtt1+I8j3YoAWQNsFGbhTKxrhKO7EEvi44iFK3Vw8sYQ8gjZRNUfr0lY1xXZTlPPDVcxrl4ipd5UafPYA0U0ZFuSJXGRlHf77Ttkz9mvLaa6+dMl3dazaOWqAAIAtU1zedvaNWzeeff365y3k7Tlf4hw8f/otp2AcdOQCQFVE6d5SVykyXL9VZ4G/durXryJEjS0yfrxHHDEIDkCXKLGWXKWWmstPVS3YW+O+9995vTZ+rDRDm2QPIImVXlE3cKNl5I04CX5sPp0+frjZ5rur2bNICyDJlmLLMhLLT1Qau9cDXRu3BgwfbTJ4b3K0KALJOWWZaz1eGuujNtx74n376ab/pRq0+FbkHLYA8UJaZViuUocpS26fBalumJmG+/PLLR0ye29LSQlcOgNxRTX9oaMjoZb3wwgtrbU7UtLrCHx4eNr7tVNSZFACQRlGyLUqmzsRa4Gt1b3oHK+1oMxQNQB4p20y7dpSpylZbp8Va4J84ceI1k+dpU6Ory1nbKQAkThlnuoFrmq0zsRL42k0eHBw06kHSrztcYAUgz5RxpqUdZautjh0rgW/amVNXV8cUTACFoKxT5oVls2PHSuB/9NFHPzd5Xl+f1f0IAEg108wzzdjrRQ78p59++nWTq2rVhsn4BABFosxT9oWljFXWRj1VkQN/ZGTklybPY6MWQBGZZp9p1paLFPhqFzK5uYnqWO3t7VF+NABkkrLPpJavrI3aohkp8D/77LOXTJ7HcDQARWaagaaZG4g0WuHuu+++ErZ+r17UiYkJ458JAHmgVs3JyclQr2TZsmVXv/jii1tMX77xCn/Hjh1PmGzWUrsHALMsVOYqe01Pn3Hgnzx5cqfJ8+i7BwDzLDTNXi9K4B89evTHYZ/T1tbG+GMAmB6frEwMyyR7A0aBb1rOoTMHAP7JJBOjlHWMAv/zzz/fEvY52qylnAMA/6RMNBmqZpLBnmngHz9+/Kdhn8PqHgB+yCQbTTLYMwl8TW0bHR29LezzCHwA+CGTbFQGm0zQDB34X3311XNhn+MR+AAwI9NsNMni0IF/5syZX4R9jslONAAUhUlGmmRx6MAfHR1tCPscpmICwOxMMtIki0OPVqiqqgo9i+HUqVP03wPALMbGxrzly5eHPj1TU1OhbjwVaoW/devW0NcCayocYQ8As1NGmkzQDJvJoQL/7NmzoXcXKOcAwI2ZZOW5c+dC3U0lVOBPTk7eHfaAmpqawj4FAArHJCu//PLLe8N8fajAHx8fXxr2gAh8ALgxk6wMm8mhNm1NNmyjzNsHgCKpqgq1BxtkbMVPqniFb3JrrcbGxrBPAYDCMsnMMNlcceBfvHjxJ2EPhO4cAKicSWaGyeaKAz/sbrBH/R4AQjHJzDDZXHHgX758eXEcBw8ARWWSmWGyueLAP3v2bOjLeHWTXgCAu8wMk80VB/6FCxduDXsgrPABoHImmRkmm43vaVsJVvgAUDnXmVlxH37YHnzdtmtiYsL0uApncHCw6KcAM2A0SfEo9CcnJ0O97kp78UPfiLxSlHMqUyqVvK6uLl0xl4XDRcw0UKunp4cbCBWIsnNoaMjJC3Za0sHcdAPjjRs3EvaYlf5u6O+I/q4AURH4CdHKvr+/v5CvHeHp74r+zgBREPgJURkHCIO/M4iKwE+ANmgp4yAs/Z1hcx9RVBT4JoPTaMkEgHSpKPD37Nnzp7BHTZcOAITnMjsp6QBAirisjhD4AFAQBD4AFASBDwAFQeADQEE4m6UDu/bu3UvnU86MjIx427dvL/ppQIwI/IxQ2DM5EUAUlHQAoCAIfAAoCAIfAAqCwAeAgiDwAaAgCHwAKAgCHwAKgsAHgIIg8AGgIAh8ACgIAh8ACoLAB4CCIPABoCAIfAAoCAIfAAqCwAeAgiDwAaAgCHwAKAgCHwAKgsAHgIIg8AGgIAh8ACgIAh8ACoLAB4CCIPABoCAIfAAoCAIfAAqCwAeAgiDwAaAgCHwAKAgCHwAKgsAHgIIg8AGgIAh8ACgIAh8ACqKaNxpIxm0nT3oPhvzJeo7X2so7BiMEPuDItyMj3ndjY97V6T+vPcbH/R+4yvO8g2F/9LPPeueefdb/jzfV1Xk31ddfe1Q3Nfl/3tzUxFuKGRH4gAUK96uDg3646z9/e+yY89OqDw7/w2No6Af/382NjX7w39La6v/JhwA8Ah8wo5X6lVLJu6KQHxz0piYnU3Um9YGjxzf9/f5/r6qp8apbW/0PgFva2/3fBFA8BD5QIQX7Nwr5UulaWSYr9IF0ZWDAf3jbt/vlIAX//M5OVv8FQuADc1B55nJfn/dNX1/qVvFR6APr8r59/oPwLw7aMoHrTE1MeJd7erzJ+nrvfHOzH4p5CvvrBeGv16rXrNeuc4D8IfCBaSrZXOjs9CYWL/Yubt+eubKNDXrNeu06BzoXOifIDwIfhadyzT9aW71/rF9/bZMTnn8udE50bnSOkH0EPgpLIaYSxoXNm72rM7Q24ns6NzpHOlcEf7YR+Cic8qAvYtnGlM4VwZ9tBD4KQ/VolScI+miC4Ne5pMafLQQ+ck8XSWkDUvVoSjf26FzqnP5ve7t/jpF+9OEj19Ri+HV3d6raKoMZOFJ93SC0/zl71rt06dK1/1533RWxwYq6fCZP0nQx1/nBQW9+V5d3W3d3Ko4JMyPwkUu6YEqr+jhm2swmmGejcNdIg2DI2VzCDjzQ61TPvEY86EMgrjk+19MH6qXdu/2rkBf29XEBV0oR+MgdregVPnGrbmm5Nq/m+pW7K0Gwlv88fQAo+IM5P3GWsfRhowu4bt21i9V+ChH4yA2tcFVPjmuFq4FkGkkwr73dD9yq2tpUnEodR3XZh44+AMrnAMVR3mK1n05s2iIX1CZ4vqnJedgr5Od1dHi3Hzjg1U5M+IGm0E9L2M9Ex6Zj1LHqmHXseg16LS7pveCirXQh8JFpWr2qVq82QZcrV5VrFvb2/kvIZ1V5+Os16bW5ovdE743eI+bzJI/AR2aphOOvIB2NQwhW8zWnTnl3DA568zo7c/eXRa9Jr02v0eWq3x/T0Nrq7y0gOQQ+MknB4aqEo9DTpmPN2Ji/Ei7CzUL0GvVa9Zr12l0Ef1Di4WKt5BD4yBy/Xt/cbL2EUx706jBJc13eFb1mvXZXwa/3zB9SR10/EQQ+MkUXUqkmbNv8bdsKHfTXKw9+nRvb9B5e7OpK0SsuBgIfmaGNP81qt0kblqpfL+jpIehnoHOic6NzZHtzVzdduZDDfZE0I/CRCQoGm5uzGm+g9kRtWHJD7xvTOdK50jnTubNF7ymhHx8CH6lnO+xVolg0MpLp1sqk6Jzp3Nks8xD68SHwkWo2w14bkHccOkT5JqKgzKNzaWu1T+jHg8BHatkM+1va2vwNyLhm3BSBzqX/m1Jbm5VXS+i7R+AjlWyG/YK9e73bSyVW9Q7onOrc6hzbQOi7ReAjddR6aSPsVcJZNDzsz2mHWzrHOtc2+vb13tOy6QaBj1TRBTk2Wi81i17lBiY1xkfnWmUznfuo1LKpaZuwi8BHavg3LbFwUZVqyrRbJkMlHn/uUEdH5J/PKt8+Ah+pEAxCi8ofXUy9PlE695rLEzX0dQtHhq3ZReAjcRqbqxuXRJ2No4BZyIyW1NB7oXk8URD4dhH4SJx+dY869ZKwTyfN49HMfaQDgY9EaZM2akcOYZ9umrlvGvrsw9hF4CMxqttH3Zgj7LNBoR+2vKMWTy6Us4vAR2Ki1u0J+2xReSfMRi7XT9hH4CMRX3d3R6rbq/WSsM+eSrt39DX6gIBdBD5ip86LS7t3G/9YXdhD2GdX0L0z01W5wV3HeH/dqM7ji0K6RZmVokDIc5/9YNn9Xmtra72mnF4prNX7rV1d/v1tr063XlY3Nfk1e66hcIfAR6w0JydKKSevV9D29PT4j/Hx8X/53+vq6rzu7m6vM4cDxRTsmq/PfQniQ0kHsVFXztcR6rKayJi32Tha0dfX13vbt2//QdiL/rfNmzd7ra2t/7L6B0wQ+IiNwt60K0ebtHnq2hgbG/Pa29u99evXzxj01xsaGvK/Vit9PRcwQeAjFqrVml5gpbp9XjbxJiYm/BLN8uXLvYGBgdDP7+/v9+v63XSwwACBj1hEKeXkZZO2r6/PL9/sjtChJJOTk/730PcqMUIYIRD4cE7jE64ODRn9GN0sO+tXW6r2rlW5avGTEQfElVMpaOPGjX59f4QhY6gAgQ/nTFf3ukF2li++Ua1dNXfV3o9FHA43F9X3m5ub/Z+lkhEwGwIfTml1/10Fm5IzWdDTk8lSTlCn16q+39J9eSuhn6Uyj9o7gZkQ+HDKdHVf3dKSyf5s1dQV9Kqx2yzfVEo/Uy2eCn7aOHE9Ah/ORFndZ60rRzV01dJVU6+kzdI1HYNKSTom2jgRIPDhzGXD0NZGbVauplX5RrVz1dCHDDemXdIxqQVUJSbq+yDw4YQ/I8UgANVzn5WNWoWoSidx1ulNBW2cfQwlKzQCH04Yr+67ulK/URuMQ0iqTm9Kx6rWUO0xUN8vJgIf1umm5CZX1fqjcVM8PkG1cNXEKx2HYKqtrc1raWlx9v3VIqrXoNEO1PeLhcCHdd/kbHWv2ndXV5dfC3dZp29sbPQOHTrkd/poBX7gwAF/WqYrGu0QjGmgvl8MBD6su2TQB57W1X0wDmHfvn3OfkZNTY3X29t7rdMnEKzAd+3a5X+NC8GYBgU/9f38I/Bhle5mZdKKqZ77NK3uXY1DuN62bduuXZE7G63A9TUdIe4HG1b5GGbGNOQXgQ+rTDdr09KZUz622OU4BNXoT5065V8VW1vBB52+Rivw4eFhp/V9xjTkG4EPq0zq97qqNum++6hjiyulmrzq9EGnT1hBh41KQC7r+8GYBsYw5wuBD2vUe29yg5P5Cd++TyvnYByCK6rB792791qnT1Ragav0Ekd9nzHM+UHgw5pvDEJBm7XzEgr8YJNUtWuXbZaqvSvouyxvSqvMoxW4Xofr+n4whpk2zmwj8GHNFYPAT2pAmlasCjCXbZaqtavmrt8gKqnTmwquoFWpSK2druhc6TchNnWzi8CHFbpBuUl3zrwEAj/oinHVfaPaunrog06fuAQdNqrvuyzz6OewoZtNBD6sMFndq5yTxApfZRAXYa+QVU1dodue4Gjn4EbnOhYXdO6YuZ9NBD6suGIwmyXJco5tqqEr6PVh4rJ8U6mgvq/WTxdtnGziZhOBDyuuGgR+EuUcb3qFaovCVLXz4IrctAluhKJjtNnG6fIaBbhD4CMyXV1r0o6Z5ZuTB+MQFKY22ixdCzps1Brqqr6P9CPwEZnJ6l4XW2XxfrWi2viNxiGklVpDdewa6YDiIfAR2VWDNr0sru41tlg18bTU6U3p2LXp6npMA9KHwEdk3xoE/i0ZCvxgHII2KtNYpzcVjGlQCyllnmIg8BHZtwYbeFla4Svks1CnN6UW0jivF0ByCHxEYrK6v9nh1aAAZkfgI5LvDGar3MxqEkgEgY9ITDZskx6FDBQVgY9ITFb4WdqwBfKEwEckJoHPCh9IBoGPSAh8IDsIfEQSdiTyTQ5vywdgbgQ+YsXqHkhONec+G9J4l6HbTp70VqXgOABUhsDPiO3bt6fuQB/0PO9gyOdkeUImkHWUdACgIAh8ACgIAh8ACoLAR6zGDfr2AdhB4CNW395+OyccSAiBD2P/j1MHZAqBD2P/ZfDEhVevcsKBhBD4CdDdk+oKOmLg/yxZkoKjAIqJwE+IbiINAHEi8BOi+4h2dHQU8rUDSAaBn6C+vj7vwIEDhS3vAIgXs3QSppW+HhqONjExkalj1/A079lnQz3n6uCgs+MBMDcCPyWasnhj79ZW71zIwAeQHEo6iJXJHbIA2EHgI5KbGxtDPT3sHbIA2EPgI5Kq2trQT/82hTdzAYqAwEckJrcsnMrY5jSQFwQ+IjEJ/Ct06gCJIPARSbVBdxElHSAZBD4iMVnhE/hAMgh8RHKzwQpfnTrU8YH4EfiIrLqlJfS3yNIVt2NjY95gjvcdSqWSf6U38o/AR2Qmq/yrGQqY8fFxb/369f4IjLEcXTimkNeo7o0bN3qTk5MpOCK4RuAjMpON2yulUuZO/MDAgLd8+XKvu7s7c3OPyunYu7q6vObmZm9oaCg9BwbnCHxEZrLC//bYsczW8Xfv3u3V19f7006zRvdh0LHv27cvc8eO6Ah8RKbAr6qpCf1tsrjKD6gEsnnzZr8kkoX6vo5RQb99+3bKNwVG4MOK6tbW0N8mqQuwagw+nGajkojq+52dnams7+uY9KGkYxy3OMeoMeQMJaQDgQ8r5rW3h/42Sa3w2w2O9Ub6+/v9Eddpqe/rGHQs2nNwUad3cQ7hHoEPK0xW+FOTk4mEvoLQ5io/oFKJ6vsK/lKC5SrtLah8o2NxQedOm77IHgIfVuiK27CjkuWbBIIx2HB1EfredBunWh1VSomzv111en3YaG/BVZ1e50w/p9ZgSiqSR+DDGqM6fqmUSLeOShIKrhaDi8YqpVKKWh9V33dZ5lGdXj9Ddfpjx445+zk6V/oAy+Td2eAj8GHN/M7O0N8qqbKON31bSYV+b2+v0xvJq76v3yrUEmlTUKfX69DPcEXnRjfbDzp9kF0EPqxRe+ZNBsF5OeF+dq2OtXLdtWuXs5+hEotaIhWYNto4VZJS0KtO77J8o3Oi3yDYpM0HAh9W3WIQDFeHhhKfoKmatFbLp06d8tra2pz9nGBMg+r7Jm2cwTgE1elttller6Ojwz8+nRPkB4EPq0zKOnLJcrnDlFbg6rA5dOiQ015z1ffVMqlul0rq+/oa/SbiehyC6vTDw8P+bxBszOYPgQ+rVNYx6tbp7/e+S9GFS0GHjer7rrp5RCMObjSmQatsfY3rOr1ea9Dpg3wi8GGd6So/6Vr+TIIraLdt2+bsZwRjGoJN5IB+0wj66V3X6fXh1mn4viE7CHxYN8808Ht6UjlQTaUNddiovu+yjVMtlcEY5mBsscs6vfYqFPT6DYLyTTEQ+LCuqrbWm9fREfrbqkUzLbX8mQQdNqrvu2zj1Bhml3V67U3oNQS/QaA4CHw4cavhpfdpXeWXCzpsVApxWd+3TceqOn3Q6YPiIfDhhDZvTW59qFX+xYzMaVEpRMHfYfDbTNyCfnrq9MVG4MOZ2wx7uNPWsTMX1b7VYaNWRpf1fVM6Ju09UKeHR+DDJc3WMWnRlAsZW4kGHTYaQeCyvl8pHYPq9IxDQDkCH06Z1vJ19W0W74ilDptgTEMS9X39zL1791678QlQjsCHU2rRNJmv402v8rN439tgTIOCP876vq4VUNAzqx6zIfDh3ELDC6q0gft1hme5BFfQqrTisr4fjEPQtQLU6TEXAh/OqZZv0rEjl/ft865m4CbhcwludG57TEP52GLGIaASBD5iYdqxI//b3p7J0s71gjENUccwM7YYpgh8xEKrfJOrb73p0k7WunZmE3UMs/YEgnEIQFgEPmKzoKfHqzIsaVwZGPCvws2L8jHMlbRxqk6vrw1uUA6YIPARG83YiVLaubh9e+I3SrEtGNOgVsqZgr98bDFtloiqmjOIOM3v6vLHIH9reLPtf7S2ejVjY/6HR56olVKP8vHIKv+wGQubCHzETm2a55ubjX6s6vkK/TsGB3MX+t70ih9whZIOYqfBardG6FTRbwd52cQF4kTgIxGq5ZvO2fGmN3EJfSAcZ4E/krPNNdh3e6lk3LXjTU/VzMooZaBSgwYXGu7cufPBSr7OWeBXcid+FNtN9fV+q2YUuhL3mxTeCxeI0549e/5UyY+jpINEabia6QVZgQubNxP6QAUIfCROq/wo9XxvOvQp7wBzI/CROLVXRq3ne9PlHTZygdkR+EgF1fPvsDAVUxu5WZ2jD7hWNTU1VdGPqKqqquwLp2miHxu3CEu1eJVnolKJKK8XZyHfdIX15ORkqNc4NTVVVcnXVbzCv//++0Old9gDBrzpTdwoF2UFdHHWZH197mbvIP/CZmeYbHZa0mGFDxO6KCtq5443PYZBIxzo4EFWuM7MigN/4cKFl8J+cy6+ginN27ER+t50B09ebqKCfDPJzDDZXHHgL1myZDTsgbDCRxQ2Q1+jGM43NWX+donIN5PMDJPNFQf+/Pnzz4U9EFb4iMpm6H83Pu79Y/16v1+f1T7SyCQzw2RzxYG/ePHiobAHQuDDBpuh703367PaRxqZZGaYbK448BcsWPC3sAeiO/kANtgO/WC1r9r+d/w9RUqYZGaYbK64D98z6MX3vu8PDfsUYFZfd3d7l3bvtnqCdIWvxjvM4ypdJKyqqqJ2+n9RaQ++F7Yts6Gh4euwB2My6hOYjVo2F/b2Wj0/at9UJw89+0iSSVaGzeRQgV9XV3cm7AFRx4dtWonfcehQ5Nk712P4GpJkkpVhMzlU4N91112fhD0gAh8uVLe2eotGRiJP2Sx3dWiIej4SY5KVYTM5VOCbdOpQ0oErwcA1q5u5BD4SYpKVYTM51KatZ7hxe+rUKa++vj7s04CKXe7p8Td0pyLOcFKpSL89AHFSd87y5ctD/8QwG7aeySwdk43bUqkU9ilAKPO7uvzVvs0SDxAXk4w0yWKTwA89YoGyDuJwc1OTX9ePMm1T3wOIm2GHTugsDh34S5cu/WPY5wwMDIR9CmBMrZsqzYRd7c/fto35+UiESUaaZHHowL/zzjt/F/Y5HmUdxOzPREcAAAlWSURBVCzo4tFqv5L2TX046IMCiJtpNppkcejAf+mll8ap4yMrFOIK/lva2mY9Yv1/3B0LSTGt3yuLwz6v2uQ13nfffX8dHR1tCfMcAh9JUfumbpKuK2m/KZX8oWkKd9Xr57W3U7dHokyyURlscsxGgX/PPffs9zwvVODrtl19fX1eJ/NKkBAF+22EO1JEmWhyO9jpDA4tdB9+4O67775y+vTpUB8YbW1trPQBYFp7e3voDdtly5Zd/eKLL24xOYfG97Rds2bN38M+Ry+MkckA8P3FVibdOSbZGzAO/JUrV+4xeV4fN5QGAOMsNM1eL0pJxzMs69TU1HCvWwCFV1tbG7p+H6Wc40VZ4csDDzzw57DPCTZvAaCoTDdrTTK3XKTAX7FixYsmz+vmAhcABWaagaaZG4hU0vG+30A49/HHH4e+YuXAgQP+DjUAFIk6FTdu3Bj6Fd9///0TR48eXRzlVEVa4UtTU9MfTJ7X09MT9UcDQOaYZp9p1paLvML3DDdv5dChQ14rs8cBFISmYq5fvz70i426WRuIvML3ImwkcNUtgCIxzbyom7UBK4G/atWqjkWLFoX+VWF8fJyOHQCFoKxT5oWlbFXG2jhHVko63vdjE4YPHjwYelCJ+vJ1xVktkwoB5JSuPdJtXk1aMTds2DAyMDDQbOPMWFnhy+rVq583eZ5OABu4APJMGWcS9l6EbJ2JtRW+PPzwwyc//PDDH5k8d3h4WLvQ1o4FANJgZGTEa242W6A/9NBD//nBBx+stPUyrK3wpbm52XgXtqury+ahAEAqRMm2KJk6E6uBv2fPnj89/vjjQybPHRoaorQDIFeUaco2E8pSZarN82E18L0IHTve9OXGjE8GkAfKMtMRCjY7c8pZD3zdZ3HDhg3hhzxPb+AybgFAHijLTDdqlaEm96y9EaubtuVMr76VXbt2MWANQGYpv3bv3m10+Lauqp2J9RV+4NFHH/216XN1onQJMgBkjbLLNOy9iNl5I85W+LJu3br/PnLkyBKT53JBFoCsiXKBlaxdu/bs4cOH/6+rl+1she99H/g/M93A1QljsBqALFFmmYa9slKZ6fLlOg38KBu4cuzYMQasAcgEZZUyy5SrjdpyTks6AdObpATYxAWQZlE2aT1LNzephNMVfuCRRx5pMi3teNObuEzVBJBGyqYoYa9sVEbG8dJiCXz9mvLkk0++HOV7bN68mdAHkCrKJGVTFMpG16WcQCwlnYDpCOWAOnfU8sSQNQBJ01C0KJu0nuXRx5WIZYUfuPfee9sbGhq+Nn1+0LmjEw0ASbER9spCZWKcLyHWwNevLe3t7Q9FqecT+gCSZCPslYHKwrhKOYFYA9+bnqgZtZ4fhD41fQBxUuZEDXtvum5vexJmJWKt4Zd76qmnDrz11luRf53p7e2lVx+AczY2aGXTpk2lN998c2MS71hige9FvENWOfr0AbgUtc8+YPsOVmElGviehYuyAh0dHZR4AFinCkJ/f3/kbxvXxVVzib2Gfz1dcBClcyegN0TtmhpeBABRKUuUKTbCXhkX18VVc0k88LVL/dhjj622EfqaY6FJdYxWBhCFMkRZEmU2TkDZpoyLuyNnJokHvmepXTOg3fP169dT0wdgRNmhDInaieNNt1+mJey9NNTwy+3YseOJ119//T/Onz9fZeP7NTY2eqVSyf+kBoC56P4bui2hjVW9Nx32zzzzzL+98sorv0/LiU/FCj+gE6MTZGOl702XeFSD053jAWA2yghlRZ7D3kvbCj+wc+fOB0ul0oejo6O32fqeLS0t195UAPCmr5rt6uryhoaGrJ0P1exVok7iwqobSWXgy4svvlj37rvvnrAZ+t50z77eYG6dCBSXOnC0ALTRW18uTRu0M0lt4HvTof/++++P2OjTL6epm3qzuUIXKB5dr6NFn41N2XLqs1frZVrD3kt74AdsXZF7vbq6umuzMQDkm1ottcgbH7efx0lfQVupVG3azkYnUvMnbH9fvfFqv1Lgq5sHQP7o37b+jevfuouwVzZlIex9WuFn5fHcc8/9ZtGiRd/psF086urqpnp7e6cAZJ/+LevftKu8UBYpk7KUoZko6ZRz0cFzPdX4VePTr3/08APZoV56lWm1R2e7Rl8uzZ04c8lc4HvTm7mffPJJKcrtEivV1tbmX4zBBi+QXgp5lW4GBgacH6NuS6g7VaV5c3Y2mQz8wJYtW37z9ttvv2Dryty5aNWv4A8eAJKlgA8eLlfzAV1MpRuX7N+//9+z+tZnOvA9h62bN6KVvzaCFP6UfQD3VK5RuKvbJo6VfLkstFxWIvOBH9AdtA4ePNgWx2r/emrvVPjrKl49aPMEolOw60pYPfSfXXTY3IhW9Rs2bBhI6g5VtuUm8L3p1f7hw4f/cuTIkSVJH4sGt2nlH3wI6Mre4E8A39MVrwr04E89tJK3NdMmirVr155dt27dz7K+qi+Xq8APbN26teu999777enTp6vTcUQ/pNk+M+G3A+TJbPemULDHUXc3sWzZsquPPvror1999dX8TV3MUg9p2MemTZsOuOzb58GDR34eygplRp4zMZcr/HIq83z66af977zzzsxLagCF9/jjjw+tWrWqI0/lm5nkPvADumBreHi4z8VMHgDZpBk4zc3NnVm7gMpUYQI/oOA/ceLEa4ODg41JdPQASJY6b1pbW4+tXr36+aIEfaBwgR8ISj0fffTRz9O8uQvADm3GPvDAA38uQulmNoUN/HJPP/306yMjI7+M++ItAO7poqmmpqY/vPHGG88U/XQT+GVU7vnss89eYtUPZFuwml+xYsWLRSvbzIXAn8WOHTueOHny5M6jR4/+mPAH0k8hv2bNmr+vXLlyT9puHp4WBH4FFP6ff/75luPHj//U5VhmAOFoTPF9993313vuuWc/IX9jBH5I2uz96quvnjtz5swvRkdHG/gAAOKjgG9oaBhdunTpH++8887fFXXz1RSBb4FGOZw7d67lyy+/vHd8fHwpHwJAdAr3urq6M3fdddcnixcvHsrlqIOYEfiOaAP44sWLP9EHweXLlxefPXu24cKFC7fqp9ENBHzfPaM/Fy5ceGnJkiWj8+fPP6dgX7Bgwd/YaHWDwAeAgriJNxoAioHAB4CCIPABoCAIfAAoCAIfAAqCwAeAgiDwAaAgCHwAKAgCHwCKwPO8/w8voWTcCTSV0AAAAABJRU5ErkJggg==",
+        "mediatype": "image/png"
+    }
+}
+{
+    "schema": "olm.channel",
+    "name": "stable",
+    "package": "sandboxed-containers-operator",
+    "entries": [
+        {
+            "name": "sandboxed-containers-operator.v1.10.0",
+            "replaces": "sandboxed-containers-operator.v1.9.0",
+            "skipRange": ">=1.1.0 <1.10.0"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "sandboxed-containers-operator.v1.10.0",
+    "package": "sandboxed-containers-operator",
+    "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:23eb79b96ef69c351b5bcb81bae0524e87aa964047759fbfe92d57b59d90cee2",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "confidentialcontainers.org",
+                "kind": "PeerPod",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kataconfiguration.openshift.io",
+                "kind": "KataConfig",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "sandboxed-containers-operator",
+                "version": "1.10.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kataconfiguration.openshift.io/v1\",\n    \"kind\": \"KataConfig\",\n    \"metadata\": {\n      \"name\": \"example-kataconfig\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "createdAt": "2025-03-10T11:49:47Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "false",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "olm.skipRange": ">=1.1.0 <1.10.0",
+                    "operatorframework.io/suggested-namespace": "openshift-sandboxed-containers-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.39.1",
+                    "operators.operatorframework.io/internal-objects": "[\"peerpods.confidentialcontainers.org\",\"peerpodconfigs.confidentialcontainers.org\"]",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "repository": "https://github.com/openshift/sandboxed-containers-operator"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kataconfigs.kataconfiguration.openshift.io",
+                            "version": "v1",
+                            "kind": "KataConfig",
+                            "description": "The kataconfig CR represent a installation of Kata in a cluster and its current state."
+                        },
+                        {
+                            "name": "peerpods.confidentialcontainers.org",
+                            "version": "v1alpha1",
+                            "kind": "PeerPod"
+                        }
+                    ]
+                },
+                "description": "OpenShift sandboxed containers, based on the Kata Containers open source\nproject, provides an Open Container Initiative (OCI) compliant container\nruntime using lightweight virtual machines, running your workloads in their own\nisolated kernel and therefore contributing an additional layer of isolation\nback to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for\nmore information.\n\n# Requirements\nYour cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.\n\n# Features & benefits\n- **Isolated Developer Environments & Privileges Scoping**\n  As a developer working on debugging an application using state-of-the-art\n  tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With\n  OpenShift sandboxed containers, any impact will be limited to a separate\n  dedicated kernel.\n\n- **Legacy Containerized Workload Isolation**\n  You are mid-way in converting a containerized monolith into cloud-native\n  microservices. However, the monolith still runs on your cluster unpatched and\n  unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel\n  to reduce risk.\n\n- **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**\n  If you are providing a service to multiple tenants, it could mean that the\n  service workloads are sharing the same resources (e.g., worker node). By\n  deploying in a dedicated kernel, the impact of these workloads have on one\n  another is greatly reduced.\n\n- **Additional Isolation with Native Kubernetes User Experience**\n  OpenShift sandboxed containers is used as a compliant OCI runtime.\n  Therefore, many operational patterns used with normal containers are still\n  preserved including but not limited to image scanning, GitOps, Imagestreams,\n  and so on.\n\n# How to install\n  Read the information about the Operator and click Install.\n\n  On the Install Operator page:\n\n  - Select `candidate` from the list of available Update Channel options.\n  This ensures that you install the latest version of OpenShift sandboxed containers\n  that is compatible with your OpenShift Container Platform version.\n\n  - For Installed Namespace, ensure that the Operator recommended namespace\n    option is selected. This installs the Operator in the mandatory\n    `openshift-sandboxed-containers-operator` namespace, which is automatically\n    created if it does not exist. Attempting to install the OpenShift\n    sandboxed containers Operator in a namespace other than\n    `openshift-sandboxed-containers-operator` causes the installation to fail.\n\n  - For Approval Strategy, ensure that Automatic, which is the default value,\n    is selected. OpenShift sandboxed containers automatically updates when a new\n    z-stream release is available.\n\n  - Click Install to make the Operator available to the OpenShift sandboxed\n    containers namespace.\n\n  - The OpenShift sandboxed containers Operator is now installed on your\n    cluster. You can trigger the Operator by enabling the runtime on your cluster.\n    You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click\n    on \"create instance\" on the operator overview page.\n\n# Documentation\nSee the [OpenShift sandboxed containers documentation](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/).",
+                "displayName": "OpenShift sandboxed containers Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "sandboxed-containers",
+                    "kata"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Sandboxed Containers Operator",
+                        "url": "https://www.github.com/openshift/sandboxed-containers-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "'Red Hat",
+                        "email": "support@redhat.com'"
+                    }
+                ],
+                "maturity": "beta",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:23eb79b96ef69c351b5bcb81bae0524e87aa964047759fbfe92d57b59d90cee2"
+        },
+        {
+            "name": "caa",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:2453b3f36547f5dde1f771df8c07eea6cd1467c07338d1598ee503d302db1e52"
+        },
+        {
+            "name": "peerpods-webhook",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:abfbd658b8fa83492420ff276fe369388898a828ba18e060f33d13e54ae4353f"
+        },
+        {
+            "name": "kata-monitor",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:aa36c6a0d45cac5d7a0b6a5c89205828b42c45892addf3a93ffa77c7b9c47a51"
+        },
+        {
+            "name": "podvm-builder",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:c4d8f716bbf9ffe1c0600cd4909e7a31945e8a1d9b223d6825ab9a534862efc9"
+        },
+        {
+            "name": "podvm-payload",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:925ccddf23ba2a12a1c8ec86d3a678f28e4a868441b28aa0e3932cc6d4caccaa"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:d104d069fecb41f5a19b6b2b97c328a809ed94c6ccad6ed7bf0a4038063562c8"
+        }
+    ]
+}


### PR DESCRIPTION
Trying to find a way to automate the creation of a catalog.

This PR adds a new FBC build that creates a very simple catalog with only one image - our latest build.
I plan to add this as a component to our Konflux application (sandboxed-containers) and then try to use the nudging mechanism to make Konflux update the bundle reference every time a new bundle is built.

I'm not sure that's the right way, but if it works we should have a catalog built automatically for testing.
Obviously, this is not meant for release - all our other FBCs are here for that.

NOTE: about render.sh
I cherry-picked the commit for updating the render script.
I also had to modify that script slightly to make it skip numeric version check when we render the test catalog.

Since the default is to look only at version numbers, the script's behavior is to ignore the test-fbc catalog by default, which is fine with me: I want Konflux to update the references, I don't want us to render it on every build.