### PR TITLE
Use a public builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1756993846 as builder
+
+# Required by the ubi based go-toolset image
+USER root
 
 WORKDIR /workspace
 


### PR DESCRIPTION
The builder image at brew.registry.redhat.io we're currently using isn't accessible to some clusters in prow.

```
Warning: Pull failed, retrying in 5s ...
Trying to pull brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24...
Warning: Pull failed, retrying in 5s ...
Trying to pull brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24...
Warning: Pull failed, retrying in 5s ...
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication
```

Switch to an image that is publicly available with authentication.
