### PR TITLE
correct kata-tdx and kata-snp config.d paths for kernel params

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -475,10 +475,10 @@ kernel_params=\"$kernel_params\""
 
     case $tee_type in
     tdx)
-        filepath=/etc/kata-containers/tdx/config.d/96-kata-kernel-config
+        filepath=/etc/kata-containers/kata-tdx/config.d/96-kata-kernel-config
         ;;
     snp)
-        filepath=/etc/kata-containers/snp/config.d/96-kata-kernel-config
+        filepath=/etc/kata-containers/kata-snp/config.d/96-kata-kernel-config
         ;;
     esac
 


### PR DESCRIPTION
The  script  `scripts/install-helpers/baremetal-coco/install.sh` creates `/etc/kata-containers/tdx/config.d/96-kata-kernel-config` to contain extra/updated config for kata-tdx where as  [kata-initrd](https://github.com/cclaudio/coco-install/tree/kata-initrd-v2/misc/kata-initrd/configs/etc/kata-containers) uses `/etc/kata-containers/kata-tdx/` for kata-tdx config. 

The same is being done for kata-snp.

This PR replaces tdx to kata-tdx and snp to kata-snp under `/etc/kata-containers` to keep the updated values of the kernel params for kata-tdx and kata-snp runtimeclass handlers.


