### PR TITLE
[1.10] podvm-builder: update the RPM lockfile after the base image change

### DIFF
--- a/config/peerpods/podvm/redhat.repo
+++ b/config/peerpods/podvm/redhat.repo
@@ -9,1766 +9,16 @@
 # a "yum repolist" to refresh available repos
 #
 
-[codeready-builder-for-rhel-9-$basearch-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 5 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-source-rpms]
-name = Red Hat Container Development Kit 3.4 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rhui-rpms]
-name = Single Sign-On Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-interconnect-textonly-1-for-middleware-rpms]
-name = Red Hat AMQ Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.12-rpms]
-name = Red Hat Container Development Kit 3.12 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-rpms]
-name = Red Hat Container Development Kit 3.4 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Grid Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-source-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.20-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -1781,7540 +31,8 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-debug-rpms]
-name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-debug-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-rpms]
-name = Red Hat Container Development Kit 3.5 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-debug-rpms]
-name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 6 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.7-rpms]
-name = Red Hat Container Development Kit 3.7 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhsi-textonly-1-for-middleware-rpms]
-name = Red Hat Service Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.20-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-debug-rpms]
-name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-source-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.13-rpms]
-name = Red Hat Container Development Kit 3.13 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-rpms]
-name = Red Hat Container Development Kit 2.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-for-rhel-9-textonly-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhose-textonly-1-for-middleware-rpms]
-name = Red Hat Middleware Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.9-rpms]
-name = Red Hat Container Development Kit 3.9 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-source-rpms]
-name = Red Hat Container Development Kit 2.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.8-rpms]
-name = Red Hat Container Development Kit 3.8 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.20-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.15-rpms]
-name = Red Hat Container Development Kit 3.15 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-rpms]
-name = Red Hat Container Development Kit 3.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-debug-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-rpms]
-name = Fast Datapath for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.14-rpms]
-name = Red Hat Container Development Kit 3.14 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-debug-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-textonly-1-for-middleware-rpms]
-name = OpenJDK Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rpms]
-name = Single Sign-On Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quarkus-textonly-1-for-middleware-rpms]
-name = Red Hat build of Quarkus Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jon-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Operations Network Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jpp-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Portal Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Server Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss AMQ Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fsw-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Fuse Service Works Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[wfk-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Framework Kit Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.11-rpms]
-name = Red Hat Container Development Kit 3.11 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-source-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jdv-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Virtualization Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-debug-rpms]
-name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhosds-textonly-3-for-middleware-rpms]
-name = Red Hat OpenShift Dev Spaces 3 Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.10-rpms]
-name = Red Hat Container Development Kit 3.10 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-source-rpms]
-name = Red Hat Container Development Kit 3.6 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhbop-textonly-1-for-middleware-rpms]
-name = Red Hat Build of OptaPlanner Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[soa-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss SOA Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-debug-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.16-rpms]
-name = Red Hat Container Development Kit 3.16 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.17-rpms]
-name = Red Hat Container Development Kit 3.17 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-source-rpms]
-name = Red Hat Container Development Kit 3.5 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openliberty-textonly-1-for-middleware-rpms]
-name = Open Liberty Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-source-rpms]
-name = Red Hat Container Development Kit 3.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
-name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-rpms]
-name = Red Hat Container Development Kit 3.6 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -9327,92 +45,260 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-highavailability-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-8-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-atomic-7-cdk-3.5-debug-rpms]
-name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-ironic-4.20-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/os
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -9425,8 +311,9542 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.19-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.21-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.19-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.21-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.19-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -9439,8 +9859,64 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/4455887482394223345-key.pem
-sslclientcert = /etc/pki/entitlement/4455887482394223345.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhcl-textonly-1-for-middleware-rpms]
+name = Red Hat Connectivity Link Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhcl/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/6316779263689430807-key.pem
+sslclientcert = /etc/pki/entitlement/6316779263689430807.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0

--- a/config/peerpods/podvm/rpms.lock.yaml
+++ b/config/peerpods/podvm/rpms.lock.yaml
@@ -39,13 +39,13 @@ arches:
     name: criu-libs
     evr: 3.19-1.el9
     sourcerpm: criu-3.19-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/crun-1.22-1.el9_6.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/c/crun-1.23.1-2.el9_6.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 229965
