### PR TITLE
scripts: update intel DCAP deployment images

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -40,6 +40,12 @@ spec:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-pccs
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs
 ---
 apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
@@ -83,3 +89,9 @@ spec:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-pccs
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/pccs.yaml.in
@@ -57,7 +57,7 @@ spec:
             privileged: true  # Required for chcon to work on host files
       containers:
         - name: pccs
-          image: quay.io/openshift_sandboxed_containers/dcap/pccs:0.2.4
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:64c8df8575c0b9b67922a5b7adb0d14aed1637261a869ed4a341d58d4a16997b
           envFrom:
             - secretRef:
                 name: pccs-secrets

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
         - name: platform-registration
-          image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs:edcc57ff3ac78f64b58f232b69e4c37420ba8926
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:583cd20b21a859ac6abefcd5b37e2c353c2c3c572ee7fcae66bfe1db6f97886e
           restartPolicy: Always
           command: [ '/usr/bin/dcap-registration-flow' ]
           env:
@@ -46,7 +46,7 @@ spec:
               mountPath: /sys/firmware/efi/efivars
       containers:
         - name: tdx-qgs
-          image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs:edcc57ff3ac78f64b58f232b69e4c37420ba8926
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:583cd20b21a859ac6abefcd5b37e2c353c2c3c572ee7fcae66bfe1db6f97886e
           args:
             - -p=4050
             - -n=4


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**

Intel DCAP deployment for TDX needs image updates.

**- What I did**

Changed the deployment to use the latest images from Konflux.

**- How to verify it**

`install.sh` deployment for TDX.

**- Description for the changelog**
Use the latest, UBI10 / RHEL 10.1 based images.