### PR TITLE
chore: update digest for osc-dm-verity-image

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -400,7 +400,7 @@ spec:
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:73a82ac1c252f068f9d046a36dfca7932202ad728f94fc575a332d8707650905
                 - name: RELATED_IMAGE_PODVM_OCI
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:93f3c45cda820a16030273e5a3f5c186d602f9affcb3cfa91230084a516dc3f4
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:238ffe72da6977c57b93a329282b2134b60ad71037042dcc97ff609bfc6691eb
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -557,7 +557,7 @@ spec:
     name: podvm-builder
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:73a82ac1c252f068f9d046a36dfca7932202ad728f94fc575a332d8707650905 
     name: podvm-payload
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:93f3c45cda820a16030273e5a3f5c186d602f9affcb3cfa91230084a516dc3f4
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:238ffe72da6977c57b93a329282b2134b60ad71037042dcc97ff609bfc6691eb
     name: podvm-oci
   replaces: sandboxed-containers-operator.v1.9.0
   version: 1.10.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
             - name: RELATED_IMAGE_PODVM_PAYLOAD
               value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:73a82ac1c252f068f9d046a36dfca7932202ad728f94fc575a332d8707650905 
             - name: RELATED_IMAGE_PODVM_OCI
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:93f3c45cda820a16030273e5a3f5c186d602f9affcb3cfa91230084a516dc3f4
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:238ffe72da6977c57b93a329282b2134b60ad71037042dcc97ff609bfc6691eb
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Update the digest for the dm-verity-image. From the next we should receive updates from the bot.