### PR TITLE
tests: add a dummy integration test to try Konflux testing

### DIFF
--- a/tests/show-snapshot.yaml
+++ b/tests/show-snapshot.yaml
@@ -1,0 +1,57 @@
+kind: Pipeline
+apiVersion: tekton.dev/v1beta1
+metadata:
+  name: show-snapshot
+spec:
+  params:
+    - description: 'Snapshot of the application'
+      name: SNAPSHOT
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+  tasks:
+    - name: task-1
+      description: Placeholder task that prints the Snapshot and outputs standard TEST_OUTPUT
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+        - name: SNAPSHOT
+        results:
+        - name: TEST_OUTPUT
+          description: Test output
+        steps:
+        - image: registry.redhat.io/openshift4/ose-cli:latest
+          env:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+          script: |
+          #!/bin/bash
+          set -e
+          dnf -y install jq
+          snapshotComponents=$(jq -c '.components[]' <<< "${SNAPSHOT}")
+
+          echo -e "Example test task for the Snapshot:\n ${SNAPSHOT}"
+          # Run custom tests for the given Snapshot here
+          while read componentEntry
+          do
+            # Variables
+            componentName=$(echo "${componentEntry}" | jq -r '.name')
+            componentUrl=$(echo "${componentEntry}" | jq -r '.source.git.url')
+            componentUrlWithoutSuffix=$(echo $componentUrl | sed 's/\.git$//')
+            componentSha=$(echo "${componentEntry}" | jq -r '.source.git.revision')
+
+            echo "Print the infomation for component ${componentName} included in snapshot, more test can be added to inspect git source and containerImage in component::"
+            echo "${componentName}"
+            echo "${componentUrl}"
+            echo "${componentUrlWithoutSuffix}"
+            echo "${componentSha}"
+          done < <(echo "$snapshotComponents")
+
+          # After the tests finish, record the overall result in the RESULT variable
+          RESULT="SUCCESS"
+
+          # Output the standardized TEST_OUTPUT result in JSON form
+          TEST_OUTPUT=$(jq -rc --arg date $(date -u --iso-8601=seconds) --arg RESULT "${RESULT}" --null-input \
+            '{result: $RESULT, timestamp: $date, failures: 0, successes: 1, warnings: 0}')
+          echo -n "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)


### PR DESCRIPTION
This example test comes from the Konflux documentation https://konflux.pages.redhat.com/docs/users/testing/integration/creating.html

I will use it to see how much we can do for testing in Konflux.