-    checksum: sha256:109e5b867b36e6dd01208fad047cb5b66ef24eef7f8ad350fe7859e805575a04
+    size: 231679
+    checksum: sha256:09f8995e4ad877a3db891c0bcb3f8405cca630710fe8b5dd6fd2802835bb3cfc
     name: crun
-    evr: 1.22-1.el9_6
-    sourcerpm: crun-1.22-1.el9_6.src.rpm
+    evr: 1.23.1-2.el9_6
+    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/e/emacs-filesystem-27.2-14.el9_6.2.noarch.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 9099
@@ -123,6 +123,13 @@ arches:
     name: netavark
     evr: 2:1.14.1-1.el9_6
     sourcerpm: netavark-1.14.1-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.s390x.rpm
+    repoid: ubi-9-for-s390x-appstream-rpms
+    size: 168035
+    checksum: sha256:ba2f6b929e94e26e4b058ed6eb6fba2178053af399c5b1cd612979bb42d3ad07
+    name: passt
+    evr: 0^20250217.ga1e48a0-10.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 21344
@@ -564,13 +571,13 @@ arches:
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/podman-5.4.0-12.el9_6.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/podman-5.4.0-13.el9_6.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 16399291
-    checksum: sha256:27db5d3256228e6237062f6613bc06cdafc388811f72d31b58733428390563ff
+    size: 16478231
+    checksum: sha256:e0e720b715f1dad7708d60cb05c254a7b45986573ac18454db45c3e5bf2072ac
     name: podman
-    evr: 5:5.4.0-12.el9_6
-    sourcerpm: podman-5.4.0-12.el9_6.src.rpm
+    evr: 5:5.4.0-13.el9_6
+    sourcerpm: podman-5.4.0-13.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 9000980
@@ -767,20 +774,13 @@ arches:
     name: unzip
     evr: 6.0-58.el9_5
     sourcerpm: unzip-6.0-58.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 168035
-    checksum: sha256:ba2f6b929e94e26e4b058ed6eb6fba2178053af399c5b1cd612979bb42d3ad07
-    name: passt
-    evr: 0^20250217.ga1e48a0-10.el9_6
-    sourcerpm: passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.7.s390x.rpm
-    repoid: rhel-9-for-s390x-appstream-rpms
-    size: 2043594
-    checksum: sha256:366107c3f70027577ad607081dfd30e5d220c4a7bd3a9bb1855962ed01b2f5f7
+    size: 2034132
+    checksum: sha256:00c653509b0652470860bda02507281a664e7b004440c8f1afd58b19211add3e
     name: qemu-img
-    evr: 17:9.1.0-15.el9_6.7
-    sourcerpm: qemu-kvm-9.1.0-15.el9_6.7.src.rpm
+    evr: 17:9.1.0-15.el9_6.9
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 225688
@@ -789,474 +789,474 @@ arches:
     evr: 6.9.6-1.el9.6
     sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/a/aardvark-dns-1.14.0-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/a/aardvark-dns-1.14.0-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 7571634
     checksum: sha256:7b06cb49aadb1f82ba3a8573c1017cfa577d2ede31dbd1894ebafb07b43b20e5
     name: aardvark-dns
     evr: 2:1.14.0-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/conmon-2.1.12-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/c/conmon-2.1.12-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 136182
     checksum: sha256:9c5cbcb53099efa0aef954de1de3e21168cbbca4e43a0a167002070356406ea9
     name: conmon
     evr: 3:2.1.12-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/containers-common-1-117.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/c/containers-common-1-117.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 168528
     checksum: sha256:3ae3f5c20849053dcd2d8dfc378f1687f63c19280045df9af39071d83d329834
     name: containers-common
     evr: 2:1-117.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 1397103
     checksum: sha256:e9d46b1c6c4ffa968a235504c57a721185ebc89bbc59e700589c908d0c1872f6
     name: criu
     evr: 3.19-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/c/crun-1.22-1.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 824093
-    checksum: sha256:f90bc0717e1e6192a81458b111da3dac9644babaa7af9462520f67eba7d4c880
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 845345
+    checksum: sha256:8fcfe0507a43ab0de2194e4d973b4f18ff24750fd56b5edbcb22ca626d07a6af
     name: crun
