### PR TITLE
pipeline definition 

### DIFF
--- a/pipelinedef/README.md
+++ b/pipelinedef/README.md
@@ -79,6 +79,8 @@ In order to have a full build of Sandboxed Containers, we need:
 
 - the "openshift-sandboxed-containers" application, and all its components
 - the "osc-test-catalog" application, and the associated "osc-test-fbc" component
+- the "build-definitions" application, and the associated
+  "build-dm-verity-image-task" component
 - the integration tests associated with those two applications.
   Note that the Enterprise Contract doesn't need to be in the template, as it is
   created automatically for all components in Konflux.
@@ -128,22 +130,6 @@ to use that rather than the hyphenized version.
 
 We have that application and component that is used to create the build task
 we use for building the dm-verity image.
-This task is not duplicated for now, as we expect the same task can be used
-for multiple versions of the dm-verity build.
-
-If we require specific versions of the tasks for specific versions of dm-verity,
-we may need to duplicate that too.
-
->[NOTE (Julien - 2025/08/19)] the existing pipeline define a nudge from
-`osc-podvm-payload` to the `build-dm-verity-image-task`. But the resulting PRs
-are changing the `osc-podvm-payload` image reference in the `build-pipeline.yaml`
-file used by the `osc-dm-verity-image` component. And only that component gets rebuilt with it.
->
->I think the right nudge should target the `osc-dm-verity-image` component, with
-the same result as `build-dm-verity-image-task` and `osc-dm-verity-image` share
-the same repository.
->
->If this nudge really needs to happen, we'll need to duplicate the build task too.
 
 >[NOTE (Julien - 2025/12/09)] the experience from the 1.10.x releases is that we
 >need to get the build-dm-verity-image-task duplicated too. The reason for that
@@ -154,6 +140,8 @@ the same repository.
 >Now the problem is that they also need to be versioned, otherwise only one task
 >image will be kept (I think?).
 >This may require more info / help from the Konflux support.
+
+[TODO] Need to confirm the behavior of duplicated task builds
 
 ## Branching
 
