### PR TITLE
test-fbc: make sure only the test catalog is updated by bundle builds

### DIFF
--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/sandboxed-containers-operator?rev={{revision}}
+    build.appstudio.openshift.io/build-nudge-files: ".*/test-fbc/catalog-template.yaml"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/fbc/test-fbc/catalog-template.yaml
+++ b/fbc/test-fbc/catalog-template.yaml
@@ -13,6 +13,6 @@ entries:
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:23eb79b96ef69c351b5bcb81bae0524e87aa964047759fbfe92d57b59d90cee2
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:3e6a27288796d55687e80f6eea77b05326a79556e048dfd00295b684259895db
     schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
The test-fbc must be modified by automated PRs from Konflux whenever a new bundle is built. However by default, this nudging mechanism looks for references everywhere in the repository. The result is that when the bundle is updated, all our catalogs gets their files modified, with every single entry replaced by the new bundle's reference.

This commit adds an explicit list of files that need to be updated when the test-fbc is nudged: we want to have only this catalog template to be updated, and no other.