-    evr: 1.22-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+    evr: 1.23.1-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 44824139
     checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
     name: emacs
     evr: 1:27.2-14.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 114235
     checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
     name: fuse-overlayfs
     evr: 1.14-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 7707656
     checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
     name: git
     evr: 2.47.3-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 611553
     checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
     name: libnet
     evr: 1.2-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 128699
     checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
     name: libslirp
     evr: 4.4.0-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 306309
     checksum: sha256:748f99b4f3a7b03d1e91877d6a51e7f89c0e66089dbfc0b09a2ab53a85079793
     name: liburing
     evr: 2.5-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/n/netavark-1.14.1-1.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/n/netavark-1.14.1-1.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 18638548
     checksum: sha256:ec09355ee8b738dbeda11d9b808bbb6c37d2cb2940b8291ab64c78748c8c68d3
     name: netavark
     evr: 2:1.14.1-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 12786537
-    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
-    name: perl
-    evr: 4:5.32.1-481.1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 37030
-    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
-    name: perl-Carp
-    evr: 1.50-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 131573
-    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
-    name: perl-Data-Dumper
-    evr: 2.174-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 22653
-    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
-    name: perl-Digest
-    evr: 1.19-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 60213
-    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
-    name: perl-Digest-MD5
-    evr: 2.58-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 1915541
-    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
-    name: perl-Encode
-    evr: 4:3.08-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 46570
-    checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
-    name: perl-Error
-    evr: 1:0.17029-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 32709
-    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
-    name: perl-Exporter
-    evr: 5.74-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 43503
-    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
-    name: perl-File-Path
-    evr: 2.18-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 89500
-    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
-    name: perl-File-Temp
-    evr: 1:0.231.100-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 55697
-    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
-    name: perl-Getopt-Long
-    evr: 1:2.52-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 93389
-    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
-    name: perl-HTTP-Tiny
-    evr: 0.076-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 58169
-    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
-    name: perl-IO-Socket-IP
-    evr: 0.41-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 295384
-    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
-    name: perl-IO-Socket-SSL
-    evr: 2.073-2.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 43653
-    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
-    name: perl-MIME-Base64
-    evr: 3.16-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 151174
-    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
-    name: perl-Mozilla-CA
-    evr: 20200520-6.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 693539
-    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
-    name: perl-Net-SSLeay
-    evr: 1.94-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 141038
-    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
-    name: perl-PathTools
-    evr: 3.78-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 22192
-    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
-    name: perl-Pod-Escapes
-    evr: 1:1.07-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 225409
-    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
-    name: perl-Pod-Perldoc
-    evr: 3.28.01-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 318605
-    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
-    name: perl-Pod-Simple
-    evr: 1:3.42-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 91508
-    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
-    name: perl-Pod-Usage
-    evr: 4:2.01-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 187594
-    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
-    name: perl-Scalar-List-Utils
-    evr: 4:1.56-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 57721
-    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
-    name: perl-Socket
-    evr: 4:2.031-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 225886
-    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
-    name: perl-Storable
-    evr: 1:3.21-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 69123
-    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
-    name: perl-Term-ANSIColor
-    evr: 5.01-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 23367
-    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
-    name: perl-Term-Cap
-    evr: 1.17-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 98184
-    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
-    name: perl-TermReadKey
-    evr: 2.38-11.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 18773
-    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
-    name: perl-Text-ParseWords
-    evr: 3.30-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 30727
-    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
-    name: perl-Text-Tabs+Wrap
-    evr: 2013.0523-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 54755
-    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
-    name: perl-Time-Local
-    evr: 2:1.300-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 123780
-    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
-    name: perl-URI
-    evr: 5.09-3.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 32045
-    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
-    name: perl-constant
-    evr: 1.33-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 110461
-    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
-    name: perl-libnet
-    evr: 3.13-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 23463
-    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
-    name: perl-parent
-    evr: 1:0.238-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 150048
-    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
-    name: perl-podlators
-    evr: 1:4.14-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/podman-5.4.0-12.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 27533936
-    checksum: sha256:de8dcc05448738a852f6b2a13685acaf9058bc6dd9dfba15c2b707d4eed49979
-    name: podman
-    evr: 5:5.4.0-12.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-2.el9_6.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 10643546
-    checksum: sha256:1903a01e852401b8f0949fd1292da3c4e54816472a51ce6471e7704efbba1aac
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 76240
-    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
-    name: slirp4netns
-    evr: 1.3.2-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
-    repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 101373
-    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
-    name: yajl
-    evr: 2.1.0-25.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.1.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 2548520
-    checksum: sha256:36d71e3853fc8272af05f0367fec8e5bacfcb72731d93ed06525e754f35e6367
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 799367
-    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
-    name: fuse3
-    evr: 3.10.2-9.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 4138121
-    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
-    name: groff
-    evr: 1.22.4-10.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 709624
-    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
-    name: iptables
-    evr: 1.8.10-11.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 447607
-    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
-    name: jansson
-    evr: 2.14-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 1505374
-    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
-    name: jq
-    evr: 1.6-17.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 582431
-    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
-    name: kmod
-    evr: 28-10.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 385311
-    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
-    name: less
-    evr: 590-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 59434
-    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
-    name: libaio
-    evr: 0.3.111-13.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 276760
-    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
-    name: libcbor
-    evr: 0.7.0-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 531597
-    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
-    name: libedit
-    evr: 3.1-38.20210216cvs.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 865138
-    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
-    name: libfido2
-    evr: 1.13.0-2.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 388193
-    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
-    name: libnetfilter_conntrack
-    evr: 1.0.9-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 334502
-    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
-    name: libnfnetlink
-    evr: 1.0.1-23.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 400952
-    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
-    name: libnftnl
-    evr: 1.2.6-4.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 5068824
-    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
-    name: libnl3
-    evr: 3.11.0-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 2335546
-    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
-    name: make
-    evr: 1:4.3-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 3587058
-    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
-    name: ncurses
-    evr: 6.2-10.20210508.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/n/nftables-1.0.9-3.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 1009094
-    checksum: sha256:13ce4d036cdfb75fd7a919a22aa73714aa6bf08d0a566f8f16efa5f179e22c29
-    name: nftables
-    evr: 1:1.0.9-3.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 2415807
-    checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
-    name: openssh
-    evr: 8.7p1-45.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 513224
-    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
-    name: protobuf-c
-    evr: 1.3.3-13.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 1715281
-    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
-    name: shadow-utils
-    evr: 2:4.9-12.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
-    repoid: ubi-9-for-s390x-baseos-source-rpms
-    size: 1436757
-    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
-    name: unzip
-    evr: 6.0-58.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
     repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 307122
     checksum: sha256:87c7e342a579a0707c3ab950857d3bb52833828ebb5cadfbda529e01b3136072
     name: passt
     evr: 0^20250217.ga1e48a0-10.el9_6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
     repoid: rhel-9-for-s390x-appstream-source-rpms
