### PR TITLE
Enable Confidential Containers on Baremetal

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-06T16:02:13Z"
+    createdAt: "2025-10-07T13:31:15Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -155,6 +155,14 @@ spec:
           - nodes/status
           verbs:
           - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -167,6 +167,15 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Credentials")
 		os.Exit(1)
 	}
+
+	if err = (&controllers.RuntimeClassReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("RuntimeClass"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "RuntimeClass")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -1,25 +1,53 @@
 package controllers
 
 import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// When the feature is enabled, handleFeatureConfidential sets config maps to confidential values.
+const (
+	// kata-cc runtime class for CoCo BM
+	kataCCRuntimeClassName        = "kata-cc"
+	kataCCRuntimeClassCpuOverhead = "0.25"
+	kataCCRuntimeClassMemOverhead = "350Mi"
+
+	// TEE node labels
+	intelTDXNodeLabel = "intel.feature.node.kubernetes.io/tdx"
+	amdSNPNodeLabel   = "amd.feature.node.kubernetes.io/snp"
+
+	// RuntimeClass handlers for TEE
+	kataCCIntelHandler = "kata-cc-intel"
+	kataCCAmdHandler   = "kata-cc-amd"
+)
+
+// When the feature is enabled, handleFeatureConfidential configures confidential computing support.
 //
-// Changes the ImageConfigMap, so that the image creation job will create a confidential image.
-// This will happen at the first reconciliation loop, before the image creation job starts.
+// For peer pods: sets ImageConfigMap and peer pods configMap to enable confidential images and CVM support.
+// For baremetal: creates kata-cc runtime classes with TEE-specific handlers (Intel TDX or AMD SNP).
 //
-// Changes the peer pods configMap to enable confidential.
-// This will happen likely after several reconciliation loops, because it has prerequisites:
-//
-//   - Peer pods must be enabled in the KataConfig.
-//   - The peer pods config map must exist.
-//
-// When the feature is disabled, handleFeatureConfidential resets the config maps to non-confidential values.
+// When the feature is disabled, handleFeatureConfidential resets config maps and deletes runtime classes.
 func (r *KataConfigOpenShiftReconciler) handleFeatureConfidential(state FeatureGateState) error {
+	if r.kataConfig.Spec.EnablePeerPods {
+		if err := r.handleConfidentialPeerPods(state); err != nil {
+			return err
+		}
+	}
 
+	if err := r.handleConfidentialBaremetal(state); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handleConfidentialPeerPods configures confidential computing for peer pods deployments.
+// It manages ImageConfigMap and peer pods configMap to control confidential images and CVM support.
+func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state FeatureGateState) error {
 	// ImageConfigMap
-
 	if err := InitializeImageGenerator(r.Client); err != nil {
 		return err
 	}
@@ -56,8 +84,6 @@ func (r *KataConfigOpenShiftReconciler) handleFeatureConfidential(state FeatureG
 		}
 	}
 
-	// peer pods config
-
 	// Patch peer pods configMap, if it exists.
 	var peerpodsCMData map[string]string
 	if state == Enabled {
@@ -75,4 +101,82 @@ func (r *KataConfigOpenShiftReconciler) handleFeatureConfidential(state FeatureG
 	}
 
 	return nil
+}
+
+// handleConfidentialBaremetal configures confidential computing for baremetal deployments.
+// It manages kata-cc runtime classes with TEE-specific handlers (Intel TDX or AMD SNP).
+func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state FeatureGateState) error {
+	if state == Enabled {
+		r.Log.Info("Creating " + kataCCRuntimeClassName + " runtime class for confidential containers")
+
+		handler, nodeLabel, err := r.computeTEEHandlerAndLabel()
+		if err != nil {
+			// If peer pods is enabled, just warn and skip baremetal coco
+			if r.kataConfig.Spec.EnablePeerPods {
+				r.Log.Info("WARNING: No TEE hardware detected, skipping baremetal confidential containers (peer pods CVM will handle confidential workloads)", "err", err)
+				return nil
+			}
+			// If peer pods disabled, this is an error - user wants baremetal coco but no hardware
+			r.Log.Info("failed to detect TEE platform", "err", err)
+			return err
+		}
+
+		// Create kata-cc runtime class restricted to the detected TEE subset
+		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, handler, nodeLabel)
+		if err != nil {
+			r.Log.Info("Error creating "+kataCCRuntimeClassName+" runtime class", "err", err)
+			return fmt.Errorf("Error creating "+kataCCRuntimeClassName+" runtime class: %w", err)
+		}
+
+	} else {
+		r.Log.Info("Deleting " + kataCCRuntimeClassName + " runtime class for confidential containers")
+
+		// Delete kata-cc runtime class
+		err := r.deleteRuntimeClass(kataCCRuntimeClassName)
+		if err != nil {
+			r.Log.Info("Error deleting "+kataCCRuntimeClassName+" runtime class", "err", err)
+			return fmt.Errorf("Error deleting "+kataCCRuntimeClassName+" runtime class: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *KataConfigOpenShiftReconciler) computeTEEHandlerAndLabel() (string, string, error) {
+	selector, err := r.getKataConfigNodeSelectorAsSelector()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to build node selector: %w", err)
+	}
+
+	nodes := &corev1.NodeList{}
+	listOpts := []client.ListOption{
+		client.MatchingLabelsSelector{Selector: selector},
+	}
+	if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+		return "", "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var hasIntelTDX bool
+	var hasAmdSNP bool
+	for _, n := range nodes.Items {
+		if v, ok := n.Labels[intelTDXNodeLabel]; ok && v == "true" {
+			hasIntelTDX = true
+		}
+		if v, ok := n.Labels[amdSNPNodeLabel]; ok && v == "true" {
+			hasAmdSNP = true
+		}
+	}
+
+	if hasIntelTDX && hasAmdSNP {
+		return "", "", fmt.Errorf("multiple TEE platforms detected; only one per cluster supported")
+	}
+
+	if hasIntelTDX {
+		return kataCCIntelHandler, intelTDXNodeLabel, nil
+	}
+	if hasAmdSNP {
+		return kataCCAmdHandler, amdSNPNodeLabel, nil
+	}
+
+	return "", "", fmt.Errorf("no TEE platform labels found (expected %s or %s)", intelTDXNodeLabel, amdSNPNodeLabel)
 }

--- a/controllers/fg_handler.go
+++ b/controllers/fg_handler.go
@@ -110,19 +110,17 @@ func (r *KataConfigOpenShiftReconciler) processFeatureGates() error {
 
 	// Check which feature gates are enabled in the FG ConfigMap and
 	// perform the necessary actions
-	if r.kataConfig.Spec.EnablePeerPods {
-		if fgStatus.IsEnabled(ConfidentialFeatureGate) {
-			r.Log.Info("Feature gate is enabled", "featuregate", ConfidentialFeatureGate)
-			// Perform the necessary actions
-			if err := r.handleFeatureConfidential(Enabled); err != nil {
-				return err
-			}
-		} else {
-			r.Log.Info("Feature gate is disabled", "featuregate", ConfidentialFeatureGate)
-			// Perform the necessary actions
-			if err := r.handleFeatureConfidential(Disabled); err != nil {
-				return err
-			}
+	if fgStatus.IsEnabled(ConfidentialFeatureGate) {
+		r.Log.Info("Feature gate is enabled", "featuregate", ConfidentialFeatureGate)
+		// Perform the necessary actions
+		if err := r.handleFeatureConfidential(Enabled); err != nil {
+			return err
+		}
+	} else {
+		r.Log.Info("Feature gate is disabled", "featuregate", ConfidentialFeatureGate)
+		// Perform the necessary actions
+		if err := r.handleFeatureConfidential(Disabled); err != nil {
+			return err
 		}
 	}
 

--- a/controllers/migrate.go
+++ b/controllers/migrate.go
@@ -16,10 +16,13 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	nodeapi "k8s.io/api/node/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // migratePeerPodsLimit moves the PeerPodConfig "Limit" value to peer-pods-cm
@@ -79,5 +82,34 @@ func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 	}
 
 	r.Log.Info("Successfully migrated PeerPodConfig Limit to peer-pods-cm and deleted PeerPodConfig")
+	return nil
+}
+
+// ensureRuntimeClassFinalizers adds finalizers to existing runtime classes that don't have them
+func (r *KataConfigOpenShiftReconciler) ensureRuntimeClassFinalizers() error {
+	runtimeClasses := []string{
+		kataCCRuntimeClassName,
+		peerpodsRuntimeClassName,
+		kataRuntimeClassName,
+	}
+
+	for _, name := range runtimeClasses {
+		rc := &nodeapi.RuntimeClass{}
+		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name}, rc)
+		if k8serrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		if !controllerutil.ContainsFinalizer(rc, runtimeClassFinalizerName) {
+			r.Log.Info("Adding finalizer to existing runtime class", "runtimeClass", name)
+			controllerutil.AddFinalizer(rc, runtimeClassFinalizerName)
+			if err := r.Client.Update(context.TODO(), rc); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -772,7 +772,7 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string) error {
+func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, handler string, additionalNodeLabel string) error {
 
 	rc := func() *nodeapi.RuntimeClass {
 		rc := &nodeapi.RuntimeClass{
@@ -783,7 +783,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 			ObjectMeta: metav1.ObjectMeta{
 				Name: runtimeClassName,
 			},
-			Handler: runtimeClassName,
+			Handler: handler,
 			Overhead: &nodeapi.Overhead{
 				PodFixed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse(cpuOverhead),
@@ -793,6 +793,11 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 		}
 
 		nodeSelector := r.getNodeSelectorAsMap()
+
+		// Add additional node label if provided
+		if additionalNodeLabel != "" {
+			nodeSelector[additionalNodeLabel] = "true"
+		}
 
 		rc.Scheduling = &nodeapi.Scheduling{
 			NodeSelector: nodeSelector,
@@ -2197,7 +2202,7 @@ func (r *KataConfigOpenShiftReconciler) deleteScc() error {
 func (r *KataConfigOpenShiftReconciler) postKataInstallation() (*ctrl.Result, error) {
 	r.Log.Info("create runtime class")
 	r.resetInProgressCondition()
-	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead)
+	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, kataRuntimeClassName, "")
 	if err != nil {
 		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -834,6 +834,34 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 	return nil
 }
 
+func (r *KataConfigOpenShiftReconciler) deleteRuntimeClass(runtimeClassName string) error {
+
+	foundRc := &nodeapi.RuntimeClass{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: runtimeClassName}, foundRc)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if err := r.Client.Delete(context.TODO(), foundRc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	for i, name := range r.kataConfig.Status.RuntimeClasses {
+		if name == runtimeClassName {
+			r.kataConfig.Status.RuntimeClasses = append(r.kataConfig.Status.RuntimeClasses[:i], r.kataConfig.Status.RuntimeClasses[i+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
 // "KataConfigNodeSelector" in the names of the following couple of helper
 // functions refers to the value of KataConfig.spec.kataConfigPoolSelector,
 // i.e. the original selector supplied by the user of KataConfig.

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -127,6 +127,12 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
+	err = r.ensureRuntimeClassFinalizers()
+	if err != nil {
+		r.Log.Info("Failed to ensure runtime class finalizers", "err", err)
+		return ctrl.Result{}, err
+	}
+
 	err = r.processFeatureGates()
 	if err != nil {
 		r.Log.Info("Unable to process feature gates", "err", err)

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -781,7 +781,8 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 				Kind:       "RuntimeClass",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: runtimeClassName,
+				Name:       runtimeClassName,
+				Finalizers: []string{runtimeClassFinalizerName},
 			},
 			Handler: handler,
 			Overhead: &nodeapi.Overhead{

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -360,7 +360,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	}
 
 	// Create runtimeClass config for peer-pods
-	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead)
+	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead, peerpodsRuntimeClassName, "")
 	if err != nil {
 		r.Log.Info("Error in creating kata remote runtimeclass", "err", err)
 		return err

--- a/controllers/runtimeclass_controller.go
+++ b/controllers/runtimeclass_controller.go
@@ -1,0 +1,139 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	nodeapi "k8s.io/api/node/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// RuntimeClassReconciler reconciles RuntimeClass objects to handle finalizers
+type RuntimeClassReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+const (
+	runtimeClassFinalizerName = "kataconfig.openshift.io/runtime-class-cleanup"
+	requeueInterval           = time.Second * 10
+)
+
+// +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile handles RuntimeClass lifecycle, specifically finalizer cleanup
+func (r *RuntimeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("runtimeclass", req.NamespacedName.Name)
+
+	runtimeClass := &nodeapi.RuntimeClass{}
+	err := r.Get(ctx, req.NamespacedName, runtimeClass)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get RuntimeClass")
+		return ctrl.Result{}, err
+	}
+
+	if !controllerutil.ContainsFinalizer(runtimeClass, runtimeClassFinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	if runtimeClass.DeletionTimestamp != nil {
+		return r.handleRuntimeClassDeletion(ctx, runtimeClass, log)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// handleRuntimeClassDeletion manages the cleanup process when a RuntimeClass is being deleted
+func (r *RuntimeClassReconciler) handleRuntimeClassDeletion(ctx context.Context, runtimeClass *nodeapi.RuntimeClass, log logr.Logger) (ctrl.Result, error) {
+	log.Info("RuntimeClass is being deleted, checking for active pods")
+
+	hasActivePods, err := r.hasPodsUsingRuntimeClass(ctx, runtimeClass.Name)
+	if err != nil {
+		log.Error(err, "Failed to check for pods using runtime class")
+		return ctrl.Result{RequeueAfter: requeueInterval}, nil
+	}
+
+	if hasActivePods {
+		log.Info("Runtime class still has active pods, waiting for them to be deleted manually or terminate naturally")
+		return ctrl.Result{RequeueAfter: requeueInterval}, nil
+	}
+
+	log.Info("No active pods found, removing finalizer to allow deletion")
+	controllerutil.RemoveFinalizer(runtimeClass, runtimeClassFinalizerName)
+	err = r.Update(ctx, runtimeClass)
+	if err != nil {
+		log.Error(err, "Failed to remove finalizer from RuntimeClass")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Successfully removed finalizer, RuntimeClass will be deleted")
+	return ctrl.Result{}, nil
+}
+
+// hasPodsUsingRuntimeClass checks if there are any active pods using the specified runtime class
+func (r *RuntimeClassReconciler) hasPodsUsingRuntimeClass(ctx context.Context, runtimeClassName string) (bool, error) {
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList); err != nil {
+		return true, err
+	}
+
+	for _, pod := range podList.Items {
+		if pod.Spec.RuntimeClassName != nil &&
+			*pod.Spec.RuntimeClassName == runtimeClassName {
+			if pod.Status.Phase == corev1.PodRunning ||
+				pod.Status.Phase == corev1.PodPending ||
+				pod.Status.Phase == corev1.PodUnknown {
+				r.Log.Info("Found active pod using runtime class",
+					"pod", pod.Name,
+					"namespace", pod.Namespace,
+					"runtimeClass", runtimeClassName,
+					"phase", pod.Status.Phase)
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *RuntimeClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&nodeapi.RuntimeClass{}, builder.WithPredicates(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				rc := e.ObjectNew.(*nodeapi.RuntimeClass)
+				return controllerutil.ContainsFinalizer(rc, runtimeClassFinalizerName) &&
+					rc.DeletionTimestamp != nil
+			},
+		})).
+		Complete(r)
+}


### PR DESCRIPTION
This adds initial support for Confidential on baremetal. Until now, Confidential was only supported by peerpods. With this change, we are introducing the Confidential feature to baremetal as well.
    
Our consensus so far, is to use the same config option "confidential" to enable Confidential features in both cases.
    
We are also reusing the same logic for KataConfigPoolSelector and checkNodeEligibility, just as we have been doing so far.

One aspect we are evaluating is enabling the MachineConfigs on all nodes alongside CRIO, regardless of whether the machine has support. The RuntimeClass would be responsible for filtering machines according to their capabilities.

RPM work is still needed.