### PR TITLE
konflux: add a renovate.json file to control Mintmaker PR flow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true",
+        "github>konflux-ci/mintmaker-presets:disable-minor-updates"
+    ]
+}


### PR DESCRIPTION
Trying to add renovate (Mintmaker) config to reduce the number of PRs we get.
The rationale is
- we usually don't want to merge major versions of dependencies, as they are generally more risky. We should do that in a controlled, manual way.
- we may want to keep minor version updates. But at this point I think we should reduce drastically the number of PRs we get every week.

With this setting, we should get only "patch" version updates, which in theory gets us security fixes, with a reduced risk of breaking things.