-    size: 133006228
-    checksum: sha256:0ef91bfba0eb437562c840fd5f29cc922a9a9e191de5dc669f79d891a0b919c3
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 46570
+    checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
+    name: perl-Error
+    evr: 1:0.17029-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/podman-5.4.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 27554069
+    checksum: sha256:97129c769ef9fc1e57e7094e24c8d86271b365268247d137b6b4b2916b2b8bd4
+    name: podman
+    evr: 5:5.4.0-13.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 133005080
+    checksum: sha256:b79fc40e10431471c9e97f7a0ad94fee59be4b392387e63458da0058ca34f01b
     name: qemu-kvm
-    evr: 17:9.1.0-15.el9_6.7
+    evr: 17:9.1.0-15.el9_6.9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-2.el9_6.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 10643546
+    checksum: sha256:1903a01e852401b8f0949fd1292da3c4e54816472a51ce6471e7704efbba1aac
+    name: skopeo
+    evr: 2:1.18.1-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-s390x-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.1.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 2548520
+    checksum: sha256:36d71e3853fc8272af05f0367fec8e5bacfcb72731d93ed06525e754f35e6367
+    name: curl
+    evr: 7.76.1-31.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 709624
+    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
+    name: iptables
+    evr: 1.8.10-11.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 447607
+    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
+    name: jansson
+    evr: 2.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 59434
+    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
+    name: libaio
+    evr: 0.3.111-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 388193
+    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 334502
+    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 400952
+    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/n/nftables-1.0.9-3.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 1009094
+    checksum: sha256:13ce4d036cdfb75fd7a919a22aa73714aa6bf08d0a566f8f16efa5f179e22c29
+    name: nftables
+    evr: 1:1.0.9-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 935874
     checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
     name: oniguruma
     evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 2415807
