### PR TITLE
baremetal-coco: Uninstall update - delete kata-cc runtimeclass

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -514,7 +514,7 @@ EOF
 #handler: kata-$TEE_TYPE
 #kind: RuntimeClass
 #metadata:
-#  name: kata-$TEE_TYPE
+#  name: kata-cc
 #scheduling:
 #  nodeSelector:
 #    $label
@@ -865,7 +865,7 @@ function uninstall() {
     wait_for_mcp worker || return 1
 
     # Delete the runtimeClass
-    oc delete runtimeclass kata-"$TEE_TYPE" &>/dev/null
+    oc delete runtimeclass kata-cc &>/dev/null
 
     echo "Uninstall completed successfully"
 }


### PR DESCRIPTION
Due to previous change (unifying naming for kata-tdx/kata-snp -> kata-cc runtimeclass) updated uninstall script

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- Description of the problem which is fixed/What is the use case**

Fixed removing runtimeclass which name was previously changed from kata-tdx/kata-snp to kata-cc

**- How to verify it**

1. Perform install either with TEE: TDX or SNP 
2. Perform uninstall
3. Expected behavior -> oc get runtimeclass will not show kata-cc name with handler: kata-tdx/kata-snp

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated uninstall script - fixed removing runtimeclass