### PR TITLE
[WIP] release: add files to create snapshots and releases from the CLI

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,138 @@
+# OSC Release procedure
+
+## Rationale
+
+See [the documentation][doc_snapshots] about snapshots.
+
+Konflux Snapshots are used to represent a related set of images, that can be used
+for testing and releasing.
+
+Snapshots are created automatically whenever something is rebuilt.
+When a component is modified, its image is updated, and added to a new snapshot.
+The snapshot is then completed with the latest build for the other images for our
+application.
+
+Automated snapshot creation makes no difference between `on-pull-request` and
+`on-push` builds.
+This results in snapshots that contains a mix of merged and unmerged code.
+This is fine to test images from PRs (pre-merge), as no PR will rebuild all the
+images. But when we try to make a release, if an unrelated PR comes up, its image
+can get mixed in the snapshot that we are working on.
+
+The only way to get a releasable snapshot from the automated snapshot creation is
+to finely control what gets built to ensure that snapshot and bundle are synchronized.
+In any case, when we make a release (stage or prod), the Enterprise Contract for
+the release will check that the snapshot and the bundle are in sync, and will error
+out if they are not.
+
+This is cumbersome, and could lead to unneeded rebuilds to make sure the latest
+image for each component is the one we have in the snapshot (this is what we did
+in 1.10.2).
+
+Instead of counting on automated snapshots, we can [create our own snapshots manually][doc_manual_snapshots].
+
+This folder contains a Snapshot definition, listing all the images we want.
+We will use the existing nudge PRs for our images to update it at the same time
+as the bundle and test catalog are updated, making sure the bundle and snapshot
+are synchronized.
+
+Based on this snapshot definition, we can make a controlled release without
+wondering what snapshot we should use.
+
+## Process
+
+### Prerequisite
+
+This process requires to use the CLI to interact with our Konflux instance.
+You need to `oc login` to our instance of Konflux, and use our team's namespace
+on it.
+
+```bash
+$ oc login --web https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443/
+...
+$ oc project ose-osc-tenant
+Now using project "ose-osc-tenant" on server "https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443".
+```
+
+Another pre-requisite is to have a working build of the operator, including a bundle
+that lists all the expected images.
+
+**This operator build needs to be tested and validated by the team.**
+
+### Push the Snapshot
+
+1) verify that the `snapshot.yaml` file contains the same image references as
+   the tested operator's bundle.
+2) run:
+
+   ```bash
+   $ oc create -f snapshot.yaml
+   ...
+   ```
+
+3) in the Konflux console, or with the CLI, you can verify that the snapshot
+   is listed appropriately under the name "osc-release-snapshot-[number]".
+
+Note: snapshots need to have a unique name. They are deleted after some time, but
+if you do multiple pushes in a short time, you will need to rename it.
+This is why we append a number at the end of its name.
+Modify this number to make sure the snapshot is unique in our instance.
+You don't need to commit the name change to our repo.
+
+### Make a stage release
+
+This folder contains a `stage-release.yaml` file that references our snapshot
+by its name. You can use it to trigger a stage release for the snapshot you
+just pushed.
+
+1) make sure `stage-release.yaml` is using the right snapshot name, as set in
+   `snapshot.yaml`
+2) run:
+
+    ```bash
+    $ oc create -f stage-release.yaml
+    ...
+    ```
+
+Note: as for the snapshot, the release need to be uniquely named. Make sure you
+edit that name if you need to make multiple stage releases.
+
+### Make a prod release
+
+Stage and prod releases are made exactly in the same way.
+We could just edit `stage-release.yaml` and modify the `releasePlan` reference from
+"stage" to "prod", and just push the same file again.
+Now to avoid errors like "pushing a prod release when we thought we're making a stage one",
+we are keeping two separate files for stage and prod releases.
+
+1) make sure `prod-release.yaml` is using the right snapshot name, as set in
+   `snapshot.yaml`
+2) make sure `prod-release.yaml` has all the expected issues and CVEs listed for
+   your release.
+3) Fill the `synopsis` in `prod-release.yaml` to make sure the right version is
+   referenced in our advisory. Optionally set the other fields too to override
+   the defaults that come from our ReleasePlan.
+4) Double check everything.
+5) run:
+
+    ```bash
+    $ oc create -f prod-release.yaml
+    ...
+    ```
+
+## Why not use the UI console to make the release?
+
+All of the above can also be done from the Konflux console if you feel more
+confortable with it. The only caveat is listing the CVEs for the prod release,
+as the console UI have [a bug (at the time of writing)][konflux_bug] that generates
+wrongly formatted structures when we try to list multiple components for the same
+CVE.
+
+We started using the CLI because of this bug when we did 1.10.2.
+If we don't have CVEs to list, or when the bug is fixed in Konflux, we can
+consider reusing the console.
+
+---
+[doc_snapshots]: https://konflux.pages.redhat.com/docs/users/testing/integration/snapshots/index.html
+[doc_manual_snapshots]: https://konflux.pages.redhat.com/docs/users/testing/integration/snapshots/working-with-snapshots.html
+[konflux_bug]: https://issues.redhat.com/browse/KFLUXSPRT-5045

