### PR TITLE
Add OCP version check for CoCo bare metal support

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -125,6 +125,22 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 // It manages kata-cc runtime classes with TEE-specific handlers (Intel TDX, AMD SNP or IBM SE).
 func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state FeatureGateState) error {
 	if state == Enabled {
+		if !r.kataConfig.Spec.EnablePeerPods {
+			isLess, version, err := r.isOCPVersionLessThan("4.20")
+			if err != nil {
+				// Return error to trigger reconcile retry (cluster version not available yet or API error)
+				return err
+			}
+			if isLess {
+				r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", version, "minVersion", "4.20")
+				cond := r.retrieveInProgressConditionForChange()
+				cond.Status = corev1.ConditionFalse
+				cond.Reason = "UnsupportedOCPVersion"
+				cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: 4.20)", version)
+				return nil
+			}
+		}
+
 		r.Log.Info("Creating " + kataCCRuntimeClassName + " runtime class for confidential containers")
 
 		handler, nodeLabel, err := r.computeTEEHandlerAndLabel()

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	semver "github.com/Masterminds/semver/v3"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -568,6 +569,34 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 
 	// As RHCOS is rather special variant, use "kata-containers" by default, which also applies to FCOS/SCOS
 	return "kata-containers", nil
+}
+
+// isOCPVersionLessThan checks if the current OpenShift cluster version is less than the specified minimum version.
+// Returns (true, version, nil) if current version < minVersion, (false, version, nil) if current >= minVersion.
+// Returns error if cluster version is not available or cannot be retrieved.
+func (r *KataConfigOpenShiftReconciler) isOCPVersionLessThan(minVersion string) (bool, string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	if err != nil {
+		return false, "", err
+	}
+
+	currentVersion := clusterVersion.Status.Desired.Version
+	if currentVersion == "" {
+		return false, "", fmt.Errorf("cluster version not available yet")
+	}
+
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false, currentVersion, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
+	}
+
+	min, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return false, currentVersion, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
+	}
+
+	return current.LessThan(min), currentVersion, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) newMCForCR(machinePool string) (*mcfgv1.MachineConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/confidential-containers/cloud-api-adaptor/src/cloud-providers v0.16.0
 	github.com/confidential-containers/cloud-api-adaptor/src/peerpod-ctrl v0.16.0
 	github.com/coreos/ignition/v2 v2.20.0
@@ -39,7 +40,6 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.89.0 // indirect
 	github.com/IBM/vpc-go-sdk v0.74.1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 // indirect
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.10 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect


### PR DESCRIPTION
Validate OpenShift version >= 4.20 before enabling CoCo bare metal. Set UnsupportedOCPVersion condition and skip reconciliation on older versions.

Fixes: rhjira#[KATA-3965](https://issues.redhat.com//browse/KATA-3965)
