### PR TITLE
osc-release-v1.10: update the bundle image with latest builds

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -391,17 +391,17 @@ spec:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
                 - name: RELATED_IMAGE_KATA_MONITOR
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:9e297de3d963cb5ebd80a609f848ee716eb1dedb0ee6cc76f523d7fe9005a167
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:cce42890434fcbc9e9401aa9f1255e90ad07b545fa7aa89678c6e0ef34e444cd
                 - name: RELATED_IMAGE_CAA
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:d4973b793f3af9d9df3da45417082f77dc991e734ea9cf3d132aaf2d7def9552
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:9cd8d2068f3161fe1f904e7b832b58a7dd90d620a8bc58092ebbe2e7f5a12037
                 - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:ef4a8efcfb74e3e6b68fe3c566b343ac5da0a4d1de203342c46defae60029a81
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:97d0e8e547332adc4b6f4c2524592311d063e467c3739af8aa953d09a5b199a2
                 - name: RELATED_IMAGE_PODVM_BUILDER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:8d23df1699f72afcf5cec8734d6c5d3b92ce432fcb488909e967380c74068a8a
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:5a000e0476bb1e6c2179c0bde811bb73166393660ffe30639f1b3a3f304c5150
                 - name: RELATED_IMAGE_PODVM_PAYLOAD
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:d9b2ac90fd3663310a9160bcb232e1e7039869838d77c3509464b558d56f4142
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:f615e0fc32a197c96c472eb3d7bdd113afacb141178b6117c95a8ee2b9188558
                 - name: RELATED_IMAGE_PODVM_OCI
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:3ae0ddf604a57a9f5a16d023e03f9d5060312e4d153e72ff2b537107a06ebf60
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:9dc6c17d1b8874e6d7771ba62b6361b67f34e367e29182da09dbb0c27896be52
                 envFrom:
                 - secretRef:
                     name: peer-pods-secret
@@ -409,7 +409,7 @@ spec:
                 - configMapRef:
                     name: peer-pods-cm
                     optional: true
-                image: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:4fb018ce03cfaa06b983e801508036352247d3f9fc09981949f85b7e8ab4520b
+                image: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:387f27bfc70c67c242b02fe2ed603c6c86550bf9c3dd3a961e03c052b1200861
                 imagePullPolicy: Always
                 name: manager
                 ports:
@@ -482,7 +482,7 @@ spec:
               containers:
               - command:
                 - /metrics-server
-                image: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:4fb018ce03cfaa06b983e801508036352247d3f9fc09981949f85b7e8ab4520b
+                image: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:387f27bfc70c67c242b02fe2ed603c6c86550bf9c3dd3a961e03c052b1200861
                 name: metrics-server
                 ports:
                 - containerPort: 8091
@@ -548,17 +548,17 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:9e297de3d963cb5ebd80a609f848ee716eb1dedb0ee6cc76f523d7fe9005a167
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:cce42890434fcbc9e9401aa9f1255e90ad07b545fa7aa89678c6e0ef34e444cd
     name: kata-monitor
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:d4973b793f3af9d9df3da45417082f77dc991e734ea9cf3d132aaf2d7def9552
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:9cd8d2068f3161fe1f904e7b832b58a7dd90d620a8bc58092ebbe2e7f5a12037
     name: caa
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:ef4a8efcfb74e3e6b68fe3c566b343ac5da0a4d1de203342c46defae60029a81
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:97d0e8e547332adc4b6f4c2524592311d063e467c3739af8aa953d09a5b199a2
     name: peerpods-webhook
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:8d23df1699f72afcf5cec8734d6c5d3b92ce432fcb488909e967380c74068a8a
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:5a000e0476bb1e6c2179c0bde811bb73166393660ffe30639f1b3a3f304c5150
     name: podvm-builder
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:d9b2ac90fd3663310a9160bcb232e1e7039869838d77c3509464b558d56f4142
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:f615e0fc32a197c96c472eb3d7bdd113afacb141178b6117c95a8ee2b9188558
     name: podvm-payload
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:3ae0ddf604a57a9f5a16d023e03f9d5060312e4d153e72ff2b537107a06ebf60
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:9dc6c17d1b8874e6d7771ba62b6361b67f34e367e29182da09dbb0c27896be52
     name: podvm-oci
   replaces: sandboxed-containers-operator.v1.10.0
   version: 1.10.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,17 +78,17 @@ spec:
             - name: PEERPODS_NAMESPACE
               value: "openshift-sandboxed-containers-operator"
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:9e297de3d963cb5ebd80a609f848ee716eb1dedb0ee6cc76f523d7fe9005a167
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:cce42890434fcbc9e9401aa9f1255e90ad07b545fa7aa89678c6e0ef34e444cd
             - name: RELATED_IMAGE_CAA
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:d4973b793f3af9d9df3da45417082f77dc991e734ea9cf3d132aaf2d7def9552
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:9cd8d2068f3161fe1f904e7b832b58a7dd90d620a8bc58092ebbe2e7f5a12037
             - name: RELATED_IMAGE_PEERPODS_WEBHOOK
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:ef4a8efcfb74e3e6b68fe3c566b343ac5da0a4d1de203342c46defae60029a81
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:97d0e8e547332adc4b6f4c2524592311d063e467c3739af8aa953d09a5b199a2
             - name: RELATED_IMAGE_PODVM_BUILDER
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:8d23df1699f72afcf5cec8734d6c5d3b92ce432fcb488909e967380c74068a8a
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:5a000e0476bb1e6c2179c0bde811bb73166393660ffe30639f1b3a3f304c5150
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:d9b2ac90fd3663310a9160bcb232e1e7039869838d77c3509464b558d56f4142 
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:f615e0fc32a197c96c472eb3d7bdd113afacb141178b6117c95a8ee2b9188558 
             - name: RELATED_IMAGE_PODVM_OCI
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:3ae0ddf604a57a9f5a16d023e03f9d5060312e4d153e72ff2b537107a06ebf60
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:9dc6c17d1b8874e6d7771ba62b6361b67f34e367e29182da09dbb0c27896be52
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
To enable nudge PRs, we need to have a reference to the first build for the different components. After that, Mintmaker should be able to update that reference whenever a new build occurs.

This commits sets the first build's reference of all our components.
