### PR TITLE
test-fbc: set the catalog's tag to 1.11.x-timestamp

### DIFF
--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -309,7 +309,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: ["latest", "1.10.1-$(tasks.clone-repository.results.commit-timestamp)"]
+        value: ["latest", "1.11.0-$(tasks.clone-repository.results.commit-timestamp)"]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Keeping the tag to 1.10.1 is confusing when bugs are reported from this catalog. Using "1.11.x" to mark the fact that this is not an official release version, but an intermediate build.

Also, this commit does not change the version strings everywhere else, it is just about the test catalog.
