### PR TITLE
ibmcloud: initial support for IBM Cloud as a provider

### DIFF
--- a/config/peerpods/podvm/Dockerfile.podvm-builder
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder
@@ -24,7 +24,7 @@ ARG ACTIVATION_KEY
 
 RUN mkdir -p /scripts
 
-ADD ami-helper.sh lib.sh libvirt-podvm-image-handler.sh aws-podvm-image-handler.sh azure-podvm-image-handler.sh gcp-podvm-image-handler.sh /scripts/
+ADD ami-helper.sh lib.sh libvirt-podvm-image-handler.sh aws-podvm-image-handler.sh azure-podvm-image-handler.sh gcp-podvm-image-handler.sh ibmcloud-podvm-image-handler.sh /scripts/
 
 RUN mkdir -p /scripts/bootc
 ADD bootc/config.toml /scripts/bootc/

--- a/config/peerpods/podvm/ibmcloud-podvm-image-cm.yaml
+++ b/config/peerpods/podvm/ibmcloud-podvm-image-cm.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibmcloud-podvm-image-cm
+  namespace: openshift-sandboxed-containers-operator
+# these are just placeholders for now
+data:
+  # Booleans
+  INSTALL_PACKAGES: "no"
+  DOWNLOAD_SOURCES: "no"
+  CONFIDENTIAL_COMPUTE_ENABLED: "no"
+  DISABLE_CLOUD_CONFIG: "true"
+  ENABLE_NVIDIA_GPU: "no"
+  UPDATE_PEERPODS_CM: "yes"
+  BOOT_FIPS: "no"
+
+  # precreated artifacts
+  #COS_BUCKET_NAME: existing-bucket-name
+  PODVM_IMAGE_URI: bootc::image-registry.openshift-image-registry.svc:5000/openshift-sandboxed-containers-operator/podvm-bootc

--- a/config/peerpods/podvm/ibmcloud-podvm-image-handler.sh
+++ b/config/peerpods/podvm/ibmcloud-podvm-image-handler.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# FILEPATH: ibmcloud-podvm-image-handler.sh
+
+# This script is used to import PodVM images to IBM Cloud
+# The basic assumption is that the required variables are set as environment variables in the pod
+# Typically the variables are read from configmaps and set as environment variables in the pod
+# The script will be called with one of the following options:
+# Create image (-c)
+# Delete image (-C)
+
+# include common functions from lib.sh
+# shellcheck source=/dev/null
+# The directory is where ibmcloud-podvm-image-handler.sh is located
+source "$(dirname "$0")"/lib.sh
+
+# function to download and install ibmcloud cli
+
+function install_ibmcloud_cli() {
+    # Install ibmcloud cli
+    # If any error occurs, exit the script with an error message
+
+    # Check if ibmcloud cli is already installed
+    if command -v ibmcloud &>/dev/null; then
+        echo "ibmcloud cli is already installed"
+        return
+    fi
+
+    # Download ibmcloud cli
+    curl -fsSL https://clis.cloud.ibm.com/install/linux -o /tmp/ibmcloud_install.sh ||
+        error_exit "Failed to download ibmcloud cli"
+
+    # Install ibmcloud cli
+    sh /tmp/ibmcloud_install.sh ||
+        error_exit "Failed to execute ibmcloud cli installer"
+
+    # Install ibmcloud cli plugins
+    ibmcloud plugin install -a ||
+        error_exit "Failed to install ibmcloud cli plugins"
+
+    # Clean up temporary files
+    rm -f "/tmp/ibmcloud_install.sh"
+}
+
+function create_image() {
+    error_exit "currently not supported"
+}
+
+function delete_image() {
+    error_exit "currently not supported"
+}
+
+# display help message
+
+function display_help() {
+    echo "This script is used to import PodVM images to IBM Cloud"
+    echo "Usage: $0 [-c|-C] [-- install_binaries|install_rpms|install_cli]"
+    echo "Options:"
+    echo "-c  Create image"
+    echo "-C  Delete image"
+}
+
+# main function
+
+if [ "$#" -eq 0 ]; then
+    display_help
+    exit 1
+fi
+
+if [ "$1" = "--" ]; then
+    shift
+    # Handle positional parameters
+    case "$1" in
+
+    install_binaries)
+        install_binary_packages
+        ;;
+    install_rpms)
+        install_rpm_packages
+        ;;
+    install_cli)
+        install_ibmcloud_cli
+        ;;
+    *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+else
+    while getopts "cCh" opt; do
+        verify_vars
+        case ${opt} in
+        c)
+            create_image
+            ;;
+        C)
+            delete_image
+            ;;
+        h)
+            # Display help
+            display_help
+            exit 0
+            ;;
+        *)
+            # Invalid option
+            display_help
+            exit 1
+            ;;
+        esac
+    done
+fi

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -34,6 +34,7 @@ spec:
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # gcp-podvm-image-handler.sh script under /scripts/gcp-podvm-image-handler.sh
+          # ibmcloud-podvm-image-handler.sh script under /scripts/ibmcloud-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           lifecycle: 
             preStop: 
