### PR TITLE
test-fbc: Handle pagination in quay.io API

### DIFF
--- a/fbc/test-fbc/changelog.sh
+++ b/fbc/test-fbc/changelog.sh
@@ -56,6 +56,8 @@ function get_commit_for_image() {
                 fi
             done
         fi
+        HAS_MORE=$(echo "$RESPONSE" | jq -r '.has_additional')
+        [[ "$HAS_MORE" != "true" ]] && break
         PAGE=$((PAGE + 1))
     done
 }


### PR DESCRIPTION
Our pipeline is currently failing to create test catalogs. It appears to be looping on :

  jq: error (at <stdin>:1): Cannot iterate over null (null)
  jq: error (at <stdin>:1): Cannot iterate over null (null)
  jq: error (at <stdin>:1): Cannot iterate over null (null)
  jq: error (at <stdin>:1): Cannot iterate over null (null)
  jq: error (at <stdin>:1): Cannot iterate over null (null)

This comes from a ininite loop when trying to generate the changelog. Leverage `.has_additional` from the quay.io to break out the loop.