+    checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
+    name: openssh
+    evr: 8.7p1-45.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
   module_metadata: []
 - arch: x86_64
   packages:
@@ -1295,13 +1295,13 @@ arches:
     name: criu-libs
     evr: 3.19-1.el9
     sourcerpm: criu-3.19-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.22-1.el9_6.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/crun-1.23.1-2.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 248049
-    checksum: sha256:89b235259e4f2594ff0cfb383fa1dfc8a5db98b787f1277791f79307a78ade30
+    size: 249255
+    checksum: sha256:0f885a416fe6086cf8d5e2dca053fdc8366e7878be939da6fe049dbb685eaa06
     name: crun
-    evr: 1.22-1.el9_6
-    sourcerpm: crun-1.22-1.el9_6.src.rpm
+    evr: 1.23.1-2.el9_6
+    sourcerpm: crun-1.23.1-2.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-14.el9_6.2.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9099
@@ -1379,6 +1379,13 @@ arches:
     name: netavark
     evr: 2:1.14.1-1.el9_6
     sourcerpm: netavark-1.14.1-1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 268131
+    checksum: sha256:d6ee97b3fd5226ecf3ee057aebbf395b5615a27d0f594b3fd1c1295d9cacdbb6
+    name: passt
+    evr: 0^20250217.ga1e48a0-10.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21344
@@ -1820,13 +1827,13 @@ arches:
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/podman-5.4.0-12.el9_6.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/podman-5.4.0-13.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 17637653
-    checksum: sha256:454750737efec23a651b10c69b83ffb3f56d2d39480a6f804d7c8cf5e3814e77
+    size: 17803252
+    checksum: sha256:7f3d4038e48455d3467e57c4f412ecca6d2c44a44bcf2d74b983cdb3b7cafd32
     name: podman
-    evr: 5:5.4.0-12.el9_6
-    sourcerpm: podman-5.4.0-12.el9_6.src.rpm
+    evr: 5:5.4.0-13.el9_6
+    sourcerpm: podman-5.4.0-13.el9_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.18.1-2.el9_6.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9530108
@@ -2030,20 +2037,13 @@ arches:
     name: unzip
     evr: 6.0-58.el9_5
     sourcerpm: unzip-6.0-58.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 268131
-    checksum: sha256:d6ee97b3fd5226ecf3ee057aebbf395b5615a27d0f594b3fd1c1295d9cacdbb6
-    name: passt
-    evr: 0^20250217.ga1e48a0-10.el9_6
-    sourcerpm: passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.7.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2599793
-    checksum: sha256:ceccbe4eb9f84ad867ff20c5fa4018f7d609d4c0e1c16805368cce3bca47fe13
+    size: 2590850
+    checksum: sha256:d09601658e499ce2f22878c95d1e80839ff1f51a35e6c24427d2bfb62c4d9195
     name: qemu-img
-    evr: 17:9.1.0-15.el9_6.7
-    sourcerpm: qemu-kvm-9.1.0-15.el9_6.7.src.rpm
+    evr: 17:9.1.0-15.el9_6.9
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 226451
@@ -2052,478 +2052,478 @@ arches:
     evr: 6.9.6-1.el9.6
     sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/a/aardvark-dns-1.14.0-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/aardvark-dns-1.14.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 7571634
     checksum: sha256:7b06cb49aadb1f82ba3a8573c1017cfa577d2ede31dbd1894ebafb07b43b20e5
     name: aardvark-dns
     evr: 2:1.14.0-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/conmon-2.1.12-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/conmon-2.1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 136182
     checksum: sha256:9c5cbcb53099efa0aef954de1de3e21168cbbca4e43a0a167002070356406ea9
     name: conmon
     evr: 3:2.1.12-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/containers-common-1-117.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/containers-common-1-117.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 168528
     checksum: sha256:3ae3f5c20849053dcd2d8dfc378f1687f63c19280045df9af39071d83d329834
     name: containers-common
     evr: 2:1-117.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/criu-3.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 1397103
     checksum: sha256:e9d46b1c6c4ffa968a235504c57a721185ebc89bbc59e700589c908d0c1872f6
     name: criu
     evr: 3.19-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/c/crun-1.22-1.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 824093
