### PR TITLE
osc-operator: build upon yaml changes

### DIFF
--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -11,10 +11,19 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
-      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+      (
+        (
+          "config/peerpods/podvm/osc-podvm-*-job.yaml".pathChanged() ||
+          "config/peerpods/podvm/*-podvm-image-cm.yaml".pathChanged() ||
+          "config/peerpods/credentials-requests/credentials_request_*.yaml".pathChanged() ||
+          "config/peerpods/mc-*.yaml".pathChanged()
+        ) || (
+          files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
+          files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+          files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+          files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+        )
+      )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -10,10 +10,19 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
       target_branch == "devel" &&
-      files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
-      files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
-      files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
-      files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+      (
+        (
+          "config/peerpods/podvm/osc-podvm-*-job.yaml".pathChanged() ||
+          "config/peerpods/podvm/*-podvm-image-cm.yaml".pathChanged() ||
+          "config/peerpods/credentials-requests/credentials_request_*.yaml".pathChanged() ||
+          "config/peerpods/mc-*.yaml".pathChanged()
+        ) || (
+          files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
+          files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
+          files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
+          files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
+        )
+      )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
some yaml are parsed at runtime, trigger operator build when these are modified:
controllers/utils.go:func parseJobYAML(yamlData []byte) (*batchv1.Job, error) { controllers/utils.go:func parseMachineConfigYAML(yamlData []byte) (*mcfgv1.MachineConfig, error) { controllers/utils.go:func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, error) { controllers/utils.go:func parseConfigMapYAML(yamlData []byte) (*corev1.ConfigMap, error) {

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
