### PR TITLE
Add Intel's related images to manager.yaml

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-07T13:31:15Z"
+    createdAt: "2025-11-13T15:21:40Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -91,6 +91,12 @@ spec:
               value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:d5562f5797b71e1cd40aadfce8a47a5d605e34e52efb1ed78e98e3da7e938763
             - name: RELATED_IMAGE_MUST_GATHER
               value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:6ec8e552e49510e252de2f962595f14e7983f424ba796ddc6c08f235e463ba84
+            - name: RELATED_IMAGE_PCCS
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:64c8df8575c0b9b67922a5b7adb0d14aed1637261a869ed4a341d58d4a16997b
+            - name: RELATED_IMAGE_TDX_QGS
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:583cd20b21a859ac6abefcd5b37e2c353c2c3c572ee7fcae66bfe1db6f97886e
+            - name: RELATED_IMAGE_STORAGE_HELPER
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:61aba7d0642f5f8cc2e61bd22a8fd1727c8d6bd6b07036e66ab6a25570b204e7
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
This is the only place where we should change the RELATED_IMAGES. After we change them here, we should update the rest with "make bundle" and then commit the changes created in the CSV file.

In this commit I'm also update the date when it was generated (rounding up a few hours).

For further information, please see https://github.com/openshift/sandboxed-containers-operator/pull/1339 and commit 58a821a5d.

When this commit is merged, all images will be synced accordingly.

