### PR TITLE
renaming confidential runtimeclass handlers

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -20,8 +20,8 @@ const (
 	amdSNPNodeLabel   = "amd.feature.node.kubernetes.io/snp"
 
 	// RuntimeClass handlers for TEE
-	kataCCIntelHandler = "kata-cc-intel"
-	kataCCAmdHandler   = "kata-cc-amd"
+	kataCCIntelHandler = "kata-tdx"
+	kataCCAmdHandler   = "kata-snp"
 
 	// Extended resources for TEE
 	intelTDXExtendedResource = "tdx.intel.com/keys"

--- a/scripts/install-helpers/baremetal-coco/README.md
+++ b/scripts/install-helpers/baremetal-coco/README.md
@@ -123,7 +123,10 @@ The deployment sequence is described below:
 
   This will deploy the pre-GA release of OSC operator on TDX hosts.
 
-After successful install `kata`, `kata-tdx` or `kata-snp` runtimeclasses will be created based on the TEE type.
+After successful install, the following runtimeclasses will be created:
+  - `kata` for non-confidential workloads
+  - `kata-cc` for confidential workloads (with handler `kata-tdx` for Intel TDX or `kata-snp` for AMD SNP)
+
 
 ## Un-installation
 


### PR DESCRIPTION
This is a rename to match what we have today in our install scripts.

Fixes rhjira#KATA-4267.
