### PR TITLE
osc-operator: remove controller-gen pre-fetch workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY controllers controllers/
 COPY controller-gen bin/
 
 # get the version of controller-gen in an env variable for reusing
-RUN echo "export CONTROLLER_TOOLS_VERSION=$(grep controller-tools go.mod | awk '{print $2}')" > controller-tools-ver
+RUN echo "export CONTROLLER_TOOLS_VERSION=$(grep -m 1 controller-tools go.mod | awk '{print $2}')" > controller-tools-ver
 
 # rename the script to use the same version as defined in our go.mod file
 RUN . ./controller-tools-ver && mv bin/controller-gen bin/controller-gen-$CONTROLLER_TOOLS_VERSION

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,14 +41,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	// These imports are unused but required in go.mod
-	// for caching during manifest generation by controller-gen
-	_ "github.com/spf13/cobra"
-	_ "sigs.k8s.io/controller-tools/pkg/crd"
-	_ "sigs.k8s.io/controller-tools/pkg/genall"
-	_ "sigs.k8s.io/controller-tools/pkg/genall/help/pretty"
-	_ "sigs.k8s.io/controller-tools/pkg/loader"
-
 	peerpod "github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl/api/v1alpha1"
 	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 

--- a/controller-gen
+++ b/controller-gen
@@ -12,4 +12,4 @@
 # to find controller-gen.
 # Makefile will then NOT install the tool, and just run the script instead.
 
-go run sigs.k8s.io/controller-tools/cmd/controller-gen $@
+go tool sigs.k8s.io/controller-tools/cmd/controller-gen $@

--- a/go.mod
+++ b/go.mod
@@ -205,3 +205,5 @@ require (
 )
 
 replace vbom.ml/util => github.com/fvbommel/util v0.0.3
+
+tool sigs.k8s.io/controller-tools/cmd/controller-gen


### PR DESCRIPTION
"go tool" is a feature introduced with go v1.24 [0], that lets developpers declare a tool that is needed for their project, and manage its dependency along with any other.

This removes the need to make a blank import from our main.go file. We can also remove the script that calls "go run" for downstream builds, as now we can use "go tool" even within the Makefile.

[0] https://go.dev/doc/modules/managing-dependencies#tools
