### PR TITLE
Revert "correct kata-tdx and kata-snp config paths for kernel_params"

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -475,10 +475,10 @@ kernel_params=\"$kernel_params\""
 
     case $tee_type in
     tdx)
-        filepath=/etc/kata-containers/kata-tdx/config.d/96-kata-kernel-config
+        filepath=/etc/kata-containers/tdx/config.d/96-kata-kernel-config
         ;;
     snp)
-        filepath=/etc/kata-containers/kata-snp/config.d/96-kata-kernel-config
+        filepath=/etc/kata-containers/snp/config.d/96-kata-kernel-config
         ;;
     esac
 


### PR DESCRIPTION
This reverts commit ae1696157a24778682db5a1d92b46ed6ed2ee51b.

Per [Pei Zhang's request](https://redhat-internal.slack.com/archives/G01H4GSHP1B/p1760521883364809?thread_ts=1759380788.059529&cid=G01H4GSHP1B) as this PR is causing the current CI setup fail.


