### PR TITLE
Update Dockerfile to support multiple architectures

### DIFF
--- a/scripts/kata-install/Dockerfile
+++ b/scripts/kata-install/Dockerfile
@@ -1,15 +1,26 @@
 FROM registry.access.redhat.com/ubi9/skopeo:9.6-1760517870
 
-RUN mkdir -p /files
+ARG UMO_VERSION=0.4.7
+ARG TARGETARCH
+
+RUN mkdir -p /files /scripts
 
 ADD 50-kata-remote configuration-remote.toml /files/
-
-RUN mkdir -p /scripts
-
 ADD osc-kata-install.sh osc-configs-script.sh osc-log-level.sh lib.sh /scripts/
 
-RUN curl -sSL "https://github.com/opencontainers/umoci/releases/download/v0.4.7/umoci.amd64" -o "/usr/local/bin/umoci" &&\
-    chmod +x "/usr/local/bin/umoci"
+# fetch the right umoci binary for the target arch
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64)    UMO_SUFFIX=amd64 ;; \
+      arm64)    UMO_SUFFIX=arm64 ;; \
+      ppc64le)  UMO_SUFFIX=ppc64le ;; \
+      s390x)    UMO_SUFFIX=s390x ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/opencontainers/umoci/releases/download/v${UMO_VERSION}/umoci.${UMO_SUFFIX}" \
+      -o /usr/local/bin/umoci; \
+    chmod +x /usr/local/bin/umoci; \
+    # optional: verify it runs and prints a version
+    /usr/local/bin/umoci --version || { echo "umoci not runnable"; exit 1; }
 
 CMD ["/scripts/osc-kata-install.sh"]
- 


### PR DESCRIPTION
The umoci was hard coded to amd64. Diversifying the dockerfile. Disclaimer: I haven't tested this yet. Just wanted to put a proposal out here.

**- Description of the problem which is fixed/What is the use case**
s390 team noticed daemonset install container had resources that wouldn't run on s390. 

**- What I did**
Added a TARGETARCH to specify platform.

**- How to verify it**
build container and run on different platforms. 

**- Description for the changelog**
expand daemonset installer container to support s390x, ppc64le, arm64 (beyond the original amd64)