### PR TITLE
OSC on Managed Identities Cluster Support

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-01-08T14:32:12Z"
+    createdAt: "2026-02-16T11:35:51Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -21,9 +21,9 @@ metadata:
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "true"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=1.1.0 <1.11.2'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -451,6 +451,9 @@ spec:
                 - mountPath: /root/.ssh/
                   name: ssh
                   readOnly: true
+                - mountPath: /var/run/secrets/openshift/serviceaccount
+                  name: bound-sa-token
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -481,6 +484,12 @@ spec:
                   defaultMode: 384
                   optional: true
                   secretName: ssh-key-secret
+              - name: bound-sa-token
+                projected:
+                  sources:
+                  - serviceAccountToken:
+                      audience: openshift
+                      path: token
       - label:
           app: operator-metrics-server
         name: operator-metrics-server

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,6 +55,12 @@ spec:
             defaultMode: 384
             optional: true
             secretName: ssh-key-secret
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
       containers:
         - command:
             - /manager
@@ -64,6 +70,9 @@ spec:
           volumeMounts:
             - mountPath: /root/.ssh/
               name: ssh
+              readOnly: true
+            - mountPath: /var/run/secrets/openshift/serviceaccount
+              name: bound-sa-token
               readOnly: true
           envFrom:
             - secretRef:

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -20,9 +20,9 @@ metadata:
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "true"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=1.1.0 <1.11.2'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift

--- a/config/peerpods/credentials-requests/credentials_request_azure.yaml
+++ b/config/peerpods/credentials-requests/credentials_request_azure.yaml
@@ -15,3 +15,4 @@ spec:
       - role: Virtual Machine Contributor
       - role: Network Contributor
       - role: Storage Account Contributor
+      - role: Compute Gallery Artifacts Publisher

