### PR TITLE
[1.10] osc-podvm-builder: change submodule for the 1.10 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "config/peerpods/podvm/cloud-api-adaptor"]
 	path = config/peerpods/podvm/cloud-api-adaptor
 	url = https://github.com/openshift/cloud-api-adaptor/
-	branch = osc-release
+	branch = osc-release-v1.10


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

On the 1.10 branch for the operator, we need to track the 1.10 branch for cloud-api-adaptor submodule.