--- a/release/prod-release.yaml
+++ b/release/prod-release.yaml
@@ -1,0 +1,44 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: jrope
+  name: osc-prod-release-v1-10-2-take3
+  namespace: ose-osc-tenant
+spec:
+  releasePlan: osc-prod-release-plan-v1-10
+  snapshot: openshift-sandboxed-containers-v1-10-7gp4c
+  data:
+    releaseNotes:
+      cves:
+      - component: osc-podvm-builder-v1-10
+        key: CVE-2025-6020
+      - component: osc-podvm-payload-v1-10
+        key: CVE-2025-6020
+      - component: osc-caa-v1-10
+        key: CVE-2025-6020
+      - component: osc-monitor-v1-10
+        key: CVE-2025-6020
+      - component: osc-monitor-v1-10
+        key: CVE-2025-8941
+      - component: osc-podvm-payload-v1-10
+        key: CVE-2025-8941
+      - component: osc-podvm-builder-v1-10
+        key: CVE-2025-8941
+      - component: osc-caa-v1-10
+        key: CVE-2025-8941
+      - component: osc-caa-v1-10
+        key: CVE-2025-5914
+      - component: osc-caa-webhook-v1-10
+        key: CVE-2025-5914
+      - component: osc-monitor-v1-10
+        key: CVE-2025-5914
+      - component: osc-must-gather-v1-10
+        key: CVE-2025-5914
+      - component: osc-operator-v1-10
+        key: CVE-2025-5914
+      - component: osc-podvm-builder-v1-10
+        key: CVE-2025-5914
+      - component: osc-podvm-payload-v1-10
+        key: CVE-2025-5914
+

--- a/release/snapshot.yaml
+++ b/release/snapshot.yaml
@@ -13,11 +13,11 @@ spec:
         dockerfileUrl: Dockerfile.monitor
         revision: 4560d2b96839bcc8035a60348ecfe0b3a7c8a77d
         url: https://github.com/openshift/kata-containers
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10@sha256:dc75d0d32e24479e6cfb4042f6eda587f747b6e6aff25cdda1c1f8af859fbc0f
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10@sha256:417ee37b223c39a06e8534fbe8b9f11e54e481df17977e4d4d62c62ccf8e63a4
     name: osc-operator-bundle-v1-10
     source:
       git:
-        revision: 47bb073abf9f88a24a77b0efb5dfa5a860db2154
+        revision: a894d05350ba200e176db6b09d49568eedb49b80
         url: https://github.com/openshift/sandboxed-containers-operator
   - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10@sha256:21e810dd9d030c3835fadfc4c434e36a26ab57d9451dc955fc1625b48fac3815
     name: osc-podvm-builder-v1-10
@@ -48,11 +48,11 @@ spec:
       git:
         revision: 3962471832c450387a0659432d057ce88443f16a
         url: https://github.com/confidential-devhub/coco-podvm-scripts
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10@sha256:f35734f1ed34110193d0f38027f67c50c82dcb5110df2a1c388e8882ddc663d5
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10@sha256:1ffb432d9a8833854fa5e5262dcbf42530dfbaadfddf6978f7bc7804b84d2e3f
     name: osc-operator-v1-10
     source:
       git:
-        revision: d36004f697731521faa9b1bc6acd94f9ca99dcd4
+        revision: d317b15b575172392731b2c00876846ebc45922d
         url: https://github.com/openshift/sandboxed-containers-operator
   - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10@sha256:6802f00a939f24ecd6dad150433db5ea3fd72d171f0c410cb894d3af910fc7fd
     name: osc-caa-webhook-v1-10

--- a/release/snapshot.yaml
+++ b/release/snapshot.yaml
@@ -6,65 +6,65 @@ metadata:
 spec:
   application: openshift-sandboxed-containers-v1-10
   components:
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor@sha256:9e297de3d963cb5ebd80a609f848ee716eb1dedb0ee6cc76f523d7fe9005a167
-    name: osc-monitor
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor-v1-10@sha256:ce49124dc965c77cd93e9fa34b0392194761cc949543cf39d3a0ce7d33a64572
+    name: osc-monitor-v1-10
     source:
       git:
         dockerfileUrl: Dockerfile.monitor