-    checksum: sha256:f90bc0717e1e6192a81458b111da3dac9644babaa7af9462520f67eba7d4c880
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/crun-1.23.1-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 845345
+    checksum: sha256:8fcfe0507a43ab0de2194e4d973b4f18ff24750fd56b5edbcb22ca626d07a6af
     name: crun
-    evr: 1.22-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+    evr: 1.23.1-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-14.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 44824139
     checksum: sha256:50a3faee5df3fd8d39609d97a62ef1297f668733105f4871d41a9257840269a3
     name: emacs
     evr: 1:27.2-14.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/f/fuse-overlayfs-1.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 114235
     checksum: sha256:ed1f6fd4c4c9efc2e499ffcb86c63d0f82657395e579a3f7b8525a4087ba5ece
     name: fuse-overlayfs
     evr: 1.14-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/git-2.47.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 7707656
     checksum: sha256:815c2ae9574006ecb596000492929264de785444736ee3968d5ee34cb6e75159
     name: git
     evr: 2.47.3-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libnet-1.2-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 611553
     checksum: sha256:bc2724e7061c48e2038f4f47b433bebccedb4ffc227dc351baaf3d5a52f03b08
     name: libnet
     evr: 1.2-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 128699
     checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
     name: libslirp
     evr: 4.4.0-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 306309
     checksum: sha256:748f99b4f3a7b03d1e91877d6a51e7f89c0e66089dbfc0b09a2ab53a85079793
     name: liburing
     evr: 2.5-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/n/netavark-1.14.1-1.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/n/netavark-1.14.1-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 18638548
     checksum: sha256:ec09355ee8b738dbeda11d9b808bbb6c37d2cb2940b8291ab64c78748c8c68d3
     name: netavark
     evr: 2:1.14.1-1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 12786537
