### PR TITLE
Remove image signature verification hack

### DIFF
--- a/config/peerpods/podvm/lib.sh
+++ b/config/peerpods/podvm/lib.sh
@@ -266,18 +266,15 @@ to edit policy.conf"
 
     # Enable image signature check
     if [[ "$CONFIDENTIAL_COMPUTE_ENABLED" == "yes" ]]; then
-        local agent_config_file="/etc/agent-config.toml"
-
-        cat <<EOF >"${podvm_dir}/files${agent_config_file}"
+	cat<<EOF>"${podvm_dir}"/files/etc/agent-config.toml
 server_addr = "unix:///run/kata-containers/agent.sock"
 guest_components_procs = "none"
 image_registry_auth = "file:///run/peerpod/auth.json"
 enable_signature_verification = true
 image_policy_file = "kbs:///default/security-policy/osc"
 EOF
-        sed -i "s,/run/peerpod/agent-config.toml,${agent_config_file},g" \
-            "${podvm_dir}"/files/etc/systemd/system/kata-agent.service
-        echo "sudo cp -a /tmp/files${agent_config_file} ${agent_config_file}" >>"${podvm_dir}"/qcow2/copy-files.sh
+	sed -i 's,/run/peerpod/agent-config.toml,/etc/agent-config.toml,' \
+	    "${podvm_dir}"/files/etc/systemd/system/kata-agent.service
     fi
 }
 

--- a/config/peerpods/podvm/lib.sh
+++ b/config/peerpods/podvm/lib.sh
@@ -264,18 +264,6 @@ to edit policy.conf"
         fi
     fi
 
-    # Enable image signature check
-    if [[ "$CONFIDENTIAL_COMPUTE_ENABLED" == "yes" ]]; then
-	cat<<EOF>"${podvm_dir}"/files/etc/agent-config.toml
-server_addr = "unix:///run/kata-containers/agent.sock"
-guest_components_procs = "none"
-image_registry_auth = "file:///run/peerpod/auth.json"
-enable_signature_verification = true
-image_policy_file = "kbs:///default/security-policy/osc"
-EOF
-	sed -i 's,/run/peerpod/agent-config.toml,/etc/agent-config.toml,' \
-	    "${podvm_dir}"/files/etc/systemd/system/kata-agent.service
-    fi
 }
 
 # Download and extract the pause container image


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

On OSC 1.9.0 we introduced a hack to allow image signature verification on CoCo (peer pods) workloads. It was needed because the code was not ready upstream yet, as we needed that feature rolled out for our dev/tech preview.

The upcoming OSC 1.11 ships a version of kata-agent and guest-components that proper support image signature verification.

**- What I did**

Reverted the hack.

**- How to verify it**

It's enabled by simply adding a `[image]` directive in `cdh.toml` section in the initdata.

Here is the template:
```
[image]
image_security_policy_uri = 'SECURITY_POLICY_KBS_URI'
```

Where `SECURITY_POLICY_KBS_URI` is the  URI for the containers-policy.json file in the KBS.

For example, suppose that you have the policy file in `kbs:///default/security-policy/osc`  then a snippet of initdata will be:
```
algorithm = "sha384"
version = "0.1.0"

[data]
"aa.toml" = '''
[token_configs]
[token_configs.coco_as]
url = 'TRUSTEE_URL'

[token_configs.kbs]
url = 'TRUSTEE_URL'
'''

"cdh.toml"  = '''
socket = 'unix:///run/confidential-containers/cdh.sock'
credentials = []

[kbc]
name = 'cc_kbc'
url = 'TRUSTEE_URL'

[image]
image_security_policy_uri = 'kbs:///default/security-policy/osc'
'''

"policy.rego" = '''
....
....
....
```
The container policy file has the same format, nothing changed. For example:
```
{
    "default": [
        {
        "type": "insecureAcceptAnything"
        }
    ],
    "transports": {
        "docker": {
            "ghcr.io/confidential-containers/test-container-image-rs": [
                {
                    "type": "sigstoreSigned",
                    "keyPath": "kbs:///default/cosign-public-key/test"
                }
            ]
        }
    }
}
```
**- Description for the changelog**