--- a/config/peerpods/podvm/azure-podvm-image-handler.sh
+++ b/config/peerpods/podvm/azure-podvm-image-handler.sh
@@ -35,7 +35,10 @@ function verify_vars() {
 
     # Ensure that the Azure specific values are set
     [[ -z "${AZURE_CLIENT_ID}" ]] && error_exit "AZURE_CLIENT_ID is empty"
-    [[ -z "${AZURE_CLIENT_SECRET}" ]] && error_exit "AZURE_CLIENT_SECRET is empty"
+    # Either AZURE_CLIENT_SECRET or AZURE_FEDERATED_TOKEN_FILE must be set
+    if [[ -z "${AZURE_CLIENT_SECRET}" && -z "${AZURE_FEDERATED_TOKEN_FILE}" ]]; then
+        error_exit "Either AZURE_CLIENT_SECRET or AZURE_FEDERATED_TOKEN_FILE must be set"
+    fi
     [[ -z "${AZURE_SUBSCRIPTION_ID}" ]] && error_exit "AZURE_SUBSCRIPTION_ID is empty"
     [[ -z "${AZURE_TENANT_ID}" ]] && error_exit "AZURE_TENANT_ID is empty"
 
@@ -132,11 +135,32 @@ function login_to_azure() {
     echo "Logging in to Azure"
     # If any error occurs, exit the script with an error message
 
-    az login --service-principal \
-        --user="${AZURE_CLIENT_ID}" \
-        --password="${AZURE_CLIENT_SECRET}" \
-        --tenant="${AZURE_TENANT_ID}" ||
-        error_exit "Failed to login to Azure"
+    if [[ -n "${AZURE_CLIENT_SECRET}" ]]; then
+        # Use client secret authentication
+        echo "Using client secret authentication"
+        az login --service-principal \
+            --user="${AZURE_CLIENT_ID}" \
+            --password="${AZURE_CLIENT_SECRET}" \
+            --tenant="${AZURE_TENANT_ID}" ||
+            error_exit "Failed to login to Azure"
+    elif [[ -n "${AZURE_FEDERATED_TOKEN_FILE}" ]]; then
+        # Use federated token authentication
+        echo "Using federated token authentication"
+
+        # Read the token from the file
+        [[ ! -f "${AZURE_FEDERATED_TOKEN_FILE}" ]] && error_exit "Federated token file ${AZURE_FEDERATED_TOKEN_FILE} does not exist"
+
+        FEDERATED_TOKEN=$(cat "${AZURE_FEDERATED_TOKEN_FILE}") ||
+            error_exit "Failed to read federated token from ${AZURE_FEDERATED_TOKEN_FILE}"
+
+        [[ -z "${FEDERATED_TOKEN}" ]] && error_exit "Federated token is empty"
+
+        az login --service-principal \
+            --user="${AZURE_CLIENT_ID}" \
+            --federated-token="${FEDERATED_TOKEN}" \
+            --tenant="${AZURE_TENANT_ID}" ||
+            error_exit "Failed to login to Azure using federated token"
+    fi
 
     echo "Selecting subscription"
     az account set --subscription ${AZURE_SUBSCRIPTION_ID} ||

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -97,11 +97,20 @@ spec:
             - name: containers-policy
               mountPath: /etc/containers/policy.json
               readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
       # Default is 30s which is too less for the preStop hook to fully execute        
       terminationGracePeriodSeconds: 180
       volumes:
         - name: payload
           emptyDir: {}
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
         - name: regauth
           secret:
             secretName: auth-json-secret

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -59,6 +59,9 @@ spec:
             - name: ssh-key-secret
               mountPath: "/root/.ssh/"
               readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
       volumes:
         - name: ssh-key-secret
           secret:
@@ -68,5 +71,11 @@ spec:
               path: "id_rsa"
             defaultMode: 0400
             optional: true
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
 
       restartPolicy: Never

--- a/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
@@ -29,5 +29,15 @@ spec:
                 name: aws-podvm-image-cm
                 optional: true
           command: ["/podvm-builder.sh", "delete-gallery", "-f"]
-
+          volumeMounts:
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
+      volumes:
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
       restartPolicy: Never

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -93,8 +93,8 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	} else if err != nil {
 		r.Log.Info("error in getting peer-pods secret", "err", err)
 		return ctrl.Result{Requeue: true}, nil
-	} else if !isSecretOwned(peerPodsSecret) { // Either STS workflow or user created secret
-		r.Log.Info("unowned peer-pods-secret exist, skipping CCO workflow...")
+	} else if !isCCOFlowSecret(peerPodsSecret) { // not a CCO created secret, shouldn't reach here
+		r.Log.Info("unexpected unowned peer-pods-secret exist, skipping CCO secret mapping flow...")
 		return ctrl.Result{}, nil
 	}
 
@@ -171,7 +171,7 @@ func (r *SecretReconciler) ccoDataMapping(ccoSecretData map[string][]byte) map[s
 	return peerPodsSecretData
 }
 
-func isSecretOwned(secret *corev1.Secret) bool {
+func isCCOFlowSecret(secret *corev1.Secret) bool {
 	if secret == nil {
 		return false
 	}
@@ -351,7 +351,7 @@ func (kh *KataConfigHandler) skipCredentialRequests() bool {
 		if !(k8serrors.IsNotFound(err) || k8serrors.IsGone(err)) {
 			kh.reconciler.Log.Info("failed to get peer-pods Secret skipping peer-pods Secret check", "error", err)
 		}
-	} else if !isControllerGenerated(peerPodsSecret) {
+	} else if !isCCOFlowSecret(peerPodsSecret) {
 		kh.reconciler.Log.Info("peerPodsSecret has already been created by the user, skipping...")
 		return true
 	}

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -79,7 +79,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	ccoSecret := &corev1.Secret{}
 	if err := r.Client.Get(context.TODO(), req.NamespacedName, ccoSecret); err != nil {
 		if k8serrors.IsNotFound(err) {
-			r.Log.Info("cco-secret not found")
+			r.Log.Info("no cco-secret has been found")
 			return ctrl.Result{}, nil
 		} else {
 			r.Log.Info("error in getting cco-secret", "err", err)
@@ -89,27 +89,23 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	peerPodsSecret, err := getPeerPodsSecret(r.Client)
 	if k8serrors.IsNotFound(err) {
-		peerPodsSecret = r.newOwnedPeerPodsSecret(ccoSecret)
+		r.Log.Info("peer-pods-secret is not found, trying to map cco-secret")
 	} else if err != nil {
 		r.Log.Info("error in getting peer-pods secret", "err", err)
 		return ctrl.Result{Requeue: true}, nil
-	}
-
-	// skip if peer-pods-secret was created by the user
-	if !isControllerGenerated(peerPodsSecret) {
-		r.Log.Info("peerPodsSecret has been created by the user, skipping...")
+	} else if !isSecretOwned(peerPodsSecret) { // Either STS workflow or user created secret
+		r.Log.Info("unowned peer-pods-secret exist, skipping CCO workflow...")
 		return ctrl.Result{}, nil
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, peerPodsSecret, func() error {
-		r.secretMapping(peerPodsSecret, ccoSecret)
-		return nil
-	}); err != nil {
+	peerpodsData := r.ccoDataMapping(ccoSecret.Data)
+	labels := map[string]string{labelCredentialsRequest: labelCredentialsRequestValue}
+	if err := r.createOrUpdateSecret(context.TODO(), peerPodsSecretName, OperatorNamespace, peerpodsData, ccoSecret, labels); err != nil {
 		r.Log.Info("error in creating or updating peer-pods secret", "err", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	r.Log.Info("cco-secret created and mapped to peer-pods secret", "CCO Secret", ccoSecret.GetName(), "Peer-Pods Secret", peerPodsSecret.GetName())
+	r.Log.Info("cco-secret created and mapped to peer-pods secret", "CCO Secret", ccoSecret.GetName(), "Peer-Pods Secret", peerPodsSecretName)
 	return ctrl.Result{}, nil
 }
 
@@ -144,8 +140,8 @@ func secretsFilterPredicate() predicate.Predicate {
 	}
 }
 
-// map ccoSecret fields to peer-pods compatible fields and set to peerPodsSecret
-func (r *SecretReconciler) secretMapping(peerPodsSecret *corev1.Secret, ccoSecret *corev1.Secret) {
+// map ccoSecret fields to peer-pods compatible fields
+func (r *SecretReconciler) ccoDataMapping(ccoSecretData map[string][]byte) map[string][]byte {
 	ccoToPp := map[string]string{
 		"aws_access_key_id":     "AWS_ACCESS_KEY_ID",
 		"aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",
@@ -159,40 +155,72 @@ func (r *SecretReconciler) secretMapping(peerPodsSecret *corev1.Secret, ccoSecre
 		//"azure_resourcegroup":   "AZURE_RESOURCE_GROUP",
 	}
 
-	if peerPodsSecret.Data == nil {
-		r.Log.Info("secretMapping: peerPodsSecret data is uninitialized")
-		return
+	if len(ccoSecretData) == 0 {
+		r.Log.Info("ccoDataMapping: ccoSecret data is uninitialized or empty")
+		return nil
 	}
 
-	if len(ccoSecret.Data) == 0 {
-		r.Log.Info("secretMapping: ccoSecret data is uninitialized or empty")
-		return
-	}
+	peerPodsSecretData := make(map[string][]byte)
 
 	// mapping is done explicitly to avoid conversion mistakes
-	for ccoKey, ppKey := range ccoSecret.Data {
+	for ccoKey, ppKey := range ccoSecretData {
 		if ccoToPp[ccoKey] != "" {
-			peerPodsSecret.Data[ccoToPp[ccoKey]] = ppKey
+			peerPodsSecretData[ccoToPp[ccoKey]] = ppKey
 		}
 	}
+	return peerPodsSecretData
 }
 
-func (r *SecretReconciler) newOwnedPeerPodsSecret(ownedSecret *corev1.Secret) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            peerPodsSecretName,
-			Namespace:       OperatorNamespace,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ownedSecret, corev1.SchemeGroupVersion.WithKind("Secret"))},
-			Labels: map[string]string{
-				labelCredentialsRequest: labelCredentialsRequestValue, // used to mark it's owned by a secret (cco-secret) created by cloud-credentials-operator
-			},
-		},
-		Data: make(map[string][]byte),
+func isSecretOwned(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
 	}
+	// Check if owned by cco-secret with controller=true
+	owner := metav1.GetControllerOf(secret)
+	return owner != nil && owner.Kind == "Secret" && owner.Name == credentialsRequestSecretRefName
 }
 
-func isControllerGenerated(secret *corev1.Secret) bool {
-	return secret != nil && secret.Labels != nil && secret.Labels[labelCredentialsRequest] == labelCredentialsRequestValue
+// createOrUpdateSecret creates or updates a Secret with the given data, optional owner, and optional labels
+// Parameters:
+//   - ctx: context for the operation
+//   - name: name of the Secret
+//   - namespace: namespace of the Secret
+//   - data: map of secret data (key-value pairs)
+//   - owner: optional owner object for setting owner reference (can be nil)
+//   - labels: optional map of labels to add to the Secret (can be nil)
+func (r *SecretReconciler) createOrUpdateSecret(ctx context.Context, name, namespace string, data map[string][]byte, owner client.Object, labels map[string]string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		// Set the data
+		secret.Data = data
+		secret.Type = corev1.SecretTypeOpaque
+
+		// Set labels if provided
+		if labels != nil {
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			for k, v := range labels {
+				secret.Labels[k] = v
+			}
+		}
+
+		// Set owner reference if provided
+		if owner != nil {
+			if err := controllerutil.SetOwnerReference(owner, secret, r.Scheme); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	return err
 }
 
 type KataConfigHandler struct {

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -54,6 +54,7 @@ const (
 	peerpodsCredentialsRequestFileFormat    = "credentials_request_%s.yaml"
 
 	// labelCredentialsRequest is to mark Secrets as created using cloud-credentials-operator
+	labelSTS                     = "kataconfiguration.openshift.io/sts"
 	labelCredentialsRequest      = "kataconfiguration.openshift.io/credentials-request-based"
 	labelCredentialsRequestValue = "true"
 )
@@ -68,10 +69,8 @@ const (
 // the following is not required by this controller, it's required by the AWS podvm creation scripts (ami-helper.sh)
 //+kubebuilder:rbac:groups=cloudcredential.openshift.io,resources=credentialsrequests,verbs=create;delete;get;list
 
-// Reconciles cco-secret secret based on the secretsFilterPredicate and maps the cco-secret
-// created by the cloud-credentials-operator to peer-pods compatible secret
-// KataConfigs are handled by the KataConfigHandler to create/delete credentialRequests from cloud-credentials-operator
-// see: https://github.com/openshift/cloud-credential-operator/tree/master?tab=readme-ov-file#openshift-cloud-credential-operator
+// Reconcile watches the cco-secret only (filtered by secretsFilterPredicate), its only role is to map
+// CCO provisioned credentials to the peer-pods-secret format.
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 	r.Log.Info("reconciling Secret for OpenShift Sandboxed Containers", "secret", req.Name)
@@ -171,6 +170,10 @@ func (r *SecretReconciler) ccoDataMapping(ccoSecretData map[string][]byte) map[s
 	return peerPodsSecretData
 }
 
+func isSTSFlowSecret(secret *corev1.Secret) bool {
+	return secret != nil && secret.Labels != nil && len(secret.Labels[labelSTS]) > 0
+}
+
 func isCCOFlowSecret(secret *corev1.Secret) bool {
 	if secret == nil {
 		return false
@@ -223,6 +226,7 @@ func (r *SecretReconciler) createOrUpdateSecret(ctx context.Context, name, names
 	return err
 }
 
+// KataConfigHandler handles KataConfig events and manages peer-pods credentials lifecycle
 type KataConfigHandler struct {
 	reconciler *SecretReconciler
 }
@@ -231,68 +235,185 @@ func (kh *KataConfigHandler) Generic(context.Context, event.GenericEvent, workqu
 	kh.reconciler.Log.Info("KataConfig Generic event")
 }
 
-// kataConfig created, create credentialRequest if peerPods enabled
+// kataConfig created, if peerPods enabled, initiate peer-pods credentials setup
 func (kh *KataConfigHandler) Create(ctx context.Context, event event.CreateEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	kh.reconciler.Log.Info("KataConfig Create event")
 	if !event.Object.(*kataconfigurationv1.KataConfig).Spec.EnablePeerPods {
 		return
 	}
 
-	// consider checking if user's secret exists
-	if err := kh.createCredentialsRequests(); err != nil {
-		kh.reconciler.Log.Info("error in creating credentialsRequests", "err", err) // invalid logging
+	if _, err := kh.setupPeerPodsCredentials(ctx); err != nil {
+		kh.reconciler.Log.Error(err, "error setting up peer-pods credentials")
 	}
-
 }
 
-// kataConfig updated, create/delete credentialRequest if peerPods enabled/disabled
+// kataConfig updated, if peerPods is enabled/disabled, initiate/teardown the peer-pods credentials setup
 func (kh *KataConfigHandler) Update(ctx context.Context, event event.UpdateEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	kh.reconciler.Log.Info("KataConfig Update event")
 	if event.ObjectNew.(*kataconfigurationv1.KataConfig).Spec.EnablePeerPods {
-		if err := kh.createCredentialsRequests(); err != nil {
-			kh.reconciler.Log.Info("error in creating credentialsRequests", "err", err)
+		if _, err := kh.setupPeerPodsCredentials(ctx); err != nil {
+			kh.reconciler.Log.Error(err, "error setting up peer-pods credentials")
 		}
 	} else {
-		if err := kh.deleteCredentialsRequests(); err != nil {
-			kh.reconciler.Log.Info("error in deleting credentialsRequests", "err", err)
+		if _, err := kh.teardownPeerPodsCredentials(ctx); err != nil {
+			kh.reconciler.Log.Error(err, "error tearing down peer-pods credentials")
 		}
 	}
 }
 
-// kataConfig deleted, delete credentialRequest if peerPods enabled
+// kataConfig deleted, if peerPods enabled, teardown peer-pods credentials setup
 func (kh *KataConfigHandler) Delete(ctx context.Context, event event.DeleteEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	kh.reconciler.Log.Info("KataConfig Delete event")
 	if !event.Object.(*kataconfigurationv1.KataConfig).Spec.EnablePeerPods {
 		return // try anyway?
 	}
-	if err := kh.deleteCredentialsRequests(); err != nil {
-		kh.reconciler.Log.Info("error in deleting credentialsRequests", "err", err)
+	if _, err := kh.teardownPeerPodsCredentials(ctx); err != nil {
+		kh.reconciler.Log.Info("error tearing down peer-pods credentials", "err", err)
 	}
 }
 
-// create credentialRequests for all supported providers
-func (kh *KataConfigHandler) createCredentialsRequests() error {
-	if kh.skipCredentialRequests() {
-		return nil
+// setupPeerPodsCredentials handles the complete credential setup flow for peer-pods.
+// Priority order: User-created -> STS workflow -> CCO workflow
+// Returns:
+//   - (true, nil) if credentials are set up successfully
+//   - (false, nil) if credentials already exist or no setup is needed
+//   - (false, error) if there's an error
+func (kh *KataConfigHandler) setupPeerPodsCredentials(ctx context.Context) (bool, error) {
+	// 1. Check if peer-pods-secret already exists
+	peerPodsSecret, err := getPeerPodsSecret(kh.reconciler.Client)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		kh.reconciler.Log.Info("error checking for existing peer-pods-secret", "err", err)
+		return false, err
 	}
 
+	// 2. If secret exists, skip (regardless of who created it)
+	if peerPodsSecret != nil {
+		kh.reconciler.Log.Info("peer-pods-secret already exists, skipping credentials setup")
+		return false, nil
+	}
+
+	// 3. Try STS workflow first (check environment variables)
+	stsConfigured, err := kh.checkAndSetupSTSWorkflow(ctx)
+	if err != nil {
+		return false, err
+	}
+	if stsConfigured {
+		kh.reconciler.Log.Info("STS workflow configured successfully")
+		return true, nil
+	}
+
+	// 4. Fall back to CCO workflow (CredentialsRequest)
+	kh.reconciler.Log.Info("Attempting CCO workflow for credential setup")
+	if err := kh.createCredentialsRequests(); err != nil {
+		kh.reconciler.Log.Error(err, "error creating CredentialsRequest")
+		return false, err
+	}
+
+	return true, nil
+}
+
+// teardownPeerPodsCredentials handles the cleanup of credentials when peer-pods is disabled.
+// Priority order: Delete STS secrets -> Delete CCO CredentialsRequest (CCO secrets auto-deleted via owner reference)
+// Returns:
+//   - (true, nil) if credentials were cleaned up successfully
+//   - (false, nil) if no cleanup was needed
+//   - (false, error) if there's an error
+func (kh *KataConfigHandler) teardownPeerPodsCredentials(ctx context.Context) (bool, error) {
+	// 1. Check if peer-pods-secret exists
+	peerPodsSecret, err := getPeerPodsSecret(kh.reconciler.Client)
+	if err != nil && !k8serrors.IsNotFound(err) && !k8serrors.IsGone(err) {
+		kh.reconciler.Log.Info("error checking for peer-pods-secret", "err", err)
+	}
+
+	// 2. Handle STS flow secrets (they don't have owner references and need manual cleanup)
+	if peerPodsSecret != nil && isSTSFlowSecret(peerPodsSecret) {
+		kh.reconciler.Log.Info("Deleting STS flow peer-pods-secret")
+		if err := kh.reconciler.Client.Delete(ctx, peerPodsSecret); err != nil {
+			if !k8serrors.IsNotFound(err) && !k8serrors.IsGone(err) {
+				kh.reconciler.Log.Error(err, "Failed to delete STS flow peer-pods-secret")
+				return false, err
+			}
+		}
+		kh.reconciler.Log.Info("STS flow peer-pods-secret deleted successfully")
+	}
+
+	// 3. Delete CredentialsRequest (for CCO workflow)
+	kh.reconciler.Log.Info("Attempting to delete CredentialsRequest if exist")
+	if err := kh.deleteCredentialsRequests(); err != nil {
+		kh.reconciler.Log.Error(err, "error deleting CredentialsRequest")
+		return false, err
+	}
+
+	return true, nil
+}
+
+// checkAndSetupSTSWorkflow checks if STS (Security Token Service) workflow environment variables
+// are set and creates/updates the peer-pods-secret accordingly.
+// Currently supports Azure only.
+// Returns true if STS workflow is detected and secret was created/updated successfully.
+// Returns false if no STS environment variables are found or if there's an error.
+func (kh *KataConfigHandler) checkAndSetupSTSWorkflow(ctx context.Context) (bool, error) {
+	// STS environment variables (from OLM/web console installation)
+	// Reference: https://github.com/openshift/enhancements/pull/1800
+
+	// Azure
+	clientID := os.Getenv("CLIENTID")             // Azure client ID
+	tenantID := os.Getenv("TENANTID")             // Azure tenant ID
+	subscriptionID := os.Getenv("SUBSCRIPTIONID") // Azure subscription ID
+	tokenPath := "/var/run/secrets/openshift/serviceaccount/token"
+
+	// Check if Azure STS credentials are provided
+	hasAzureSTSCreds := len(clientID) > 0 && len(tenantID) > 0 && len(subscriptionID) > 0
+
+	// Label to mark this as an STS-based secret
+	labels := map[string]string{
+		labelSTS: "",
+	}
+	secretData := map[string][]byte{}
+	if hasAzureSTSCreds {
+		kh.reconciler.Log.Info("STS workflow detected, creating peer-pods-secret")
+		secretData["AZURE_CLIENT_ID"] = []byte(clientID)
+		secretData["AZURE_TENANT_ID"] = []byte(tenantID)
+		secretData["AZURE_SUBSCRIPTION_ID"] = []byte(subscriptionID)
+		secretData["AZURE_FEDERATED_TOKEN_FILE"] = []byte(tokenPath)
+		labels[labelSTS] = "azure"
+	} else {
+		// No STS credentials found
+		return false, nil
+	}
+
+	// Create or update the peer-pods-secret with STS credentials
+	if err := kh.reconciler.createOrUpdateSecret(ctx, peerPodsSecretName, OperatorNamespace, secretData, nil, labels); err != nil {
+		kh.reconciler.Log.Error(err, "Failed to create/update peer-pods-secret for STS workflow")
+		return false, err
+	}
+
+	kh.reconciler.Log.Info("Successfully created/updated peer-pods-secret for STS workflow")
+	return true, nil
+}
+
+// create credentialRequests for all supported providers
+// Note: Caller is responsible for checking if peer-pods-secret already exists
+func (kh *KataConfigHandler) createCredentialsRequests() error {
 	credentialsRequest, err := kh.getCredentialsRequest()
 	if err != nil {
 		return err
 	}
 
 	if credentialsRequest == nil {
-		return nil // skip silently
+		kh.reconciler.Log.Info("No CredentialsRequest YAML for this cloud provider")
+		return nil
 	}
 
 	if err := kh.reconciler.Client.Create(context.TODO(), credentialsRequest); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
+			kh.reconciler.Log.Info("CredentialsRequest already exists", "name", credentialsRequest.Name)
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
-	kh.reconciler.Log.Info("credentialRequest created", "credentialsRequestName", credentialsRequest.Name)
+
+	kh.reconciler.Log.Info("CredentialsRequest created", "name", credentialsRequest.Name)
 	return nil
 }
 
@@ -343,27 +464,4 @@ func (kh *KataConfigHandler) getCredentialsRequest() (*v1.CredentialsRequest, er
 		return nil, err
 	}
 	return credentialsRequest, nil
-}
-
-func (kh *KataConfigHandler) skipCredentialRequests() bool {
-	// check if peer-pods secret was already created by the user
-	if peerPodsSecret, err := getPeerPodsSecret(kh.reconciler.Client); err != nil {
-		if !(k8serrors.IsNotFound(err) || k8serrors.IsGone(err)) {
-			kh.reconciler.Log.Info("failed to get peer-pods Secret skipping peer-pods Secret check", "error", err)
-		}
-	} else if !isCCOFlowSecret(peerPodsSecret) {
-		kh.reconciler.Log.Info("peerPodsSecret has already been created by the user, skipping...")
-		return true
-	}
-
-	// check if CredentialsRequest implementation exists for the cloud provider
-	if provider, err := getCloudProviderFromInfra(kh.reconciler.Client); err == nil {
-		fileName := fmt.Sprintf(peerpodsCredentialsRequestFileFormat, provider)
-		credentialsRequestsYamlFile := filepath.Join(peerpodsCredentialsRequestsPathLocation, fileName)
-		if _, err := readYamlFile(credentialsRequestsYamlFile); os.IsNotExist(err) {
-			kh.reconciler.Log.Info("no CredentialsRequest yaml file for provider, skipping", "provider", provider, "filename", fileName)
-			return true
-		}
-	}
-	return false
 }

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -614,7 +614,9 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 	// aws ConfigMap Keys
 	awsConfigMapKeys := []string{"AWS_REGION", "AWS_SUBNET_ID", "AWS_VPC_ID", "AWS_SG_IDS", "CLOUD_PROVIDER"}
 	// azure Secret Keys
-	azureSecretKeys := []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID"}
+	azureSecretKeys := []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_SUBSCRIPTION_ID", "AZURE_CLIENT_SECRET"}
+	// azure Secret Keys for Federated Token Authentication
+	azureSecretFederatedKeys := []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_SUBSCRIPTION_ID", "AZURE_FEDERATED_TOKEN_FILE"}
 	// azure ConfigMap Keys
 	azureConfigMapKeys := []string{"AZURE_RESOURCE_GROUP", "AZURE_REGION", "CLOUD_PROVIDER"}
 	// gcp Secret Keys
@@ -645,7 +647,7 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 
 	case "azure":
 		// Check if azure Secret Keys are present in the peerPodsSecret
-		if !checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretKeys) {
+		if !(checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretKeys) || checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretFederatedKeys)) {
 			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-secret Secret")
 		}
 

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -237,6 +237,44 @@ func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.Daem
 		}
 
 		return nil
+	case AzureProvider:
+		// Only add bound-sa-token volume for Azure federated identity if using STS flow
+		// Check for all STS environment variables (set during OLM installation)
+		hasAzureSTSCreds := os.Getenv("CLIENTID") != "" && os.Getenv("TENANTID") != "" && os.Getenv("SUBSCRIPTIONID") != ""
+		if hasAzureSTSCreds {
+			r.Log.Info("STS flow detected for Azure, adding bound-sa-token volume mount")
+			boundSATokenVolume := corev1.Volume{
+				Name: "bound-sa-token",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{
+								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+									Path:     "token",
+									Audience: "openshift",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			boundSATokenVolumeMount := corev1.VolumeMount{
+				MountPath: "/var/run/secrets/openshift/serviceaccount",
+				Name:      "bound-sa-token",
+				ReadOnly:  true,
+			}
+
+			ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, boundSATokenVolume)
+			for i := range ds.Spec.Template.Spec.Containers {
+				container := &ds.Spec.Template.Spec.Containers[i]
+				if container.Name == "caa-pod" {
+					container.VolumeMounts = append(container.VolumeMounts, boundSATokenVolumeMount)
+				}
+			}
+		}
+
+		return nil
 	default:
 		return nil
 	}

--- a/docs/credentials-handling.md
+++ b/docs/credentials-handling.md
@@ -1,0 +1,193 @@
+# Peer-Pods Credentials Handling
+
+This document describes the three credential flows available for providing cloud credentials to the OpenShift Sandboxed Containers Operator for peer-pods functionality.
+
+## Overview
+
+The operator supports three distinct flows for obtaining cloud credentials, evaluated in priority order:
+
+1. **User-created secret** (highest priority)
+2. **STS workflow** (Workload identity via federated tokens)
+3. **CCO workflow** (Cloud Credential Operator - fallback)
+
+The credential flow selection happens automatically in `setupPeerPodsCredentials()` during KataConfig creation or update when `enablePeerPods: true`.
+
+## Flow 1: User-Created Secret (Manual)
+
+**Priority**: Highest
+
+**Supported Providers**: All
+
+### Description
+Users manually create the `peer-pods-secret` in the `openshift-sandboxed-containers-operator` namespace with cloud provider credentials.
+
+### User Guide
+#### Credentials Setup
+1. At configuration time (before deploying KataConfig), create `peer-pods-secret` with cloud credentials as follows:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: peer-pods-secret
+  namespace: openshift-sandboxed-containers-operator
+type: Opaque
+data:
+  # Azure example
+  AZURE_CLIENT_ID: <base64-encoded-client-id>
+  AZURE_CLIENT_SECRET: <base64-encoded-client-secret>
+  AZURE_TENANT_ID: <base64-encoded-tenant-id>
+  AZURE_SUBSCRIPTION_ID: <base64-encoded-subscription-id>
+```
+
+#### Credentials Cleanup
+1. Delete the secret when no longer needed:
+```
+oc delete secret/peer-pods-secret -n openshift-sandboxed-containers-operator
+```
+
+
+### How it works
+1. User creates `peer-pods-secret` with required cloud credentials
+2. Operator detects the existing secret and skips automated credential setup
+3. Secret persists until manually deleted by the user
+
+---
+
+## Flow 2: STS Workflow (Workload Identity)
+
+**Priority**: Second (if user's secret was not created)
+
+**Supported Providers**: Azure
+
+### Description
+When the cluster is in workload/federated identitiy mode and an identity was provided during OLM installation (when applying the subscription), the operator uses Azure Workload Identity (federated tokens) for authentication without long-lived secrets.
+
+The operator reads environment variables set during OLM installation and creates a secret pointing to the projected service account token.
+
+Reference: [OpenShift Enhancement Proposal #1800](https://github.com/openshift/enhancements/pull/1800)
+
+### User Guide
+#### Credentials Setup
+1. Create an identity within your RG
+```
+IDENTITY_NAME=<identity name>
+RESOURCE_GROUP=<the RG you have created at cluster creation>
+LOCATION=<cluster's location>
+az identity create --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --location $LOCATION
+```
+2. Grant the required permissions to the created identity
+```
+CLIENT_ID=$(az identity show  --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --query clientId -o tsv)
+TENANT_ID=$(az identity show  --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --query tenantId -o tsv)
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+ROLES=("Reader" "Virtual Machine Contributor" "Network Contributor" "Storage Account Contributor" "Compute Gallery Artifacts Publisher")
+for r in "${ROLES[@]}"; do az role assignment create --assignee "$CLIENT_ID" --role "$r" --scope "/subscriptions/$SUBSCRIPTION_ID"; done
+```
+3. Create an Azure federated identity credential that links the service account in OpenShift Container Platform to the Azure user-assigned managed identity
+```
+ISSUER=$(oc get authentication.config.openshift.io cluster -o jsonpath='{.spec.serviceAccountIssuer}')
+az identity federated-credential create  --name $IDENTITY_NAME-federation  --identity-name $IDENTITY_NAME --issuer $ISSUER --subject system:serviceaccount:openshift-sandboxed-containers-operator:default -g $RESOURCE_GROUP --audiences openshift
+```
+4. Follow OSC installation instructions. At Subscription creation, you'll need to provide Client ID, Tenant ID, and Subscription ID from above (also when installing from the web console).
+Also, it is recommended to use a manual install plan
+```
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sandboxed-containers-operator
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  config:
+    env:
+    - name: CLIENTID
+      value: ${CLIENT_ID}
+    - name: TENANTID
+      value: ${TENANT_ID}
+    - name: SUBSCRIPTIONID
+      value: ${SUBSCRIPTION_ID}
+  installPlanApproval: Manual
+  channel: stable
+  name: sandboxed-containers-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: sandboxed-containers-operator.v1.12.0
+```
+5. Continue following the OSC installation instructions while making sure your created RG is always the one used (the one in use also above), in peer-pods-cm and in configuring the default worker subnet
+
+#### Credentials Cleanup
+1. Delete the identity when you delete OSC:
+```
+az identity delete --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --location $LOCATION
+```
+### How it works
+
+**Setup Flow:**
+1. User creates an identity within their resource group
+2. User assigns the required roles to this identity (based on what CAA/Job need to do)
+3. User creates a federated identity credential that points to the cluster's OIDC issuer (this is the identity provider created by ARO/ccoctl with the cluster as the signer). This tells Azure (Entra ID) to trust this issuer (which provides the cluster's signature) for this subject for certain roles and audience.
+4. During operator installation via OLM/web console, user provides the following:
+   - Azure Client ID (CLIENTID)
+   - Azure Tenant ID (TENANTID)
+   - Azure Subscription ID (SUBSCRIPTIONID)
+5. Setup: On KataConfig creation, the operator consumes the variables and creates `peer-pods-secret` and mounts the service account projected volume
+   with federated token configuration:
+   ```yaml
+   AZURE_CLIENT_ID: <from-env>
+   AZURE_TENANT_ID: <from-env>
+   AZURE_SUBSCRIPTION_ID: <from-env>
+   AZURE_FEDERATED_TOKEN_FILE: /var/run/secrets/openshift/serviceaccount/token
+   ```
+6. Token fetching: CAA DaemonSet and image jobs consume the federated signed Kubernetes token from the projected service account token file.
+7. Exchange: Azure's SDK used by the jobs/CAA code sends this token to Microsoft Entra ID
+8. Validation: Entra ID checks if it "trusts" the cluster that issued this token
+9. Access: If the trust is verified, Entra ID exchanges the Kubernetes token for an Azure Access Token, which is used to perform whatever is allowed under the defined roles (e.g., create image, create VM, etc.)
+
+**Cleanup Flow:**
+1. On KataConfig deletion or `enablePeerPods: false`:
+   - Operator identifies STS secret by its label and deletes `peer-pods-secret`
+
+### Identification
+- Secret is labeled with `kataconfiguration.openshift.io/sts: azure`
+
+---
+
+## Flow 3: CCO Workflow (Cloud Credential Operator)
+
+**Priority**: Third (fallback, automatic)
+
+**Supported Providers**: AWS, Azure, GCP
+
+### Description
+Leverages OpenShift's Cloud Credential Operator to dynamically provision cloud credentials. The operator creates a CredentialsRequest, CCO provisions credentials, and the credentials controller translates them to the peer-pods format.
+
+### User Guide
+#### Credentials Setup
+1. The peer-pods-secret will be created automatically
+#### Credentials Cleanup
+1. The peer-pods-secret will be deleted automatically
+
+
+### How it works
+
+**Setup Flow:**
+1. KataConfig created with enablePeerPods: true
+2. credentials-controller creates CredentialsRequest for provider
+3. CCO creates cco-secret in response to CredentialsRequest
+4. credentials-controller triggered by cco-secret creation
+5. credentials-controller translates cco-secret to peer-pods-secret
+6. peer-pods-secret owned by cco-secret (via OwnerReference)
+
+**Cleanup Flow:**
+1. KataConfig deleted or enablePeerPods: false
+2. credentials-controller deletes CredentialsRequest
+3. CCO deletes cco-secret
+4. Garbage Collector deletes owned peer-pods-secret
+
+### Identification
+CCO-created secrets are identified by:
+- Owner reference: controlled by `cco-secret`
+- Kind: `Secret`
+- Name: `cco-secret`
+
+---


### PR DESCRIPTION
**This pr add workload identities support for OSC in ARO clusters.**

**Testing catalog (OSC 1.11.1)**  : quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:on-pr-7814d09d32e92712a49d3adc979c997e336c48dc

# OSC on Managed Identities Cluster Workflow:
1. Create an ARO [cluster with managed identities](https://learn.microsoft.com/en-us/azure/openshift/howto-create-openshift-cluster?pivots=aro-az-cli) or [enable Entra ID on existing self-managed cluster](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/postinstallation_configuration/changing-cloud-credentials-configuration#enabling-entra-workload-id-existing-cluster_changing-cloud-credentials-configuration)
2. Create an identity in the RG you have created:
```
MID=created-identity 
az identity create --name $MID --resource-group $RESOURCEGROUP --location $LOCATION
CLIENT_ID=$(az identity show  --name $MID --resource-group $RESOURCEGROUP --query clientId -o tsv)
TENANT_ID=$(az identity show  --name $MID --resource-group $RESOURCEGROUP --query tenantId -o tsv)
SUB_ID=$(az account show --query id -o tsv)
```
3. Grant the required permission to the created identity
```
ROLES=("Reader" "Virtual Machine Contributor" "Network Contributor" "Storage Account Contributor" "Compute Gallery Artifacts Reader")
for r in "${ROLES[@]}"; do az role assignment create --assignee "$CLIENT_ID" --role "$r" --scope "/subscriptions/$SUB_ID"; done
```
4. Create an Azure federated identity credential that links the service account in OpenShift Container Platform to the Azure user-assigned managed identity
```
az identity federated-credential create  --name $MID-federation  --identity-name $MID --issuer $(oc get authentication.config.openshift.io cluster -o jsonpath='{.spec.serviceAccountIssuer}') --subject system:serviceaccount:openshift-sandboxed-containers-operator:default -g $RESOURCEGROUP --audiences openshift
```
5. Configure the [default workers subnet](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.11/html/deploying_red_hat_openshift_sandboxed_containers/deploying-osc_azure-osc#outbound-connections_azure-osc) (make sure to use your RG, not the cluster’s one as instucted)
6. Install custom OSC catalog (quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:on-pr-7814d09d32e92712a49d3adc979c997e336c48dc)
7. install operator though the UI, in subscription page you'll be required to provide the identity values `az identity show  --name $MID --resource-group $RESOURCEGROUP`
8. Set peer-pods-cm with the the RG used above
9. install kataConfig with peerpods enabled.



## Main Test Cases:
1. Standard Peer pods workflow can be fully executed on a managed-identities ARO cluster
2. No regression standard use cases (CCO created secret and provided peer-pods-secert)



# TODO after MERGE
**render.sh should be executed after this PR (and updated bundle PR) is merged in order to create the working catalogs**