### PR TITLE
coco: approve InstallPlans via Subscription

### DIFF
--- a/scripts/install-helpers/baremetal-coco/README.md
+++ b/scripts/install-helpers/baremetal-coco/README.md
@@ -58,7 +58,16 @@ The deployment sequence is described below:
 
 ## Install OSC operator GA release
 
-- Update `startingCSV` key in the `subs-ga.yaml` file to use the GA release you need.
+- The Subscription follows the `stable` channel; no `startingCSV` pinning is required.
+
+- Optional: pin to a specific CSV by setting `OSC_OPERATOR_CSV` before running the script. The script will patch the Subscription's `startingCSV` accordingly.
+
+  Example:
+
+  ```sh
+  export OSC_OPERATOR_CSV=sandboxed-containers-operator.v1.10.1
+  ./install.sh -t tdx
+  ```
 
 - If not using SNO or converged cluster then label at least a single worker node for deployment
   and export the label via the 1BM_NODE_LABEL1 env variable

--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -10,7 +10,6 @@ TRUSTEE_URL="${TRUSTEE_URL:-"http://kbs-service.trustee-operator-system:8080"}"
 CMD_TIMEOUT="${CMD_TIMEOUT:-2700}"
 TDX_NODE_LABEL='intel.feature.node.kubernetes.io/tdx: "true"'
 SNP_NODE_LABEL='amd.feature.node.kubernetes.io/snp: "true"'
-DEFAULT_OSC_OPERATOR_CSV=sandboxed-containers-operator.v1.9.0
 
 export PCCS_API_KEY="${PCCS_API_KEY:-}"
 export PCCS_DB_NAME="${PCCS_DB_NAME:-database}"
@@ -19,8 +18,6 @@ export PCCS_DB_PASSWORD="${PCCS_DB_PASSWORD:-password}"
 export PCCS_USER_TOKEN="${PCCS_USER_TOKEN:-}"
 PCCS_ADMIN_TOKEN="${PCCS_ADMIN_TOKEN:-}"
 PCCS_PEM_CERT_PATH="${PCCS_PEM_CERT_PATH:-}"
-
-OSC_OPERATOR_CSV=${OSC_OPERATOR_CSV:-$DEFAULT_OSC_OPERATOR_CSV}
 
 # Function to check if a command is available
 function check_command() {
@@ -186,34 +183,31 @@ function wait_for_runtimeclass() {
     return 1
 }
 
-# Function to approve installPlan tied to specific CSV to be available in specific namespace
-approve_installplan_for_target_csv() {
+# Function to approve InstallPlan created for a given Subscription
+approve_installplan_for_subscription() {
     local ns="$1"
-    local target_csv="$2"
+    local subscription_name="$2"
     local timeout=300
     local interval=5
     local elapsed=0
 
-    echo "Waiting for InstallPlan with CSV '$target_csv' in namespace '$ns'..."
+    echo "Waiting for InstallPlan for Subscription '$subscription_name' in namespace '$ns'..."
 
     while [ $elapsed -lt "$timeout" ]; do
-        installplans=$(oc get installplan -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
-        for ip in $installplans; do
-            csvs=$(oc get installplan "$ip" -n "$ns" -o jsonpath="{.spec.clusterServiceVersionNames[*]}" 2>/dev/null)
-            for csv in $csvs; do
-                if [ "$csv" == "$target_csv" ]; then
-                    echo "Found matching InstallPlan: $ip"
-                    echo "Approving InstallPlan: $ip"
-                    oc patch installplan "$ip" -n "$ns" -p '{"spec":{"approved":true}}' --type merge || return 1
-                    return 0
-                fi
-            done
-        done
+        ip=$(oc get subscription "$subscription_name" -n "$ns" -o json 2>/dev/null | jq -r '.status.installPlanRef.name // .status.installplan.name // empty')
+
+        if [ -n "$ip" ]; then
+            echo "Found InstallPlan: $ip"
+            echo "Approving InstallPlan: $ip"
+            oc patch installplan "$ip" -n "$ns" -p '{"spec":{"approved":true}}' --type merge || return 1
+            return 0
+        fi
+
         sleep $interval
         elapsed=$((elapsed + interval))
     done
 
-    echo "Timed out waiting for InstallPlan with CSV '$target_csv' in namespace '$ns'"
+    echo "Timed out waiting for InstallPlan for Subscription '$subscription_name' in namespace '$ns'"
     return 1
 }
 
@@ -226,10 +220,18 @@ function apply_operator_manifests() {
     oc apply -f og.yaml || return 1
     if [[ "$GA_RELEASE" == "true" ]]; then
         oc apply -f subs-ga.yaml || return 1
-	approve_installplan_for_target_csv openshift-sandboxed-containers-operator "$OSC_OPERATOR_CSV" || return 1
+        if [ -n "$OSC_OPERATOR_CSV" ]; then
+            echo "Patching Subscription startingCSV to $OSC_OPERATOR_CSV"
+            oc patch subscription openshift-sandboxed-containers-operator -n openshift-sandboxed-containers-operator -p "{\"spec\":{\"startingCSV\":\"$OSC_OPERATOR_CSV\"}}" --type merge || return 1
+        fi
+        approve_installplan_for_subscription openshift-sandboxed-containers-operator openshift-sandboxed-containers-operator || return 1
     else
         oc apply -f osc_catalog.yaml || return 1
         oc apply -f subs-upstream.yaml || return 1
+        if [ -n "$OSC_OPERATOR_CSV" ]; then
+            echo "Patching Subscription startingCSV to $OSC_OPERATOR_CSV"
+            oc patch subscription openshift-sandboxed-containers-operator -n openshift-sandboxed-containers-operator -p "{\"spec\":{\"startingCSV\":\"$OSC_OPERATOR_CSV\"}}" --type merge || return 1
+        fi
     fi
 
 }

--- a/scripts/install-helpers/baremetal-coco/subs-ga.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-ga.yaml
@@ -9,7 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  # This is tied to the CoCo on baremetal preview release
-  # We use the current GA release subscription as BM releases happens
-  # post the GA of the CoCO/peer-pods releases for now
-  startingCSV: sandboxed-containers-operator.v1.9.0
+  # Leave version resolution to channel; do not pin startingCSV

--- a/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
+++ b/scripts/install-helpers/baremetal-coco/subs-upstream.yaml
@@ -9,4 +9,4 @@ spec:
   name: sandboxed-containers-operator
   source: osc-upstream-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.10.1  ## OSC_VERSION
+  # Leave version resolution to channel; do not pin startingCSV


### PR DESCRIPTION
The install was hanging because the script tried to match and approve an InstallPlan by a hardcoded CSV (e.g., v1.9.0), while the catalog often resolved a different CSV (e.g., v1.10.1).

We now approve the InstallPlan referenced directly by the Subscription, which works regardless of the resolved CSV, and we stop pinning startingCSV so the channel picks the right version automatically. If needed, you can still pin to a specific version via OSC_OPERATOR_CSV.