### PR TITLE
test-fbc: update the on-cel-expression to avoid unneeded rebuilds

### DIFF
--- a/.tekton/osc-test-fbc-pull-request.yaml
+++ b/.tekton/osc-test-fbc-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "devel" && ( "fbc/***".pathChanged() || ".tekton/osc-test-fbc-pull-request.yaml".pathChanged()
-      || "test-fbc/Dockerfile".pathChanged() )
+      == "devel" && ( "test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: osc-test-catalog

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "devel" && ( "fbc/***".pathChanged() || ".tekton/osc-test-fbc-push.yaml".pathChanged()
-      || "test-fbc/Dockerfile".pathChanged() )
+      == "devel" && ( "test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: osc-test-catalog


### PR DESCRIPTION
We should not rebuild the test-fbc catalog when only the other FBCs are updated.
This could lead to get a new build of test-fbc with obsolete image references.

This commit changes the on-cel-expression to make test-fbc rebuild only on selected file changes:
- any file under the 'test-fbc' folder
- render.sh script changes, as it is used by the test-fbc pipeline
- the test-fbc pipeline definition itself
