### PR TITLE
Fix cleanup error: we need write auth on the new folder created for kubebuilder assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	# set write flag on created folder, so that we can clean it up
+	chmod +w $(LOCALBIN)/k8s/$(ENVTEST_K8S_VERSION)*
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.


### PR DESCRIPTION
Re-apply bef333e8 that was mistakenly removed by #451