@@ -66,6 +67,9 @@ spec:
                 optional: true
             - configMapRef:
                 name: gcp-podvm-image-cm
+                optional: true
+            - configMapRef:
+                name: ibmcloud-podvm-image-cm
                 optional: true
             - configMapRef:
                 name: libvirt-podvm-image-cm

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -18,6 +18,7 @@ spec:
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh
           # gcp-podvm-image-handler.sh script under /scripts/gcp-podvm-image-handler.sh
+          # ibmcloud-podvm-image-handler.sh script under /scripts/ibmcloud-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           # Binaries like kubectl, packer and yq under /usr/local/bin
           image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.10.1  ## OSC_VERSION
@@ -46,6 +47,9 @@ spec:
                 optional: true
             - configMapRef:
                 name: gcp-podvm-image-cm
+                optional: true
+            - configMapRef:
+                name: ibmcloud-podvm-image-cm
                 optional: true
             - configMapRef:
                 name: libvirt-podvm-image-cm

--- a/config/peerpods/podvm/podvm-builder.sh
+++ b/config/peerpods/podvm/podvm-builder.sh
@@ -31,6 +31,11 @@ function install_gcp_deps() {
   /scripts/gcp-podvm-image-handler.sh -- install_binaries
 }
 
+# Function to install IBM Cloud deps
+function install_ibmcloud_deps() {
+  /scripts/ibmcloud-podvm-image-handler.sh -- install_cli
+  /scripts/ibmcloud-podvm-image-handler.sh -- install_binaries
+}
 
 # Function to check if peer-pods-cm configmap exists
 function check_peer_pods_cm_exists() {
@@ -381,6 +386,10 @@ libvirt)
   ;;
 gcp)
   install_gcp_deps
