### PR TITLE
Delete image config map on KataConfig deletion

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -61,7 +61,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 		} else {
 			if state == Enabled {
 				// Create ImageConfigMap, if it doesn't exist already.
-				if err := ig.createImageConfigMapFromFile(); err != nil {
+				if err := ig.createImageConfigMapFromFile(r.kataConfig); err != nil {
 					return err
 				}
 

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 /*
@@ -139,7 +141,7 @@ func GetImageGenerator() *ImageGenerator {
 }
 
 // ImageCreate creates a podvm image for a cloud provider if not present
-func ImageCreate(c client.Client) (int, error) {
+func ImageCreate(c client.Client, kataConfig *kataconfigurationv1.KataConfig) (int, error) {
 	if err := InitializeImageGenerator(c); err != nil {
 		igLogger.Info("error initializing ImageGenerator instance", "err", err)
 		return ImageCreationFailed, ErrInitializingImageGenerator
@@ -157,7 +159,7 @@ func ImageCreate(c client.Client) (int, error) {
 	}
 
 	// Create required podvm image configMap
-	if err := ig.createImageConfigMapFromFile(); err != nil {
+	if err := ig.createImageConfigMapFromFile(kataConfig); err != nil {
 		igLogger.Info("error creating podvm image configMap from file", "err", err)
 		return ImageCreationFailed, ErrCreatingImageConfigMap
 	}
@@ -772,7 +774,7 @@ func (r *ImageGenerator) getImageConfigMapName() string {
 // ibmcloud-podvm-image-cm.yaml for IBM Cloud
 // Returns error if the ConfigMap creation fails
 
-func (r *ImageGenerator) createImageConfigMapFromFile() error {
+func (r *ImageGenerator) createImageConfigMapFromFile(kataConfig *kataconfigurationv1.KataConfig) error {
 	// file format: [azure|aws|libvirt]-podvm-image-cm.yaml
 	// ConfigMap name: [azure|aws|libvirt]-podvm-image-cm
 
@@ -846,6 +848,11 @@ func (r *ImageGenerator) createImageConfigMapFromFile() error {
 		imageVersion = strings.ReplaceAll(imageVersion, ".", "-")
 		cm.Data["IMAGE_VERSION"] = imageVersion
 		igLogger.Info("Setting IMAGE_VERSION", "image_version", imageVersion)
+	}
+
+	// To ensure that it gets deleted along with the KataConfig
+	if err := controllerutil.SetControllerReference(kataConfig, cm, r.client.Scheme()); err != nil {
+		return err
 	}
 
 	if err := r.client.Create(context.TODO(), cm); err != nil {

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -488,7 +488,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPods() (*ctrl.Result, error) {
 	// RequeueNeeded
 	// ImageCreationStatusUnknown
 
-	status, err := ImageCreate(r.Client)
+	status, err := ImageCreate(r.Client, r.kataConfig)
 	switch status {
 	case ImageCreatedSuccessfully:
 		r.setInProgressConditionToPodVMImageCreated()


### PR DESCRIPTION
In the default scenario, the podvm image config map is created by the operator. If the a podvm base OCI image is available, it is set in `PODVM_IMAGE_URI` item during KataConfig creation.

The config map is left untouched on KataConfig deletion. If a new KataConfig is created afterwards, it will end up silently using the OCI image from the previous deployment.

Have the KataConfig to own the podvm image config map when it is created by the controller. This will ensure it is fully removed when KataConfig is deleted.