### PR TITLE
Fix min version check for CoCo baremetal

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -105,7 +105,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 	} else {
 		peerpodsCMData = map[string]string{
 			"DISABLECVM": "true",
-			"INITDATA": defaultNonCCInitdata,
+			"INITDATA":   defaultNonCCInitdata,
 		}
 		keysToRemove = nil
 	}
@@ -126,17 +126,17 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state FeatureGateState) error {
 	if state == Enabled {
 		if !r.kataConfig.Spec.EnablePeerPods {
-			isLess, version, err := r.isOCPVersionLessThan("4.20")
+			isLess, version, err := r.isOCPVersionLessThan("4.20.6")
 			if err != nil {
 				// Return error to trigger reconcile retry (cluster version not available yet or API error)
 				return err
 			}
 			if isLess {
-				r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", version, "minVersion", "4.20")
+				r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", version, "minVersion", "4.20.6")
 				cond := r.retrieveInProgressConditionForChange()
 				cond.Status = corev1.ConditionFalse
 				cond.Reason = "UnsupportedOCPVersion"
-				cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: 4.20)", version)
+				cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: 4.20.6)", version)
 				return nil
 			}
 		}


### PR DESCRIPTION
Extract only the core version (major.minor.patch) from both versions
Ignore prerelease and build metadata when comparing

