### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-podvm-builder

### DIFF
--- a/config/peerpods/podvm/Dockerfile.podvm-builder
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder
@@ -52,7 +52,8 @@ COPY cloud-api-adaptor /src/cloud-api-adaptor
 ADD podvm-builder.sh /podvm-builder.sh
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-podvm-builder" \
+LABEL name="openshift-sandboxed-containers/osc-podvm-builder-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-podvm-builder-container" \
 summary="Container image containing artefacts that is required for creating Pod VM images" \


### PR DESCRIPTION
Following the other similar PRs : change the labels on the osc-podvm-builder image