### PR TITLE
test-fbc: fix nudging from bundle to test-fbc

### DIFF
--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/sandboxed-containers-operator?rev={{revision}}
+    build.appstudio.openshift.io/build-nudge-files: ".*/test-fbc/catalog-template.yaml"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -3,7 +3,6 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/sandboxed-containers-operator?rev={{revision}}
-    build.appstudio.openshift.io/build-nudge-files: ".*/test-fbc/catalog-template.yaml"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/fbc/test-fbc/catalog-template.yaml
+++ b/fbc/test-fbc/catalog-template.yaml
@@ -13,6 +13,6 @@ entries:
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:3e6a27288796d55687e80f6eea77b05326a79556e048dfd00295b684259895db
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:6139bd6f0fa1349ac20e0dbf605f39633493c2f1e5595b9b7797243a5304d644
     schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
The nudging filter must be set on the component that triggers the update, not on the component that is updated.
Also updating the bundle reference manually.
