### PR TITLE
Fix looping caused by LastTransitionTime updates

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -865,6 +866,13 @@ func (r *KataConfigOpenShiftReconciler) updateStatusDaemonSet(action KataDaemonS
 			err = e
 		}
 	}
+
+	sort.Strings(r.kataConfig.Status.KataNodes.WaitingToInstall)
+	sort.Strings(r.kataConfig.Status.KataNodes.Installing)
+	sort.Strings(r.kataConfig.Status.KataNodes.Installed)
+	sort.Strings(r.kataConfig.Status.KataNodes.WaitingToUninstall)
+	sort.Strings(r.kataConfig.Status.KataNodes.Uninstalling)
+	sort.Strings(r.kataConfig.Status.KataNodes.FailedToInstall)
 
 	r.kataConfig.Status.KataNodes.ReadyNodeCount = len(r.kataConfig.Status.KataNodes.Installed)
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -121,6 +121,8 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
+	oldObjStatus := r.kataConfig.Status.DeepCopy()
+
 	err = r.migratePeerPodsLimit()
 	if err != nil {
 		r.Log.Info("Failed to migrate PeerPodConfig limit", "err", err)
@@ -199,9 +201,13 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err != nil {
 			return res, err
 		}
-		updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
-		if updateErr != nil {
-			return ctrl.Result{}, updateErr
+
+		if r.IsKataConfigStatusChanged(oldObjStatus, &r.kataConfig.Status) {
+			r.Log.Info("KataConfig's status changed, updating...")
+			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+			if updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
 		}
 
 		cMap := r.processDashboardConfigMap()

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -239,6 +239,20 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 	}()
 }
 
+func (r *KataConfigOpenShiftReconciler) IsKataConfigStatusChanged(oldStatus, newStatus *kataconfigurationv1.KataConfigStatus) bool {
+	oldStatusCopy := oldStatus.DeepCopy()
+	newStatusCopy := newStatus.DeepCopy()
+
+	for i := range oldStatusCopy.Conditions {
+		oldStatusCopy.Conditions[i].LastTransitionTime = metav1.Time{}
+	}
+	for i := range newStatusCopy.Conditions {
+		newStatusCopy.Conditions[i].LastTransitionTime = metav1.Time{}
+	}
+
+	return !reflect.DeepEqual(oldStatusCopy, newStatusCopy)
+}
+
 func makeContainerRuntimeConfig(desiredLogLevel string, mcpSelector *metav1.LabelSelector) *mcfgv1.ContainerRuntimeConfig {
 	return &mcfgv1.ContainerRuntimeConfig{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
The reconciliation loop was being triggered unnecessarily due to two main issues:
1. The kataConfig.Status.KataNodes list was not sorted, causing changes in item order between reconciliations.
1. The LastTransitionTime field was always updated, even when the rest of the status remained unchanged.

These issues led to frequent status updates and redundant reconciliations.

**- What I did**
Added sorting to the kataConfig.Status.KataNodes list to ensure consistent ordering.
Introduced the IsKataConfigStatusChanged method to compare two KataConfigStatus objects while ignoring LastTransitionTime.
Updated the reconciliation logic to only update the KataConfig if meaningful changes are detected (excluding LastTransitionTime).

**- How to verify it**
Deploy the operator and observe the reconciliation behavior.
Observe reconciliation loops are no longer triggered by unchanged status or reordered lists.

**- Description for the changelog**
Fix reconciliation loop caused by unsorted KataNodes and unnecessary LastTransitionTime updates.
