### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-operator" \
+LABEL name="openshift-sandboxed-containers/osc-rhel9-operator" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-operator-container" \
 summary="This operator manages the Openshift Sandboxed Containers runtime installation" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
