### PR TITLE
test-fbc: modify the build filter for on-push

### DIFF
--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -8,7 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "devel"
+      == "devel" && ( "fbc/***".pathChanged() || ".tekton/osc-test-fbc-push.yaml".pathChanged()
+      || "test-fbc/Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: osc-test-catalog


### PR DESCRIPTION
The test-fbc gets rebuilt on various merge requests, even unrelated to it. This commit sets the "on-cel-expression" for the "on-push" pipeline to what we have on the "on-pull-request" pipeline. This should avoid unneeded rebuilds.
