### PR TITLE
osc-operator: build with CGO_ENABLED=1 to comply with FIPS checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager and metrics-server binaries.
-	CGO_ENABLED=0 GOOS=linux go build $(GOFLAGS) -o bin/manager cmd/manager/main.go
-	CGO_ENABLED=0 GOOS=linux go build $(GOFLAGS) -o bin/metrics-server cmd/metrics/metrics.go
+	CGO_ENABLED=1 GOOS=linux go build $(GOFLAGS) -o bin/manager cmd/manager/main.go
+	CGO_ENABLED=1 GOOS=linux go build $(GOFLAGS) -o bin/metrics-server cmd/metrics/metrics.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.


### PR DESCRIPTION
The FIPS check was failing during the build, because our binaries were built with CGO_ENABLED=0.
Setting the flag to 1 to fix this.

Notes:
- somehow, this failure showed up only when we build the catalogs (?) As such, this PR should help fix #676 
- this flag was actually set to 1 already in our CPaaS build, so this is not a new change, I'm just fixing something that I missed earlier.