@@ -176,8 +164,13 @@ We need to add some changes of our own in this first PR, or right after:
 - update the cloud-api-adaptor submodule in sandboxed-containers, to point to the
   HEAD of the new branch (after it's been updated with the right submodules)
 
-We also need to pay attention to the nudge PRs from podvm-payload to dm-verity,
-from all components to the bundle, and from the bundle to the test-fbc.
+We also need to pay attention to the nudge PRs:
+
+- from podvm-payload to dm-verity
+- from all components to the bundle
+- from the bundle to the test-fbc
+- from the build-dm-verity-image-task to dm-verity
+
 Make sure the PRs are all created as expected, for the right component on the
 right branch.
 

--- a/pipelinedef/README.md
+++ b/pipelinedef/README.md
@@ -1,0 +1,190 @@
+# Pipeline definition in Konflux
+
+While our main pipelines are building from the default branches of our various
+repositories, we may need to create separate working branches from time to time,
+and want those branches to have their own CI pipelines to be able to build and
+release the corresponding code.
+
+This folder and the files it contains can be used to duplicate our default
+pipelines in Konflux, in order to manage such concurrent work.
+
+It is triggered by the need to work on a 1.10.2 release for specific need, while
+continuing the longer-term 1.11 work. We will keep the files in this folder
+for future reference in case we need to do it again.
+
+This follows the [Konflux documentation](https://konflux.pages.redhat.com/docs/users/patterns/managing-multiple-versions.html) for managing multiple versions of a product.
+
+## High-level process
+
+- define our pipelines in Konflux using the usual onboarding method
+  
+  This step is DONE for us, as can be seen in our application's definition in
+  our [Konflux instance](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/ose-osc-tenant/applications/openshift-sandboxed-containers)
+
+- prepare the project.yaml file
+  
+  This defines our `Project` for the project controller.
+  The file we have in this folder is a copy of the documentation's example,
+  modified with our project's name.
+
+- prepare the template.yaml file
+  
+  It defines the `ProjectDevelopmentStreamTemplate` for our project.
+  
+  This is the most important file, as it defines what our pipeline looks like.
+  It contains the definition for:
+  - applications
+  - components
+  - image repositories
+  
+  All those definitions must have parameterized names, so that we can use it to
+  create separate pipelines by giving it a different parameter (version typically).
+
+- prepare the devstream.yaml file
+  
+  It defines the `ProjectDevelopmentStream`, which is the representation of one
+  instance of our pipelines.
+  
+  This is the file that triggers the actual creation of the pipeline, using the
+  provided version as parameter.
+
+- apply the yaml files in order
+
+- create the branch in the various repositories.
+
+- create the ReleasePlan/ReleasePlanAdmission (can be done at a later time)
+
+> **Note:** Once the `Project` and `ProjectDevelopmentStreamTemplate` are set in our Konflux instance, we can just do the creation step. However, ensure that the existing template is up to date with our latest "main pipeline" definition, as it may evolve over time.
+>
+> The files in this folder reflect the status of our pipelines as of OSC release 1.10.1.
+
+## Prerequisite
+
+- Have a CLI access to the konflux instance we use.
+  See [documentation](https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html)
+
+## template.yaml
+
+The file contains the definition of our pipeline structure.
+In order to have a full build of Sandboxed Containers, we need:
+
+- the "openshift-sandboxed-containers" application, and all its components
+- the "osc-test-catalog" application, and the associated "osc-test-fbc" component
+- the integration tests associated with those two applications.
+  Note that the Enterprise Contract doesn't need to be in the template, as it is
+  created automatically for all components in Konflux.
+- a ReleasePlan allowing the release of the images built with the new pipeline
+
+For each of them, we extract the yaml definition found on the Konflux instance:
+```bash
+$ oc get application openshift-sandboxed-containers -o yaml > osc-app.yaml
+$ oc get component osc-operator -o yaml > osc-operator-comp.yaml
+$ ...
+```
+
+The resulting yaml files need to be edited (some lines removed, others edited)
+following the steps from the documentation.
+
+To keep things consistent, we are keeping the names of applications and components,
+and just add the version as a suffix.
+e.g: "osc-operator-bundle-{{.versionName}}"
+
+We're also going to assume that we use the same branch name for all repositories,
+in the format "osc-release-{{.version}}".
+
+This way, when we prepare the devstream.yaml file, we can provide the version
+we need (e.g: "v1.10") to create the pipelines that will build from the
+`osc-release-v1.10` branch of all our repositories.
+
+### Note about versions
+
+We have two parameters in the pipeline def (see "variables" in template.yaml):
+- .version
+- .versionName
+
+The first is the one we provide when we create a new stream.
+The second is set by default to a "hyphenized" version.
+E.g: when we set version to "v1.10", we get "v1-10" for versionName.
+
+The version name is meant to be used in kubernetes objects, where dot is not allowed.
+We're using it everywhere in the template to make sure the objects we create are
+unique, with their name based on the provided version.
+
+For the git branch though, we can use the "dot" character, and we probably prefer
+to use that rather than the hyphenized version.
+
+### About the build-dm-verity-image-task
+
+We have that application and component that is used to create the build task
+we use for building the dm-verity image.
+This task is not duplicated for now, as we expect the same task can be used
+for multiple versions of the dm-verity build.
+
+If we require specific versions of the tasks for specific versions of dm-verity,
+we may need to duplicate that too.
+
+>[NOTE (Julien - 2025/08/19)] the existing pipeline define a nudge from
+`osc-podvm-payload` to the `build-dm-verity-image-task`. But the resulting PRs
+are changing the `osc-podvm-payload` image reference in the `build-pipeline.yaml`
+file used by the `osc-dm-verity-image` component. And only that component gets rebuilt with it.
+>
+>I think the right nudge should target the `osc-dm-verity-image` component, with
+the same result as `build-dm-verity-image-task` and `osc-dm-verity-image` share
+the same repository.
+>
+>If this nudge really needs to happen, we'll need to duplicate the build task too.
+
+## Branching
+
+We need to make the branch with a version in its name, so that the pipelines can
+be differenciated.
+
+We also need to modify the the branch's `.tekton` files to make sure it has the
+same application' and component's names, otherwise the pipelines won't find their
+settings and won't be able to trigger.
+
+We can create the branch after the pipelines are created. And we should make a PR
+after it is created to validate the pipelines.
+The documentation recommends that this first PR contains the required .tekton file
+modifications.
+
+We need to add some changes of our own in this first PR, or right after:
+
+- update the kata-containers and guest-component submodules in cloud-api-adaptor,
+  to point to the HEAD of the new branch
+- update the cloud-api-adaptor submodule in sandboxed-containers, to point to the
+  HEAD of the new branch (after it's been updated with the right submodules)
+
+We also need to pay attention to the nudge PRs from podvm-payload to dm-verity,
+from all components to the bundle, and from the bundle to the test-fbc.
+Make sure the PRs are all created as expected, for the right component on the
+right branch.
+
+## ReleasePlan / ReleasePlanAdmission
+
+All of the previous steps allows to build and test from the new branch.
+To be able to release anything, we need to set the ReleasePlan and ReleasePlanAdmission
+
+This is basically the same as documented:
+
+- https://konflux.pages.redhat.com/docs/users/releasing/index.html
+- https://konflux.pages.redhat.com/docs/users/releasing/preparing-for-release.html
+
+But we can simplify it by using the same ReleasePlanAdmission, depending on
+what we want to release, and when.
+
+As long as we don't need to support different versions of the product at the same
+time, we don't need a separate ReleasePlanAdmission.
+
+At the time of creating these files, our goal is to release 1.10.2, then release 1.11.
+When we release 1.11, 1.10.2 will not be supported anymore, so we can keep using
+the same ReleasePlanAdmission.
+
+If we move to a multi-stream scenario and use the template in this folder to
+create the pipelines, we will need a separate RPA.
+
+When keeping the same RPA, we just need to edit the existing one with the following:
+
+- add the new application to the list of applications in the RPA
+  (e.g: "openshift-sandboxed-containers-v1-10)
+- add the new components to the list of components in the RPA

--- a/pipelinedef/README.md
+++ b/pipelinedef/README.md
@@ -36,6 +36,7 @@ This follows the [Konflux documentation](https://konflux.pages.redhat.com/docs/u
   - applications
   - components
   - image repositories
+  - integration tests
   
   All those definitions must have parameterized names, so that we can use it to
   create separate pipelines by giving it a different parameter (version typically).
@@ -54,14 +55,22 @@ This follows the [Konflux documentation](https://konflux.pages.redhat.com/docs/u
 
 - create the ReleasePlan/ReleasePlanAdmission (can be done at a later time)
 
-> **Note:** Once the `Project` and `ProjectDevelopmentStreamTemplate` are set in our Konflux instance, we can just do the creation step. However, ensure that the existing template is up to date with our latest "main pipeline" definition, as it may evolve over time.
+> **Note:**
 >
-> The files in this folder reflect the status of our pipelines as of OSC release 1.10.1.
+> - Once the `Project` and `ProjectDevelopmentStreamTemplate` are set in
+> our Konflux instance, we can just do the creation step as many times as needed.
+> However, ensure that  the existing template is up to date with our latest "main
+> pipeline" definition, as it may evolve over time.
+> - The `ProjectDevelopmentStream` object controls the creation and
+> deletion of the pipeline. Trying to delete the Applciations/Components/etc
+> from the Konflux UI or CLI is useless: they will be re-created by the project
+> manager.
 
 ## Prerequisite
 
 - Have a CLI access to the konflux instance we use.
   See [documentation](https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html)
+- Make sure you're using our namespace (ose-osc-tenant)
 
 ## template.yaml
 
@@ -76,6 +85,7 @@ In order to have a full build of Sandboxed Containers, we need:
 - a ReleasePlan allowing the release of the images built with the new pipeline
 
 For each of them, we extract the yaml definition found on the Konflux instance:
+
 ```bash
 $ oc get application openshift-sandboxed-containers -o yaml > osc-app.yaml
 $ oc get component osc-operator -o yaml > osc-operator-comp.yaml
@@ -96,9 +106,10 @@ This way, when we prepare the devstream.yaml file, we can provide the version
 we need (e.g: "v1.10") to create the pipelines that will build from the
 `osc-release-v1.10` branch of all our repositories.
 
-### Note about versions
+### Note about versions
 
 We have two parameters in the pipeline def (see "variables" in template.yaml):
+
 - .version
 - .versionName
 
@@ -133,6 +144,16 @@ the same result as `build-dm-verity-image-task` and `osc-dm-verity-image` share
 the same repository.
 >
 >If this nudge really needs to happen, we'll need to duplicate the build task too.
+
+>[NOTE (Julien - 2025/12/09)] the experience from the 1.10.x releases is that we
+>need to get the build-dm-verity-image-task duplicated too. The reason for that
+>is that otherwise, if the task diverge because of changes in the next dev cycle
+>the previous branch for dm-verity can't be built anymore, as the task doesn't
+>stay available.
+>Having two tasks and publishing them separately should help with that.
+>Now the problem is that they also need to be versioned, otherwise only one task
+>image will be kept (I think?).
+>This may require more info / help from the Konflux support.
 
 ## Branching
 

--- a/pipelinedef/devstream.yaml
+++ b/pipelinedef/devstream.yaml
@@ -1,11 +1,11 @@
 apiVersion: projctl.konflux.dev/v1beta1
 kind: ProjectDevelopmentStream
 metadata:
-  name: openshift-sandboxed-containers-1.10
+  name: openshift-sandboxed-containers-1-11
 spec:
   project: sandboxed-containers-project
   template:
     name: sandboxed-containers-template
     values:
     - name: version
-      value: "v1.10"
+      value: "v1.11"

--- a/pipelinedef/devstream.yaml
+++ b/pipelinedef/devstream.yaml
@@ -1,0 +1,11 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: openshift-sandboxed-containers-1.10
+spec:
+  project: sandboxed-containers-project
+  template:
+    name: sandboxed-containers-template
+    values:
+    - name: version
+      value: "v1.10"

--- a/pipelinedef/project.yaml
+++ b/pipelinedef/project.yaml
@@ -1,0 +1,12 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: Project
+metadata:
+  name: sandboxed-containers-project
+spec:
+  displayName: "This project is used to deploy sandboxed containers pipelines"
+  description: |
+    Most of the development for Sandboxed Containers happen in the default branch
+    of its repositories, releasing a new version every 6 months.
+    Now sometimes we need to release an intermediate version without stopping
+    work on the future longer term release.
+    This project is used to deploy pipelines that support such concurrent work.

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -143,6 +143,8 @@ spec:
       name: "osc-must-gather-{{.versionName}}"
     spec:
       application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
       componentName: "osc-must-gather-{{.versionName}}"
       resources: {}
       source:
@@ -199,6 +201,29 @@ spec:
     metadata:
       annotations:
         build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/confidential-compute-artifacts/pull/21","configuration-time":"Tue,
+          07 Oct 2025 10:17:19 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-pccs-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-pccs-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: containerfiles/pccs
+          dockerfileUrl: Containerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/confidential-compute-artifacts
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
         build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/689","configuration-time":"Thu,
           12 Jun 2025 09:18:36 UTC"},"message":"done"}'
         git-provider: github
@@ -239,6 +264,52 @@ spec:
           dockerfileUrl: podvm-payload/Dockerfile
           revision: "osc-release-{{.version}}"
           url: https://github.com/openshift/cloud-api-adaptor
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/confidential-compute-artifacts/pull/43","configuration-time":"Mon,
+          03 Nov 2025 11:57:18 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-storage-helper-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-storage-helper-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: containerfiles/storage-helper
+          dockerfileUrl: Containerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/confidential-compute-artifacts
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/confidential-compute-artifacts/pull/22","configuration-time":"Tue,
+          07 Oct 2025 10:23:37 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-tdx-qgs-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-tdx-qgs-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: containerfiles/tdx-qgs
+          dockerfileUrl: Containerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/confidential-compute-artifacts
 
   - apiVersion: appstudio.redhat.com/v1alpha1
     kind: Component
@@ -454,6 +525,26 @@ spec:
         image-controller.appstudio.redhat.com/update-component-image: 'true'
       labels:
         appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-pccs-{{.versionName}}"
+      name: "osc-pccs-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-pccs-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
         appstudio.redhat.com/component: "osc-podvm-builder-{{.versionName}}"
       name: "osc-podvm-builder-{{.versionName}}"
     spec:
@@ -479,6 +570,46 @@ spec:
     spec:
       image:
         name: "ose-osc-tenant/osc-podvm-payload-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-storage-helper-{{.versionName}}"
+      name: "osc-storage-helper-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-storage-helper-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-tdx-qgs-{{.versionName}}"
+      name: "osc-tdx-qgs-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-tdx-qgs-{{.versionName}}"
         visibility: public
       notifications:
       - config:

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -1,0 +1,475 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStreamTemplate
+metadata:
+  name: sandboxed-containers-template
+spec:
+  project: sandboxed-containers-project
+  variables:
+  - name: version
+    description: A version number for a new development stream
+  - name: versionName
+    description: A K8s-compliant name for the version
+    defaultValue: "{{hyphenize .version}}"
+
+  resources:
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "openshift-sandboxed-containers-{{.versionName}}"
+    spec:
+      displayName: "openshift-sandboxed-containers-{{.versionName}}"
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "osc-test-catalog-{{.versionName}}"
+    spec:
+      displayName: "osc-test-catalog-{{.versionName}}"
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/cloud-api-adaptor/pull/63","configuration-time":"Fri,
+          06 Jun 2025 13:07:39 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-caa-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-caa-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: src
+          dockerfileUrl: cloud-api-adaptor/Dockerfile.openshift
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/cloud-api-adaptor
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/cloud-api-adaptor/pull/64","configuration-time":"Fri,
+          06 Jun 2025 13:08:28 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-caa-webhook-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-caa-webhook-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: src/webhook
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/cloud-api-adaptor
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/confidential-devhub/coco-podvm-scripts/pull/8","configuration-time":"Wed,
+          11 Jun 2025 09:31:23 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-dm-verity-image-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-dm-verity-image-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/confidential-devhub/coco-podvm-scripts
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/kata-containers/pull/40","configuration-time":"Fri,
+          06 Jun 2025 13:09:05 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-monitor-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-monitor-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          dockerfileUrl: Dockerfile.monitor
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/kata-containers
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/680","configuration-time":"Fri,
+          06 Jun 2025 12:59:31 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-must-gather-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      componentName: "osc-must-gather-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: must-gather
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/sandboxed-containers-operator
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/681","configuration-time":"Fri,
+          06 Jun 2025 13:06:46 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-operator-bundle-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-test-fbc-{{.versionName}}"
+      componentName: "osc-operator-bundle-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          dockerfileUrl: bundle.Dockerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/sandboxed-containers-operator
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/679","configuration-time":"Fri,
+          06 Jun 2025 09:17:30 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-operator-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-operator-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/sandboxed-containers-operator
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/689","configuration-time":"Thu,
+          12 Jun 2025 09:18:36 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-podvm-builder-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      componentName: "osc-podvm-builder-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: config/peerpods/podvm
+          dockerfileUrl: Dockerfile.podvm-builder
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/sandboxed-containers-operator
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/cloud-api-adaptor/pull/65","configuration-time":"Fri,
+          06 Jun 2025 13:09:43 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-podvm-payload-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-operator-bundle-{{.versionName}}"
+      - "osc-dm-verity-image-{{.versionName}}"
+      componentName: "osc-podvm-payload-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          dockerfileUrl: podvm-payload/Dockerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/cloud-api-adaptor
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"fbc-builder","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/sandboxed-containers-operator/pull/711","configuration-time":"Fri,
+          20 Jun 2025 15:10:51 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "osc-test-fbc-{{.versionName}}"
+    spec:
+      application: "osc-test-catalog-{{.versionName}}"
+      componentName: "osc-test-fbc-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: fbc
+          dockerfileUrl: test-fbc/Dockerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/sandboxed-containers-operator
+
+    # ImageRepository is the object that links the component to a location on quay.io
+    # where the built images will be stored.
+    # We need to have a dedicated place for each component where its images will be placed,
+    # so we need to duplicate the ImageRepository objects along with the components.
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-caa-{{.versionName}}"
+      name: osc-caa-{{.versionName}}
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-caa-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-caa-webhook-{{.versionName}}"
+      name: "osc-caa-webhook-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-caa-webhook-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-dm-verity-image-{{.versionName}}"
+      name: "osc-dm-verity-image-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-dm-verity-image-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-monitor-{{.versionName}}"
+      name: "osc-monitor-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-monitor-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-must-gather-{{.versionName}}"
+      name: "osc-must-gather-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-must-gather-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-operator-bundle-{{.versionName}}"
+      name: "osc-operator-bundle-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-operator-bundle-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-operator-{{.versionName}}"
+      name: "osc-operator-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-operator-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-podvm-builder-{{.versionName}}"
+      name: "osc-podvm-builder-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-podvm-builder-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "openshift-sandboxed-containers-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-podvm-payload-{{.versionName}}"
+      name: "osc-podvm-payload-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-podvm-payload-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "osc-test-catalog-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-test-fbc-{{.versionName}}"
+      name: "osc-test-fbc-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-test-fbc-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  # IntegrationTestScenario
+  # NOTE: we don't need to duplicate the Enterprise Contract, as it will be
+  # created automatically when the ReleasePlan is created.
+  - apiVersion: appstudio.redhat.com/v1beta2
+    kind: IntegrationTestScenario
+    metadata:
+      labels:
+        test.appstudio.openshift.io/optional: "true"
+      name: "make-test-{{.versionName}}"
+    spec:
+      application: "openshift-sandboxed-containers-{{.versionName}}"
+      contexts:
+      - description: execute the integration test when component osc-operator updates
+        name: "component_osc-operator-{{.versionName}}"
+      resolverRef:
+        params:
+        - name: url
+          value: https://github.com/openshift/sandboxed-containers-operator
+        - name: revision
+          value: "osc-release-{{.version}}"
+        - name: pathInRepo
+          value: tests/make-test.yaml
+        resolver: git
+        resourceKind: pipeline

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -27,6 +27,13 @@ spec:
       displayName: "osc-test-catalog-{{.versionName}}"
 
   - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "build-definitions-{{.versionName}}"
+    spec:
+      displayName: "build-definitions-{{.versionName}}"
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
     kind: Component
     metadata:
       annotations:
@@ -244,6 +251,28 @@ spec:
           revision: "osc-release-{{.version}}"
           url: https://github.com/openshift/sandboxed-containers-operator
 
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"tekton-bundle-builder-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/confidential-devhub/coco-podvm-scripts/pull/15","configuration-time":"Thu,
+          17 Jul 2025 11:00:35 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "build-dm-verity-image-task-{{.versionName}}"
+    spec:
+      application: "build-definitions-{{.versionName}}"
+      build-nudges-ref:
+      - "osc-dm-verity-image-{{.versionName}}"
+      componentName: "build-dm-verity-image-task-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          context: task/build-dm-verity-image/0.1
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/confidential-devhub/coco-podvm-scripts/
+
     # ImageRepository is the object that links the component to a location on quay.io
     # where the built images will be stored.
     # We need to have a dedicated place for each component where its images will be placed,
@@ -441,6 +470,26 @@ spec:
     spec:
       image:
         name: "ose-osc-tenant/osc-test-fbc-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "build-definitions-{{.versionName}}"
+        appstudio.redhat.com/component: "build-dm-verity-image-task-{{.versionName}}"
+      name: "build-dm-verity-image-task-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/build-dm-verity-image-task-{{.versionName}}"
         visibility: public
       notifications:
       - config:

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -12,6 +12,7 @@ spec:
     defaultValue: "{{hyphenize .version}}"
 
   resources:
+  # Applications
   - apiVersion: appstudio.redhat.com/v1alpha1
     kind: Application
     metadata:
@@ -32,6 +33,15 @@ spec:
       name: "build-definitions-{{.versionName}}"
     spec:
       displayName: "build-definitions-{{.versionName}}"
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "osc-dm-verity-image-debug-{{.versionName}}"
+    spec:
+      displayName: "osc-dm-verity-image-debug-{{.versionName}}"
+
+  # Components
 
   - apiVersion: appstudio.redhat.com/v1alpha1
     kind: Component
@@ -273,6 +283,25 @@ spec:
           revision: "osc-release-{{.version}}"
           url: https://github.com/confidential-devhub/coco-podvm-scripts/
 
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/confidential-devhub/coco-podvm-scripts/pull/117","configuration-time":"Mon,
+          17 Nov 2025 15:31:45 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "build-dm-verity-image-task-{{.versionName}}"
+    spec:
+      application: "osc-dm-verity-image-debug-{{.versionName}}"
+      componentName: "osc-dm-verity-image-debug-{{.versionName}}"
+      resources: {}
+      source:
+        git:
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/confidential-devhub/coco-podvm-scripts/
+
     # ImageRepository is the object that links the component to a location on quay.io
     # where the built images will be stored.
     # We need to have a dedicated place for each component where its images will be placed,
@@ -490,6 +519,26 @@ spec:
     spec:
       image:
         name: "ose-osc-tenant/build-dm-verity-image-task-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "osc-dm-verity-image-debug-{{.versionName}}"
+        appstudio.redhat.com/component: "osc-dm-verity-image-debug-{{.versionName}}"
+      name: "osc-dm-verity-image-debug-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/osc-dm-verity-image-debug-{{.versionName}}"
         visibility: public
       notifications:
       - config:

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -702,3 +702,30 @@ spec:
           value: tests/make-test.yaml
         resolver: git
         resourceKind: pipeline
+
+  - apiVersion: appstudio.redhat.com/v1beta2
+    kind: IntegrationTestScenario
+    metadata:
+      annotations:
+        test.appstudio.openshift.io/finally_timeout: 1h
+        test.appstudio.openshift.io/pipeline_timeout: 5h
+        test.appstudio.openshift.io/tasks_timeout: 4h
+      labels:
+        test.appstudio.openshift.io/optional: "true"
+      name: "osc-test-catalog-integration-{{.versionName}}"
+    spec:
+      application: "osc-test-catalog-{{.versionName}}"
+      contexts:
+      - description: execute the integration test for a Snapshot created for a `push`
+          event
+        name: push
+      resolverRef:
+        params:
+        - name: url
+          value: https://github.com/openshift/sandboxed-containers-operator
+        - name: revision
+          value: "osc-release-{{.version}}"
+        - name: pathInRepo
+          value: tests/osc-test-fbc-integration.yaml
+        resolver: git
+        resourceKind: pipeline


### PR DESCRIPTION
This commit provides our pipeline definitions, that will allow us to duplicate
our pipelines in order to support concurrent work on different versions of OSC,
while having CI ready for each branch.

Those files are not part of the build, and are not used by the Konflux pipelines
directly. We need to "apply" them from the CLI to our Konflux instance when we
want to duplicate our pipeline for a building from a new branch.
I am commiting those files in our repo to keep them available, so that we can do
that process again in the future, if need be.

The README.md file provides background information, and the steps we need to follow.
