### PR TITLE
cm-helper: add gcp support

### DIFF
--- a/scripts/cm-helpers/README.md
+++ b/scripts/cm-helpers/README.md
@@ -9,6 +9,7 @@ cloud provider, recommended best practices, and user-provided input.
 * AWS
 * Azure
 * Libvirt
+* GCP
 
 ### Prerequisites
 * jq, kubectl or oc installed


### PR DESCRIPTION
to test run the `pp-cm-helper.sh` script after osc operator is installed (before kataConfig)
