### PR TITLE
fix(ibmse): Fix to make it work without machine specific HKD

### DIFF
--- a/scripts/rvps-extraction/GetRvps.sh
+++ b/scripts/rvps-extraction/GetRvps.sh
@@ -137,8 +137,14 @@ do
             se_tag=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.tag | awk -F ":" '{ print $2 }')
             se_image_phkh=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.image_phkh | awk -F ":" '{ print $2 }')
 
+            # copy attestation phkh if image phkh is unavailable ex. without machine specific HKD
+            if [ -z "${se_image_phkh}" ]; then
+               se_image_phkh=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.attestation_phkh | awk -F ":" '{ print $2 }')
+            fi
+
             echo "se.tag: $se_tag"
             echo "se.image_phkh: $se_image_phkh"
+
 
             generate_policy_files $se_tag $se_image_phkh
 
@@ -184,6 +190,11 @@ EOF
             # Extract necessary values
             se_tag=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.tag | awk -F ":" '{ print $2 }')
             se_image_phkh=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.image_phkh | awk -F ":" '{ print $2 }')
+
+             # copy attestation phkh if image phkh is unavailable ex. without machine specific HKD
+            if [ -z "${se_image_phkh}" ]; then
+               se_image_phkh=$(python3 $PWD/static-files/se_parse_hdr.py $PWD/output-files/hdr.bin $PWD/static-files/HKD.crt | grep se.attestation_phkh | awk -F ":" '{ print $2 }')
+            fi
 
             echo "se.tag: $se_tag"
             echo "se.image_phkh: $se_image_phkh"


### PR DESCRIPTION
This fix is needed to generate correct ibmse-policy.rego for the z17 lpars

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
Even though the HKD is valid, the current script says following
```
Mounting on second attempt passed
/dev/nbd0 disconnected
SE header found at offset 0x014000
SE header written to '/home/linuxuser/eshant/Rvps-Extraction/output-files/hdr.bin' (640 bytes)
se.tag:  9121b1872ea6a57570b3b9a1bf4d10eb
se.image_phkh: 
There seems to be some issue in HKD.crt. Please use the correct one and run it again.
```

If HKD in not included during HPCC productioin image generation, then the script does not provide the ibmse rego records

**- What I did**
Instead of failing (for example, for z17), se.image_phkh will get value from se.attestation_phkh.

**- How to verify it**
running on z Lpars

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

After fix
```
Mounting on second attempt passed
/dev/nbd0 disconnected
SE header found at offset 0x014000
SE header written to '/home/linuxuser/eshant/Rvps-Extraction/output-files/hdr.bin' (640 bytes)
se.tag:  9121b1872ea6a57570b3b9a1bf4d10eb
se.image_phkh:  4941c69214b2c55fdd9de087330a0d7f0437d643ff616c29177bebed2f5330f5
provenance = ewogICAgInNlLmF0dGVzdGF0aW9uX3Boa2giOiBbCiAgICAgICAgIjQ5NDFjNjkyMTRiMmM1NWZkZDlkZTA4NzMzMGEwZDdmMDQzN2Q2NDNmZjYxNmMyOTE3N2JlYmVkMmY1MzMwZjUiCiAgICBdLAogICAgInNlLnRhZyI6IFsKICAgICAgICAiOTEyMWIxODcyZWE2YTU3NTcwYjNiOWExYmY0ZDEwZWIiCiAgICBdLAogICAgInNlLmltYWdlX3Boa2giOiBbCiAgICAgICAgIjQ5NDFjNjkyMTRiMmM1NWZkZDlkZTA4NzMzMGEwZDdmMDQzN2Q2NDNmZjYxNmMyOTE3N2JlYmVkMmY1MzMwZjUiCiAgICBdLAogICAgInNlLnVzZXJfZGF0YSI6IFsKICAgICAgICAiMDAiCiAgICBdLAogICAgInNlLnZlcnNpb24iOiBbCiAgICAgICAgIjI1NiIKICAgIF0KfQo=
-rw-r--r--. 1 root root 640 Nov 11 01:26 /home/linuxuser/eshant/Rvps-Extraction/output-files/hdr.bin
-rw-r--r--. 1 root root 561 Nov 11 01:26 /home/linuxuser/eshant/Rvps-Extraction/output-files/se-message
-rw-r--r--. 1 root root 446 Nov 11 01:26 /home/linuxuser/eshant/Rvps-Extraction/output-files/ibmse-policy.rego


$ cat output-files/ibmse-policy.rego
package policy
import rego.v1
default allow = false
converted_version := sprintf("%v", [input["se.version"]])
allow if {
    input["se.attestation_phkh"] == "4941c69214b2c55fdd9de087330a0d7f0437d643ff616c29177bebed2f5330f5"
    input["se.image_phkh"] == "4941c69214b2c55fdd9de087330a0d7f0437d643ff616c29177bebed2f5330f5"
    input["se.tag"] == "9121b1872ea6a57570b3b9a1bf4d10eb"
    input["se.user_data"] == "00"
    converted_version == "256"
}

```