### PR TITLE
test-fbc: Temporarily unplug changelog generation

### DIFF
--- a/fbc/test-fbc/Dockerfile
+++ b/fbc/test-fbc/Dockerfile
@@ -17,18 +17,22 @@ RUN cp -r test-fbc/catalog/ /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Optionally clone the git repo and generate changelog from it
-ENV GIT_URL=${GIT_URL}
-ENV GIT_REVISION=${GIT_REVISION}
-RUN if [[ -n "${GIT_URL}" && -n "${GIT_REVISION}" ]]; then \
-        echo GIT_URL="${GIT_URL}" ; \
-        echo GIT_REVISION="${GIT_REVISION}" ; \
-        git clone "${GIT_URL}" repo && \
-        pushd repo && \
-        git checkout "${GIT_REVISION}" && \
-        cd fbc/test-fbc && \
-        ./changelog.sh && \
-        popd ; \
-    fi
+#
+# FIXME : temporarily unplug changelog generation until changelog.sh is fixed
+#         see https://github.com/openshift/sandboxed-containers-operator/pull/1381
+#
+# ENV GIT_URL=${GIT_URL}
+# ENV GIT_REVISION=${GIT_REVISION}
+# RUN if [[ -n "${GIT_URL}" && -n "${GIT_REVISION}" ]]; then \
+#         echo GIT_URL="${GIT_URL}" ; \
+#         echo GIT_REVISION="${GIT_REVISION}" ; \
+#         git clone "${GIT_URL}" repo && \
+#         pushd repo && \
+#         git checkout "${GIT_REVISION}" && \
+#         cd fbc/test-fbc && \
+#         ./changelog.sh && \
+#         popd ; \
+#     fi
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
 # The base image is expected to contain
@@ -40,7 +44,11 @@ CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
 COPY --from=builder /configs /configs
 COPY --from=builder /tmp/cache /tmp/cache
-COPY --from=builder /workdir/repo/fbc/test-fbc/CHANGELOG /CHANGELOG
+#
+# FIXME : temporarily unplug changelog generation until changelog.sh is fixed
+#         see https://github.com/openshift/sandboxed-containers-operator/pull/1381
+#
+#COPY --from=builder /workdir/repo/fbc/test-fbc/CHANGELOG /CHANGELOG
 
 # Set FBC-specific label for the location of the FBC root directory
 # in the image


### PR DESCRIPTION
The `changelog.sh` script has some bugs (see #1381) that cause the pipeline to fail. This results in no new test catalogs.

Temporarily disable the changelog generation to unblock the release effort.
