### PR TITLE
Add multi-arch support to the osc-daemonset image

### DIFF
--- a/scripts/kata-install/Dockerfile
+++ b/scripts/kata-install/Dockerfile
@@ -8,8 +8,9 @@ RUN mkdir -p /scripts
 
 ADD osc-kata-install.sh osc-configs-script.sh osc-log-level.sh lib.sh /scripts/
 
-RUN curl -sSL "https://github.com/opencontainers/umoci/releases/download/v0.4.7/umoci.amd64" -o "/usr/local/bin/umoci" &&\
+# Multi-arch umoci support (amd64 and s390x)
+ARG TARGETARCH=amd64
+RUN curl -sSL "https://github.com/opencontainers/umoci/releases/download/v0.5.0/umoci.linux.${TARGETARCH}" -o "/usr/local/bin/umoci" &&\
     chmod +x "/usr/local/bin/umoci"
 
 CMD ["/scripts/osc-kata-install.sh"]
- 

--- a/scripts/kata-install/README.md
+++ b/scripts/kata-install/README.md
@@ -1,0 +1,69 @@
+# How to build the image
+
+## Multi-architecture images
+
+This guide explains how to build and push multi-architecture container images using Podman or Docker.
+
+### Prerequisites
+- A Linux system with QEMU and `binfmt` properly configured for cross-platform builds.
+- Access to a container registry (e.g., `quay.io`).
+
+The image uses an environment variable `TARGETARCH`, which should match one of the supported architectures (e.g., `amd64`, `s390x`) recognized by your build tool and `umoci`.
+
+### Building with Podman
+
+Run the following commands from the project root directory:
+
+```bash
+VERSION=1.11
+IMAGE_BASE=quay.io/openshift_sandboxed_containers/osc-daemonset
+
+# Build for amd64
+podman build \
+  --platform linux/amd64 \
+  --build-arg TARGETARCH=amd64 \
+  -t "${IMAGE_BASE}:${VERSION}-amd64" \
+  -f scripts/kata-install/Dockerfile \
+  ./scripts/kata-install
+
+# Build for s390x
+podman build \
+  --platform linux/s390x \
+  --build-arg TARGETARCH=s390x \
+  -t "${IMAGE_BASE}:${VERSION}-s390x" \
+  -f scripts/kata-install/Dockerfile \
+  ./scripts/kata-install
+
+# Create a multi-arch manifest
+podman manifest create "${IMAGE_BASE}:${VERSION}"
+podman manifest add "${IMAGE_BASE}:${VERSION}" "${IMAGE_BASE}:${VERSION}-amd64"
+podman manifest add "${IMAGE_BASE}:${VERSION}" "${IMAGE_BASE}:${VERSION}-s390x"
+
+# Push the multi-arch image
+podman manifest push --all "${IMAGE_BASE}:${VERSION}"
+```
+Tip: Verify the manifest after creation:
+
+```bash
+podman manifest inspect "${IMAGE_BASE}:${VERSION}"
+```
+
+### Building with Docker buildx
+
+Run the following command from the project root directory:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/s390x \
+  -t quay.io/openshift_sandboxed_containers/osc-daemonset:1.11 \
+  -f scripts/kata-install/Dockerfile \
+  ./scripts/kata-install \
+  --push
+```
+
+### Additional information
+
+Multi-architecture manifests allow a single image tag to support multiple CPU architectures, enabling automatic selection based on the client’s platform.
+Learn more about multi-platform builds:
+- [Docker official documentation](https://docs.docker.com/build/building/multi-platform)
+- [Red Hat guide on multi-architecture](https://developers.redhat.com/learning/learn:openshift:simplify-certificate-management-openshift-across-multiple-architectures/resource/resources:create-multi-architecture-images-cross-platform-applications)


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
Previously, the osc-daemonset image could only be built for the amd64 platform because of the hardcoded umoci URL. This PR adds support for multi-arch builds.
**- What I did**
Added a new variable TARGETARCH and modified the umoci URL to include this variable.
**- How to verify it**
Use a build tool that supports multi-arch builds to build the images.
**- Description for the changelog**
Add multi-arch support to the osc-daemonset image
