### PR TITLE
osc-release-v1.10: update the tekton files with new IDs

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -5,31 +5,31 @@ metadata:
 spec:
   imageTagMirrors:
     - mirrors:
-      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
     - mirrors:
-      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
 ---
 apiVersion: config.openshift.io/v1
@@ -39,29 +39,29 @@ metadata:
 spec:
   imageDigestMirrors:
     - mirrors:
-      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
     - mirrors:
-      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle
     - mirrors:
-        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image

--- a/.tekton/osc-must-gather-pull-request.yaml
+++ b/.tekton/osc-must-gather-pull-request.yaml
@@ -8,11 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "devel" && ( "must-gather/***".pathChanged() || ".tekton/osc-must-gather-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.10" && ( "must-gather/***".pathChanged() || ".tekton/osc-must-gather-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-must-gather
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-must-gather-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-must-gather-on-pull-request
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -615,7 +615,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-must-gather
+    serviceAccountName: build-pipeline-osc-must-gather-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-must-gather-push.yaml
+++ b/.tekton/osc-must-gather-push.yaml
@@ -7,11 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && ( "must-gather/***".pathChanged() || ".tekton/osc-must-gather-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.10" && ( "must-gather/***".pathChanged() || ".tekton/osc-must-gather-push.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-must-gather
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-must-gather-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-must-gather-on-push
   namespace: ose-osc-tenant
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -612,7 +612,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-must-gather
+    serviceAccountName: build-pipeline-osc-must-gather-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -8,11 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "devel" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.10" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator-bundle
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-operator-bundle-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-operator-bundle-on-pull-request
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -603,7 +603,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator-bundle
+    serviceAccountName: build-pipeline-osc-operator-bundle-v1-10
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -8,11 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.10" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator-bundle
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-operator-bundle-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-operator-bundle-on-push
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10:{{revision}}
   - name: dockerfile
     value: bundle.Dockerfile
   pipelineSpec:
@@ -601,7 +601,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator-bundle
+    serviceAccountName: build-pipeline-osc-operator-bundle-v1-10
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -10,15 +10,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.10" &&
       files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-operator-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-operator-on-pull-request
   namespace: ose-osc-tenant
@@ -29,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -617,7 +617,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator
+    serviceAccountName: build-pipeline-osc-operator-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -9,15 +9,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.10" &&
       files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-operator-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-operator-on-push
   namespace: ose-osc-tenant
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -614,7 +614,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator
+    serviceAccountName: build-pipeline-osc-operator-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-builder-pull-request.yaml
+++ b/.tekton/osc-podvm-builder-pull-request.yaml
@@ -8,11 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "devel" && ( "config/peerpods/podvm/***".pathChanged() || ".tekton/osc-podvm-builder-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.10" && ( "config/peerpods/podvm/***".pathChanged() || ".tekton/osc-podvm-builder-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-builder
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-podvm-builder-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-podvm-builder-on-pull-request
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -617,7 +617,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-builder
+    serviceAccountName: build-pipeline-osc-podvm-builder-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-builder-push.yaml
+++ b/.tekton/osc-podvm-builder-push.yaml
@@ -7,11 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && ( "config/peerpods/podvm/***".pathChanged() || ".tekton/osc-podvm-builder-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.10" && ( "config/peerpods/podvm/***".pathChanged() || ".tekton/osc-podvm-builder-push.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-builder
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-podvm-builder-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-podvm-builder-on-push
   namespace: ose-osc-tenant
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -614,7 +614,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-builder
+    serviceAccountName: build-pipeline-osc-podvm-builder-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-test-fbc-pull-request.yaml
+++ b/.tekton/osc-test-fbc-pull-request.yaml
@@ -9,11 +9,11 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "devel" && ( "fbc/test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-pull-request.yaml".pathChanged() )
+      == "osc-release-v1.10" && ( "fbc/test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: osc-test-catalog
-    appstudio.openshift.io/component: osc-test-fbc
+    appstudio.openshift.io/application: osc-test-catalog-v1-10
+    appstudio.openshift.io/component: osc-test-fbc-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-test-fbc-on-pull-request
   namespace: ose-osc-tenant
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -400,7 +400,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-test-fbc
+    serviceAccountName: build-pipeline-osc-test-fbc-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -8,11 +8,11 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "devel" && ( "fbc/test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-push.yaml".pathChanged() )
+      == "osc-release-v1.10" && ( "fbc/test-fbc/***".pathChanged() || "fbc/render.sh".pathChanged() || ".tekton/osc-test-fbc-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: osc-test-catalog
-    appstudio.openshift.io/component: osc-test-fbc
+    appstudio.openshift.io/application: osc-test-catalog-v1-10
+    appstudio.openshift.io/component: osc-test-fbc-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-test-fbc-on-push
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -399,7 +399,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-test-fbc
+    serviceAccountName: build-pipeline-osc-test-fbc-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -33,8 +33,8 @@ spec:
             WARNINGS=0
 
             dnf -y install jq git make go
-            srcURL=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.url' <<< "${SNAPSHOT}")
-            srcREV=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.revision' <<< "${SNAPSHOT}")
+            srcURL=$(jq -r '.components[] | select(.name=="osc-operator-v1-10") | .source.git.url' <<< "${SNAPSHOT}")
+            srcREV=$(jq -r '.components[] | select(.name=="osc-operator-v1-10") | .source.git.revision' <<< "${SNAPSHOT}")
 
             git clone ${srcURL} sources
             cd sources


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.
