### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-must-gather

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -22,7 +22,8 @@ COPY node-gather/node-gather-crd.yaml /etc/
 COPY node-gather/node-gather-ds.yaml /etc/
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-operator-must-gather" \
+LABEL name="openshift-sandboxed-containers/osc-must-gather-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-must-gather-container" \
 summary="osc-must-gather collects information about the sandboxed containers operator and the kata runtime" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
