### PR TITLE
Drop trailing space in manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -86,7 +86,7 @@ spec:
             - name: RELATED_IMAGE_PODVM_BUILDER
               value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:7eced79ce90649959d62469fa928b6bbfd7abe15d7a1e364399bfa91a5ba6912
             - name: RELATED_IMAGE_PODVM_PAYLOAD
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:5b118ab22dd0c261ed16a164c497f651b3a8bc26deddac0a4dd236f0fdbd6af4 
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:5b118ab22dd0c261ed16a164c497f651b3a8bc26deddac0a4dd236f0fdbd6af4
             - name: RELATED_IMAGE_PODVM_OCI
               value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:db8e1d9563195088d7612f648099aba32243297d0b5c403aca6240fd5a7d2d8b
             - name: RELATED_IMAGE_MUST_GATHER


### PR DESCRIPTION
The trailing space at the end of the podvm payload image URI was there
forever. Since this line gets updated by mintmaker for every new podvm
payload image build, it can cause conflicts in someone's PR if they happen
to remove the trailing space on the way.

Clean this now in a dedicated PR.