### PR TITLE
osc-must-gather: change builder image

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-must-gather:latest as builder
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.19 as builder
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
 


### PR DESCRIPTION
Using "latest" is causing an issue in our build. For some reason the s390x build can't find the "latest" tagged image. Also, we were still using "ose-must-gather", while there is an "ose-must-gather-rhel9" image available that's probably better suited for our release.

This commit modifies the builder image to use "ose-must-gather-rhel9", and uses the tag "v4.19" rather than "latest".