-        revision: 956cc37ba2929245ee9784155501fcc3a3c115d6
+        revision: 4560d2b96839bcc8035a60348ecfe0b3a7c8a77d
         url: https://github.com/openshift/kata-containers
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle@sha256:a5db075a773eceebb63cb33033afad81baaaa108ce5acd533947eb21a1b16b58
-    name: osc-operator-bundle
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-10@sha256:dc75d0d32e24479e6cfb4042f6eda587f747b6e6aff25cdda1c1f8af859fbc0f
+    name: osc-operator-bundle-v1-10
     source:
       git:
-        revision: 17ee44df4589ee9efbb68d89cd736e42a68a35cf
+        revision: 47bb073abf9f88a24a77b0efb5dfa5a860db2154
         url: https://github.com/openshift/sandboxed-containers-operator
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder@sha256:c18fef762f36f294b9f0d9881696220df8774bff479dd13e779cb897583af194
-    name: osc-podvm-builder
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-10@sha256:21e810dd9d030c3835fadfc4c434e36a26ab57d9451dc955fc1625b48fac3815
+    name: osc-podvm-builder-v1-10
     source:
       git:
         context: config/peerpods/podvm
         dockerfileUrl: Dockerfile.podvm-builder
-        revision: 154f467dd6e55c0d1f93d0d9e58c5c9427cfeebd
+        revision: d36004f697731521faa9b1bc6acd94f9ca99dcd4
         url: https://github.com/openshift/sandboxed-containers-operator
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:cd44044bdcee400f802b0ec74227467b2b860df8ff103079b10bc22ce06dfc0a
-    name: osc-podvm-payload
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10@sha256:c9790aaa961f6976c14fc9cbef448fc48fcdfacf94f3af25fa2b1e31c72c8d9f
+    name: osc-podvm-payload-v1-10
     source:
       git:
         dockerfileUrl: podvm-payload/Dockerfile
-        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        revision: bdca2073285730b4fc5e8028b6ac4dd9a0256d13
         url: https://github.com/openshift/cloud-api-adaptor
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa@sha256:04e2982cf0a6a69a5dfe7549ca038ca5a2d60fa7ea4a15c98c80043212f79a40
-    name: osc-caa
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-10@sha256:7d1fa1e85af0d34c23e75868b1388eff17abe633c04a8dc55fbefcc470195c05
+    name: osc-caa-v1-10
     source:
       git:
         context: src
         dockerfileUrl: cloud-api-adaptor/Dockerfile.openshift
-        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        revision: bdca2073285730b4fc5e8028b6ac4dd9a0256d13
         url: https://github.com/openshift/cloud-api-adaptor
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image@sha256:ad0503ae88cac7d2975f3fdf5bfc2eafe30d263f7d75d9fff7ba31a88947cc0f
-    name: osc-dm-verity-image
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10@sha256:9b32c441a08792374a8b681ed5733d8df77857ea96200630080fdd96012f8b55
+    name: osc-dm-verity-image-v1-10
     source:
       git:
-        revision: 91303a1882260587573fd04c395d49701c486b8d
+        revision: 3962471832c450387a0659432d057ce88443f16a
         url: https://github.com/confidential-devhub/coco-podvm-scripts
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator@sha256:4fb018ce03cfaa06b983e801508036352247d3f9fc09981949f85b7e8ab4520b
-    name: osc-operator
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-10@sha256:f35734f1ed34110193d0f38027f67c50c82dcb5110df2a1c388e8882ddc663d5
+    name: osc-operator-v1-10
     source:
       git:
-        revision: 43613b0f9f312b4b4e9e830927eb3c8718859026
+        revision: d36004f697731521faa9b1bc6acd94f9ca99dcd4
         url: https://github.com/openshift/sandboxed-containers-operator
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook@sha256:ef4a8efcfb74e3e6b68fe3c566b343ac5da0a4d1de203342c46defae60029a81
-    name: osc-caa-webhook
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10@sha256:6802f00a939f24ecd6dad150433db5ea3fd72d171f0c410cb894d3af910fc7fd
+    name: osc-caa-webhook-v1-10
     source:
       git:
         context: src/webhook
-        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        revision: bdca2073285730b4fc5e8028b6ac4dd9a0256d13
         url: https://github.com/openshift/cloud-api-adaptor
