### PR TITLE
tests/osc-test-fbc-integration: new parameters and misc updates

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -38,7 +38,7 @@ spec:
               echo "Snapshot: ${SNAPSHOT}"
               catalogImage=$(jq -r '.components[] | select(.name=="osc-test-fbc") | .containerImage' <<< "${SNAPSHOT}")
               echo "Catalog image: ${catalogImage}"
-              echo "${catalogImage}" > $(results.CATALOG_IMAGE.path)
+              echo -n "${catalogImage}" > $(results.CATALOG_IMAGE.path)
     - name: prow-job
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -59,7 +59,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE)"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.1"
       matrix:
         params:
           - name: PROWJOB_NAME

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -50,7 +50,7 @@ spec:
         - name: url
           value: https://github.com/openshift/konflux-tasks
         - name: revision
-          value: 26d8e981a7d1d035f05c4accd30b38d07f8f02b5
+          value: b5c2ace84d1de50a016bb319f0ebd3ad4dd0aba9
         - name: pathInRepo
           value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
       params:

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -59,7 +59,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.1"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.1,FORCE_SUCCESS_EXIT=no"
       matrix:
         params:
           - name: PROWJOB_NAME


### PR DESCRIPTION
The current osc-test-fbc-integration pipeline in Konflux which runs to test the test-fbc catalog have a broken test because it expects the old operator version of 1.11.0. I could have it fixed in Prow side, but I preferred to add a new `EXPECTED_OPERATOR_VERSION` parameter to the pipeline so we can bump the version at same time test-fbc version is raised.

In order to have `EXPECTED_OPERATOR_VERSION` taking effect I had to fix a issue (that's the commit 3c6630582b9fd496997a3a8f2c6c47030af867ca).

While in here, because testing these changes is time-consuming, I added two more changes:

* passing the `FORCE_SUCCESS_EXIT=no` parameter to force the job report fail to any kind of error (CI infra or tests failures)
* bumped the konflux-tasks to latest and greatest to pick up some nice features like job submission retry