-    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
-    name: perl
-    evr: 4:5.32.1-481.1.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 37030
-    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
-    name: perl-Carp
-    evr: 1.50-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 131573
-    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
-    name: perl-Data-Dumper
-    evr: 2.174-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 22653
-    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
-    name: perl-Digest
-    evr: 1.19-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 60213
-    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
-    name: perl-Digest-MD5
-    evr: 2.58-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 1915541
-    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
-    name: perl-Encode
-    evr: 4:3.08-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 46570
-    checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
-    name: perl-Error
-    evr: 1:0.17029-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 32709
-    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
-    name: perl-Exporter
-    evr: 5.74-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 43503
-    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
-    name: perl-File-Path
-    evr: 2.18-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 89500
-    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
-    name: perl-File-Temp
-    evr: 1:0.231.100-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 55697
-    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
-    name: perl-Getopt-Long
-    evr: 1:2.52-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 93389
-    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
-    name: perl-HTTP-Tiny
-    evr: 0.076-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 58169
-    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
-    name: perl-IO-Socket-IP
-    evr: 0.41-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 295384
-    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
-    name: perl-IO-Socket-SSL
-    evr: 2.073-2.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 43653
-    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
-    name: perl-MIME-Base64
-    evr: 3.16-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 151174
-    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
-    name: perl-Mozilla-CA
-    evr: 20200520-6.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 693539
-    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
-    name: perl-Net-SSLeay
-    evr: 1.94-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 141038
-    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
-    name: perl-PathTools
-    evr: 3.78-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 22192
-    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
-    name: perl-Pod-Escapes
-    evr: 1:1.07-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 225409
-    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
-    name: perl-Pod-Perldoc
-    evr: 3.28.01-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 318605
-    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
-    name: perl-Pod-Simple
-    evr: 1:3.42-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 91508
-    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
-    name: perl-Pod-Usage
-    evr: 4:2.01-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 187594
-    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
-    name: perl-Scalar-List-Utils
-    evr: 4:1.56-462.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 57721
-    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
-    name: perl-Socket
-    evr: 4:2.031-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 225886
-    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
-    name: perl-Storable
-    evr: 1:3.21-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 69123
-    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
-    name: perl-Term-ANSIColor
-    evr: 5.01-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 23367
-    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
-    name: perl-Term-Cap
-    evr: 1.17-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 98184
-    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
-    name: perl-TermReadKey
-    evr: 2.38-11.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 18773
-    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
-    name: perl-Text-ParseWords
-    evr: 3.30-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 30727
-    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
-    name: perl-Text-Tabs+Wrap
-    evr: 2013.0523-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 54755
-    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
-    name: perl-Time-Local
-    evr: 2:1.300-7.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 123780
-    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
-    name: perl-URI
-    evr: 5.09-3.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 32045
-    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
-    name: perl-constant
-    evr: 1.33-461.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 110461
-    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
-    name: perl-libnet
-    evr: 3.13-4.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 23463
-    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
-    name: perl-parent
-    evr: 1:0.238-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 150048
-    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
-    name: perl-podlators
-    evr: 1:4.14-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/podman-5.4.0-12.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 27533936
-    checksum: sha256:de8dcc05448738a852f6b2a13685acaf9058bc6dd9dfba15c2b707d4eed49979
-    name: podman
-    evr: 5:5.4.0-12.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-2.el9_6.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 10643546
-    checksum: sha256:1903a01e852401b8f0949fd1292da3c4e54816472a51ce6471e7704efbba1aac
-    name: skopeo
-    evr: 2:1.18.1-2.el9_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 76240
-    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
-    name: slirp4netns
-    evr: 1.3.2-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
-    repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 101373
-    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
-    name: yajl
-    evr: 2.1.0-25.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.1.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 2548520
-    checksum: sha256:36d71e3853fc8272af05f0367fec8e5bacfcb72731d93ed06525e754f35e6367
-    name: curl
-    evr: 7.76.1-31.el9_6.1
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 799367
-    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
-    name: fuse3
-    evr: 3.10.2-9.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 4138121
-    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
-    name: groff
-    evr: 1.22.4-10.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 709624
-    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
-    name: iptables
-    evr: 1.8.10-11.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 447607
-    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
-    name: jansson
-    evr: 2.14-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 1505374
-    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
-    name: jq
-    evr: 1.6-17.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 582431
-    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
-    name: kmod
-    evr: 28-10.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 385311
-    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
-    name: less
-    evr: 590-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 59434
-    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
-    name: libaio
-    evr: 0.3.111-13.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 276760
-    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
-    name: libcbor
-    evr: 0.7.0-5.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 531597
-    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
-    name: libedit
-    evr: 3.1-38.20210216cvs.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 865138
-    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
-    name: libfido2
-    evr: 1.13.0-2.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 388193
-    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
-    name: libnetfilter_conntrack
-    evr: 1.0.9-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 334502
-    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
-    name: libnfnetlink
-    evr: 1.0.1-23.el9_5
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 400952
-    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
-    name: libnftnl
-    evr: 1.2.6-4.el9_4
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 5068824
-    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
-    name: libnl3
-    evr: 3.11.0-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 2335546
-    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
-    name: make
-    evr: 1:4.3-8.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 3587058
-    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
-    name: ncurses
-    evr: 6.2-10.20210508.el9_6.2
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/n/nftables-1.0.9-3.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 1009094
-    checksum: sha256:13ce4d036cdfb75fd7a919a22aa73714aa6bf08d0a566f8f16efa5f179e22c29
-    name: nftables
-    evr: 1:1.0.9-3.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/n/numactl-2.0.19-1.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 231614
-    checksum: sha256:df493be344a68a29145a960db9b1fff8ff8ed673338b1608f404a648ef38164c
-    name: numactl
-    evr: 2.0.19-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 2415807
-    checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
-    name: openssh
-    evr: 8.7p1-45.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 513224
-    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
-    name: protobuf-c
-    evr: 1.3.3-13.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 1715281
-    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
-    name: shadow-utils
-    evr: 2:4.9-12.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
-    repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 1436757
-    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
-    name: unzip
-    evr: 6.0-58.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/passt-0^20250217.ga1e48a0-10.el9_6.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 307122
     checksum: sha256:87c7e342a579a0707c3ab950857d3bb52833828ebb5cadfbda529e01b3136072
     name: passt
     evr: 0^20250217.ga1e48a0-10.el9_6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.1.el9_6.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 133006228