-  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather@sha256:a33a8960c17aee79115934726006586e5c29c10413ff30ccea6844a2068164ae
-    name: osc-must-gather
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-10@sha256:a9dceee04f0a107c3c2a32838187c3bef7d54c7ad10ff75849e488009ed927e8
+    name: osc-must-gather-v1-10
     source:
       git:
         context: must-gather
-        revision: 43613b0f9f312b4b4e9e830927eb3c8718859026
+        revision: d36004f697731521faa9b1bc6acd94f9ca99dcd4
         url: https://github.com/openshift/sandboxed-containers-operator

--- a/release/snapshot.yaml
+++ b/release/snapshot.yaml
@@ -1,0 +1,70 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: osc-release-snapshot-1.10.3-1
+  namespace: ose-osc-tenant
+spec:
+  application: openshift-sandboxed-containers-v1-10
+  components:
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor@sha256:9e297de3d963cb5ebd80a609f848ee716eb1dedb0ee6cc76f523d7fe9005a167
+    name: osc-monitor
+    source:
+      git:
+        dockerfileUrl: Dockerfile.monitor
+        revision: 956cc37ba2929245ee9784155501fcc3a3c115d6
+        url: https://github.com/openshift/kata-containers
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle@sha256:a5db075a773eceebb63cb33033afad81baaaa108ce5acd533947eb21a1b16b58
+    name: osc-operator-bundle
+    source:
+      git:
+        revision: 17ee44df4589ee9efbb68d89cd736e42a68a35cf
+        url: https://github.com/openshift/sandboxed-containers-operator
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder@sha256:c18fef762f36f294b9f0d9881696220df8774bff479dd13e779cb897583af194
+    name: osc-podvm-builder
+    source:
+      git:
+        context: config/peerpods/podvm
+        dockerfileUrl: Dockerfile.podvm-builder
+        revision: 154f467dd6e55c0d1f93d0d9e58c5c9427cfeebd
+        url: https://github.com/openshift/sandboxed-containers-operator
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:cd44044bdcee400f802b0ec74227467b2b860df8ff103079b10bc22ce06dfc0a
+    name: osc-podvm-payload
+    source:
+      git:
+        dockerfileUrl: podvm-payload/Dockerfile
+        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        url: https://github.com/openshift/cloud-api-adaptor
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa@sha256:04e2982cf0a6a69a5dfe7549ca038ca5a2d60fa7ea4a15c98c80043212f79a40
+    name: osc-caa
+    source:
+      git:
+        context: src
+        dockerfileUrl: cloud-api-adaptor/Dockerfile.openshift
+        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        url: https://github.com/openshift/cloud-api-adaptor
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image@sha256:ad0503ae88cac7d2975f3fdf5bfc2eafe30d263f7d75d9fff7ba31a88947cc0f
+    name: osc-dm-verity-image
+    source:
+      git:
+        revision: 91303a1882260587573fd04c395d49701c486b8d
+        url: https://github.com/confidential-devhub/coco-podvm-scripts
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator@sha256:4fb018ce03cfaa06b983e801508036352247d3f9fc09981949f85b7e8ab4520b
+    name: osc-operator
+    source:
+      git:
+        revision: 43613b0f9f312b4b4e9e830927eb3c8718859026
+        url: https://github.com/openshift/sandboxed-containers-operator
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook@sha256:ef4a8efcfb74e3e6b68fe3c566b343ac5da0a4d1de203342c46defae60029a81
+    name: osc-caa-webhook
+    source:
+      git:
+        context: src/webhook
+        revision: ebb979546fb136168122ac63b4aa83227847f5c3
+        url: https://github.com/openshift/cloud-api-adaptor
+  - containerImage: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather@sha256:a33a8960c17aee79115934726006586e5c29c10413ff30ccea6844a2068164ae
+    name: osc-must-gather
+    source:
+      git:
+        context: must-gather
+        revision: 43613b0f9f312b4b4e9e830927eb3c8718859026
+        url: https://github.com/openshift/sandboxed-containers-operator

--- a/release/stage-release.yaml
+++ b/release/stage-release.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: jrope
+  name: osc-stage-release-v1-10-3-build1
+  namespace: ose-osc-tenant
+spec:
+  releasePlan: osc-prod-release-plan-v1-10
+  snapshot: osc-release-snapshot-1


### PR DESCRIPTION
Trying to get more control on our release process:
- use the CLI to create a snapshot that we can rely on
- provide ways to create a release from the CLI, as we found some issues on the web console last time we did a release

This is work in progress. The "snapshot.yaml" file currently contains an arbitrary set of image references, we need to edit it to point to our ongoing 1.10.3 release.