### PR TITLE
test-fbc: add integration tests pipeline

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: osc-test-fbc-integration
+spec:
+  description: >-
+    Run Prow jobs for testing the osc-test-fbc catalog.
+  params:
+    - name: GANGWAY_TOKEN
+      type: string
+      description: Token to authenticate with gangway
+      default: gangway-token
+    - description: 'Snapshot of the application'
+      name: SNAPSHOT
+      default: '{"components": [{"name":"osc-test-fbc", "containerImage": "quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:latest"}]}'
+      type: string
+  tasks:
+    - name: get-catalog-image
+      params:
+      - name: SNAPSHOT
+        value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        results:
+          - name: CATALOG_IMAGE
+            description: "The catalog image extracted from the SNAPSHOT"
+        steps:
+          - name: get-catalog-image
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+            script: |
+              #!/bin/bash
+              set -e
+              dnf -y install jq
+              echo "Snapshot: ${SNAPSHOT}"
+              catalogImage=$(jq -r '.components[] | select(.name=="osc-test-fbc") | .containerImage' <<< "${SNAPSHOT}")
+              echo "Catalog image: ${catalogImage}"
+              echo "${catalogImage}" > $(results.CATALOG_IMAGE.path)
+    - name: prow-job
+      displayName: "Running prow job $(params.PROWJOB_NAME)"
+      timeout: "4h"
+      runAfter:
+        - get-catalog-image
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/openshift/konflux-tasks
+        - name: revision
+          value: 26d8e981a7d1d035f05c4accd30b38d07f8f02b5
+        - name: pathInRepo
+          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: VARIANT
+          value: downstream-candidate
+        - name: ENVS
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE)"
+      matrix:
+        params:
+          - name: PROWJOB_NAME
+            value:
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-peerpods
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods


### PR DESCRIPTION

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- Description of the problem which is fixed/What is the use case**

We want to run the downstream QE tests on new builds of osc-test-catalog image.

**- What I did**

This is a tekton pipeline that should be triggered by Konflux as integration tests after a osc-test-catalog image is successful built. It will trigger the existing [downstream Prow jobs](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/sandboxed-containers-operator/openshift-sandboxed-containers-operator-devel__downstream-candidate.yaml) that will run the [OSC e2e tests](https://github.com/openshift/openshift-tests-private/tree/master/test/extended/kata) on the new test catalog.

Merging that PR **will not** enable the triggering as for that we need to configure on Konflux side.

**- How to verify it**

That's how I verified this works:

 * pushed the pipeline definition to https://github.com/wainersm/sandboxed-containers-operator/tree/osc-test-fbc-integration
 * At Konflux side, added a new integration tests (named `osc-test-catalog-intergration`) for the osc-test-catalog application, pointing to the above definition. Configured to trigger on pull request
 * Still at Konflux, created a secret named `gangway-token` with my personal [Prow API token](https://docs.ci.openshift.org/docs/how-tos/triggering-prowjobs-via-rest/#obtaining-an-authentication-token)
 *  Opened a fake PR on this repository just to trigger the pipeline on Konflux: https://github.com/openshift/sandboxed-containers-operator/pull/1228
 
As you can see in https://github.com/openshift/sandboxed-containers-operator/pull/1228/checks?check_run_id=53619686100 it triggered the pipeline on Konflux that in turn triggered 5 jobs in Prow (each of the tasks named "test-kata" correspond to a Prow job).

The pipeline failed because each task is given 2h to finish but our Prow jobs takes more time than that. It seems that the pipeline can be configured with a different timeout, I tried but it still waiting for the 2h....this is something I will need to figure out.

The triggered prow jobs all failed too because tests failed. It is something that we should be fixing on Prow and/or OSC e2e tests.

**- Description for the changelog**

N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
