### PR TITLE
Add extendedResources to TEE runtimeClasses

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -22,6 +22,10 @@ const (
 	// RuntimeClass handlers for TEE
 	kataCCIntelHandler = "kata-cc-intel"
 	kataCCAmdHandler   = "kata-cc-amd"
+
+	// Extended resources for TEE
+	intelTDXExtendedResource = "tdx.intel.com/keys"
+	amdSNPExtendedResource   = "sev-snp.amd.com/esids"
 )
 
 // When the feature is enabled, handleFeatureConfidential configures confidential computing support.
@@ -121,8 +125,16 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 			return err
 		}
 
+		// Determine extended resource based on TEE type
+		var kataCCRuntimeClassExtResOverhead string
+		if handler == kataCCIntelHandler {
+			kataCCRuntimeClassExtResOverhead = intelTDXExtendedResource
+		} else if handler == kataCCAmdHandler {
+			kataCCRuntimeClassExtResOverhead = amdSNPExtendedResource
+		}
+
 		// Create kata-cc runtime class restricted to the detected TEE subset
-		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, handler, nodeLabel)
+		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, nodeLabel)
 		if err != nil {
 			r.Log.Info("Error creating "+kataCCRuntimeClassName+" runtime class", "err", err)
 			return fmt.Errorf("Error creating "+kataCCRuntimeClassName+" runtime class: %w", err)

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -778,9 +778,19 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, handler string, additionalNodeLabel string) error {
+func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, extResOverhead string, handler string, additionalNodeLabel string) error {
 
 	rc := func() *nodeapi.RuntimeClass {
+		podFixed := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpuOverhead),
+			corev1.ResourceMemory: resource.MustParse(memoryOverhead),
+		}
+
+		// Add extended resource if provided
+		if extResOverhead != "" {
+			podFixed[corev1.ResourceName(extResOverhead)] = resource.MustParse("1")
+		}
+
 		rc := &nodeapi.RuntimeClass{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "node.k8s.io/v1",
@@ -792,10 +802,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 			},
 			Handler: handler,
 			Overhead: &nodeapi.Overhead{
-				PodFixed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse(cpuOverhead),
-					corev1.ResourceMemory: resource.MustParse(memoryOverhead),
-				},
+				PodFixed: podFixed,
 			},
 		}
 
@@ -2237,7 +2244,7 @@ func (r *KataConfigOpenShiftReconciler) deleteScc() error {
 func (r *KataConfigOpenShiftReconciler) postKataInstallation() (*ctrl.Result, error) {
 	r.Log.Info("create runtime class")
 	r.resetInProgressCondition()
-	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, kataRuntimeClassName, "")
+	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, "", kataRuntimeClassName, "")
 	if err != nil {
 		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -321,7 +321,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	}
 
 	// Create runtimeClass config for peer-pods
-	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead, peerpodsRuntimeClassName, "")
+	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead, "", peerpodsRuntimeClassName, "")
 	if err != nil {
 		r.Log.Info("Error in creating kata remote runtimeclass", "err", err)
 		return err


### PR DESCRIPTION
When the confidential computing feature is enabled for baremetal:
 - Intel TDX systems will get a RuntimeClass with tdx.intel.com/keys: 1 in the overhead
 - AMD SNP systems will get a RuntimeClass with sev-snp.amd.com/esids: 1 in the overhead

Fixes: #[KATA-4284](https://issues.redhat.com//browse/KATA-4284)