-    checksum: sha256:0ef91bfba0eb437562c840fd5f29cc922a9a9e191de5dc669f79d891a0b919c3
+    size: 12786537
+    checksum: sha256:cef69403d27b100525c0e630fb17d1ef1d598c608241ea07ba0975b559a42858
+    name: perl
+    evr: 4:5.32.1-481.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 46570
+    checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
+    name: perl-Error
+    evr: 1:0.17029-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 98184
+    checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
+    name: perl-TermReadKey
+    evr: 2.38-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/podman-5.4.0-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 27554069
+    checksum: sha256:97129c769ef9fc1e57e7094e24c8d86271b365268247d137b6b4b2916b2b8bd4
+    name: podman
+    evr: 5:5.4.0-13.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 133005080
+    checksum: sha256:b79fc40e10431471c9e97f7a0ad94fee59be4b392387e63458da0058ca34f01b
     name: qemu-kvm
-    evr: 17:9.1.0-15.el9_6.7
+    evr: 17:9.1.0-15.el9_6.9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/skopeo-1.18.1-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10643546
+    checksum: sha256:1903a01e852401b8f0949fd1292da3c4e54816472a51ce6471e7704efbba1aac
+    name: skopeo
+    evr: 2:1.18.1-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/slirp4netns-1.3.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 76240
+    checksum: sha256:9f048c86095d12608596b30fc60180fd0cc5ae4f4e5c25d26567f82b15cafede
+    name: slirp4netns
+    evr: 1.3.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/y/yajl-2.1.0-25.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 101373
+    checksum: sha256:08182ae11608d0ad5d9ef01c558a39489f331fe449f9be6df1a91c5e950163f9
+    name: yajl
+    evr: 2.1.0-25.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2548520
+    checksum: sha256:36d71e3853fc8272af05f0367fec8e5bacfcb72731d93ed06525e754f35e6367
+    name: curl
+    evr: 7.76.1-31.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 709624
+    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
+    name: iptables
+    evr: 1.8.10-11.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447607
+    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
+    name: jansson
+    evr: 2.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1505374
+    checksum: sha256:88870e90abd12a46ac6da90154b82e5f4f3f5fbf5fb9116160e85875436aa8fa
+    name: jq
+    evr: 1.6-17.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 59434
+    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
+    name: libaio
+    evr: 0.3.111-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 388193
+    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 334502
+    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 400952
+    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2335546
+    checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
+    name: make
+    evr: 1:4.3-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587058
+    checksum: sha256:2c3309af9b6637047a8dec3f7e84c03da6fa4ab9570d78cad92c045bfd0fa1e3
+    name: ncurses
+    evr: 6.2-10.20210508.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/nftables-1.0.9-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1009094
+    checksum: sha256:13ce4d036cdfb75fd7a919a22aa73714aa6bf08d0a566f8f16efa5f179e22c29
+    name: nftables
+    evr: 1:1.0.9-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/numactl-2.0.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 231614
+    checksum: sha256:df493be344a68a29145a960db9b1fff8ff8ed673338b1608f404a648ef38164c
+    name: numactl
+    evr: 2.0.19-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 935874
     checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
     name: oniguruma
     evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2415807
+    checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
+    name: openssh
+    evr: 8.7p1-45.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1715281
+    checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
+    name: shadow-utils
+    evr: 2:4.9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
   module_metadata: []


### PR DESCRIPTION
We updated the image, but not the lockfile, and we built an image with the same (vulnerable) podman version in it.

Updating the lockfile to get the fix in.
