### PR TITLE
test-fbc: use Konflux labeling to add custom tags to the catalog image

### DIFF
--- a/fbc/test-fbc/Dockerfile
+++ b/fbc/test-fbc/Dockerfile
@@ -28,3 +28,4 @@ COPY --from=builder /tmp/cache /tmp/cache
 # Set FBC-specific label for the location of the FBC root directory
 # in the image
 LABEL operators.operatorframework.io.index.configs.v1=/configs
+LABEL konflux.additional-tags="latest 1.10"


### PR DESCRIPTION
We want to have tags that can be easily identified. Since we don't have write access to the repository, this commit uses the custom tags mechanism from Konflux: adding a LABEL in the Dockerfile that gives Konflux the list of tags we want to apply to the final image.
