### PR TITLE
Bump the osc-daemonset image to 1.11

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -33,7 +33,7 @@ const (
 	rhelCoreOsExtensionsImageName = "rhel-coreos-extensions"
 	cliImageName                  = "cli"
 
-	daemonSetImage = "quay.io/openshift_sandboxed_containers/osc-daemonset:1.10.3"
+	daemonSetImage = "quay.io/openshift_sandboxed_containers/osc-daemonset:1.11"
 )
 
 // KataInstallationDaemonSetState defines the possible states of the Kata installation DaemonSet.


### PR DESCRIPTION
The image doesn't exist yet but we do want OSC 1.11 to reference it.

Note that daemonset won't be usable at all as long as the image isn't available in quay.

Cc @ANJANA-A-R-K @ajaypvictor @Pacho20 @gcoon151
