### PR TITLE
gcp: use disk.raw naming at disk upload

### DIFF
--- a/config/peerpods/podvm/gcp-podvm-image-handler.sh
+++ b/config/peerpods/podvm/gcp-podvm-image-handler.sh
@@ -154,8 +154,8 @@ function create_image_from_prebuilt_artifact() {
 
   echo "Compacting ${RAW_IMAGE_PATH} into /tmp/${IMAGE_NAME}.tar.gz"
 
-  # TAR the raw image (GCP expects a compressed archive)
-  tar -cvzf "/tmp/${IMAGE_NAME}.tar.gz" -C "$(dirname "${RAW_IMAGE_PATH}")" "$(basename "${RAW_IMAGE_PATH}")" ||
+  # TAR the raw image (GCP expects a compressed archive with disk.raw named file)
+  tar -cvzf "/tmp/${IMAGE_NAME}.tar.gz" -C "$(dirname "${RAW_IMAGE_PATH}")" --transform="s|$(basename "${RAW_IMAGE_PATH}")|disk.raw|" "$(basename "${RAW_IMAGE_PATH}")" ||
     error_exit "Failed to create tarball for GCP"
 
   # Create bucket if doesn't exist


### PR DESCRIPTION
otherwise it fails with:
The file inside the tar archive was named ''podvm.raw''. It should be named ''disk.raw''

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