+  ;;
+ibmcloud)
+  echo "IBM Cloud doesn't support this feature, please provide IBMCLOUD_PODVM_IMAGE_ID in your peer-pods-cm"
+  exit 1
   ;;
 *)
   echo "CLOUD_PROVIDER is not set to azure or aws or libvirt"

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -680,18 +680,8 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 
 func checkKeysPresentAndNotEmpty(data interface{}, keys []string) bool {
 	// Convert the input map to a map[string]string
-	var strMap map[string]string
-
-	switch v := data.(type) {
-	case map[string]string:
-		strMap = v
-	case map[string][]byte:
-		strMap = make(map[string]string)
-		for key, value := range v {
-			strMap[key] = string(value)
-		}
-	default:
-		// Unsupported type
+	strMap := toStrMap(data)
+	if strMap == nil {
 		return false
 	}
 
@@ -706,6 +696,49 @@ func checkKeysPresentAndNotEmpty(data interface{}, keys []string) bool {
 	}
 
 	return true
+}
+
+// checkAnyKeyPresentWithValue checks if any of the specified keys are present in the input map
+// and have non-empty string values.
+// It accepts a map of type map[string][]byte or map[string]string as `data`,
+// and a slice of keys to search for.
+// Returns true if any key exists in the map and its value is not an empty string.
+func checkAnyKeyPresentWithValue(data interface{}, keys []string) bool {
+	// Convert the input to a map[string]string using a helper function.
+	strMap := toStrMap(data)
+	if strMap == nil {
+		return false // Return false if conversion fails.
+	}
+
+	// Iterate over the list of keys and check if any key exists with a non-empty value.
+	for _, key := range keys {
+		value, ok := strMap[key]
+		if ok && value != "" {
+			return true // Found a key with a non-empty value.
+		}
+	}
+
+	igLogger.Info("checkAnyKeyPresentWithValue: no key is present or has non-empty value", "searchedKeys", keys)
+
+	return false // No matching key with a non-empty value found.
+}
+
+func toStrMap(data interface{}) map[string]string {
+	var strMap map[string]string
+
+	switch v := data.(type) {
+	case map[string]string:
+		strMap = v
+	case map[string][]byte:
+		strMap = make(map[string]string)
+		for key, value := range v {
+			strMap[key] = string(value)
+		}
+	default:
+		// Unsupported type
+		return nil
+	}
+	return strMap
 }
 
 func (r *ImageGenerator) getImageConfigMapName() string {

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -54,12 +54,14 @@ const (
 	peerpodsCMAzureImageKey       = "AZURE_IMAGE_ID"
 	peerpodsCMGCPImageKey         = "PODVM_IMAGE_NAME"
 	peerpodsLibvirtImageKey       = "LIBVIRT_IMAGE_ID"
+	peerpodsCMIBMCloudImageKey    = "IBMCLOUD_PODVM_IMAGE_ID"
 	fipsCMKey                     = "BOOT_FIPS"
 	procFIPS                      = "/proc/sys/crypto/fips_enabled"
 	AWSProvider                   = "aws"
 	AzureProvider                 = "azure"
 	GCPProvider                   = "gcp"
 	LibvirtProvider               = "libvirt"
+	IBMCloudProvider              = "ibmcloud"
 	peerpodsImageJobsPathLocation = "/config/peerpods/podvm"
 	azureImageGalleryPrefix       = "PodVMGallery"
 )
@@ -259,6 +261,9 @@ func newImageGenerator(client client.Client) (*ImageGenerator, error) {
 		igLogger.Info("libvirt is our provider", "provider", provider)
 		ig.CMimageIDKey = peerpodsLibvirtImageKey
 		ig.provider = provider
+	case IBMCloudProvider:
+		ig.provider = provider
+		ig.CMimageIDKey = peerpodsCMIBMCloudImageKey
 	default:
 		igLogger.Info("unsupported cloud provider, image creation/deletion will be disabled", "provider", ig.provider)
 		ig.provider = unsupportedCloudProvider
@@ -415,6 +420,7 @@ func (r *ImageGenerator) getPeerPodsCM() (*corev1.ConfigMap, error) {
 // azure-podvm-image-cm.yaml for Azure
 // aws-podvm-image-cm.yaml for AWS
 // libvirt-podvm-image-cm.yaml for Libvirt
+// ibmcloud-podvm-image-cm.yaml for IBM Cloud
 
 func (r *ImageGenerator) imageCreateJobRunner() (int, error) {
 	igLogger.Info("imageCreateJobRunner: Start")
@@ -617,6 +623,10 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 	libvirtSecretKeys := []string{"CLOUD_PROVIDER", "LIBVIRT_URI"}
 	// libvirt ConfigMap Keys
 	libvirtConfigMapKeys := []string{"CLOUD_PROVIDER", "LIBVIRT_POOL", "LIBVIRT_VOL_NAME", "LIBVIRT_DIR_NAME"}
+	// ibmcloud Secret Keys
+	ibmcloudSecretKeys := []string{"IBMCLOUD_IAM_PROFILE_ID", "IBMCLOUD_API_KEY"}
+	// ibmcloud ConfigMap Keys
+	ibmcloudConfigMapKeys := []string{"CLOUD_PROVIDER"}
 
 	// Check for each cloud provider if respective ConfigMap keys are present in the peerPodsConfigMap
 	switch r.provider {
@@ -665,6 +675,16 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-cm ConfigMap")
 		}
 
+	case IBMCloudProvider:
+		// Check if ibmcloud Secret Keys are present in the peerPodsSecret
+		if !checkAnyKeyPresentWithValue(peerPodsSecret.Data, ibmcloudSecretKeys) {
+			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-secret Secret")
+		}
+
+		// Check if ibmcloud ConfigMap Keys are present in the peerPodsConfigMap
+		if !checkKeysPresentAndNotEmpty(peerPodsCM.Data, ibmcloudConfigMapKeys) {
+			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-cm ConfigMap")
+		}
 	default:
 		return fmt.Errorf("validatePeerPodsConfigs: unsupported cloud provider %s", r.provider)
 	}
@@ -749,6 +769,7 @@ func (r *ImageGenerator) getImageConfigMapName() string {
 // azure-podvm-image-cm.yaml for Azure
 // aws-podvm-image-cm.yaml for AWS
 // libvirt-podvm-image-cm.yaml for Libvirt
+// ibmcloud-podvm-image-cm.yaml for IBM Cloud
 // Returns error if the ConfigMap creation fails
 
 func (r *ImageGenerator) createImageConfigMapFromFile() error {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -488,6 +488,54 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA() *appsv1.DaemonS
 	}
 }
 
+// Handles provider specific parts of the CAA Ds
+// Modifies the DaemonSet if needed
+func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.DaemonSet) error {
+	r.Log.Info("Getting cloud provider from infra")
+	provider, err := getCloudProviderFromInfra(r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get cloud provider from infra: %w", err)
+	}
+
+	switch provider {
+	case IBMCloudProvider:
+		var expSecs int64 = 3600
+		vaultTokenVolume := corev1.Volume{
+			Name: "vault-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Path:              "vault-token",
+								ExpirationSeconds: &expSecs,
+								Audience:          "iam",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		vaultTokenVolumeMount := corev1.VolumeMount{
+			MountPath: "/var/run/secrets/tokens",
+			Name:      "vault-token",
+		}
+
+		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, vaultTokenVolume)
+		for i := range ds.Spec.Template.Spec.Containers {
+			container := &ds.Spec.Template.Spec.Containers[i]
+			if container.Name == "caa-pod" {
+				container.VolumeMounts = append(container.VolumeMounts, vaultTokenVolumeMount)
+			}
+		}
+
+		return nil
+	default:
+		return nil
+	}
+}
+
 func (r *KataConfigOpenShiftReconciler) processDaemonsetForMonitor() *appsv1.DaemonSet {
 	var (
 		runPrivileged = false
@@ -2432,6 +2480,12 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMc() error {
 func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	// Create the CAA daemonset
 	ds := r.processDaemonsetForCAA()
+	if err := r.processProviderConfigCAA(ds); err != nil {
+		r.Log.Error(err, "Failed setting cloud provider specific configuration for cloud-api-adaptor DS")
+		return err
+	}
+	r.Log.Info("Got CAA ds manifest", "ds", ds)
+
 	if err := controllerutil.SetControllerReference(r.kataConfig, ds, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed setting ControllerReference for cloud-api-adaptor DS")
 		return err


### PR DESCRIPTION
Made modifications to support IBM Cloud as a cloud provider. Changes include:
- Adding IBM Cloud to the list of supported providers.
- Updating the image generator with new return values and an error message to reflect that IBM Cloud only supports prebuilt images; in-cluster image building is currently not supported.
- Introducing a new function to apply IBM-specific configuration to the CAA DaemonSet.

This PR depends on PR #825, as the Operator only works using the DaemonSet deployment mode on IBM Cloud.