### PR TITLE
Add karg nohibernate to tdx host

### DIFF
--- a/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
+++ b/scripts/install-helpers/baremetal-coco/layeredimage-cm-tdx.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   osImageURL: "quay.io/openshift_sandboxed_containers/rhcos-layer/ocp-4.18:tdx-0.2.0"
-  kernelArguments: "kvm_intel.tdx=1"
+  kernelArguments: "kvm_intel.tdx=1 nohibernate"
 kind: ConfigMap
 metadata:
   name: layered-image-deploy-cm


### PR DESCRIPTION
Needed to initialize tdx module with newer kernels (e.g. 5.14.0-599.tdx.el9s.x86_64 ) on tdx host.


