### PR TITLE
osc-test-fbc: add a label "latest" to the on-push pipeline

### DIFF
--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -308,6 +308,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["latest"]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
This was asked to ease identification of the latest build. Doing it on the on-push pipeline makes sure the "latest" tag points to a build that was validated and manually created, not an automated, potentially incomplete build.
