### PR TITLE
Support node-specific extension images in DaemonSet mode

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"context"
+	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -460,7 +462,7 @@ func (r *KataConfigOpenShiftReconciler) addPeerPodsConfigDaemonSet() error {
 // daemonSetForPeerPodsConfig creates a DaemonSet for peer-pods configuration.
 // The Daemonset will copy or remove the peer-pods configuration files based on the given action.
 func (r *KataConfigOpenShiftReconciler) daemonSetForPeerPodsConfig(action KataDaemonSetAction) (*appsv1.DaemonSet, error) {
-	cliImageString, err := GetImageForComponent(cliImageName, r.Client)
+	cliImages, err := r.GetNodeImages(cliImageName, "CLI_IMAGE")
 	if err != nil {
 		r.Log.Info("couldn't get image", "err", err)
 		return nil, err
@@ -479,6 +481,29 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForPeerPodsConfig(action KataDa
 
 	volumeMounts := r.volumeMountsForRegistries()
 	volumes := r.volumesForRegistries()
+
+	envVars := []corev1.EnvVar{
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+	}
+
+	for name, value := range cliImages {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+
+	// Sort the envvars, so the order is always the same, otherwise kubernetes thinks the DaemonSet changed and rollout new Pods
+	slices.SortStableFunc[[]corev1.EnvVar, corev1.EnvVar](envVars, func(a corev1.EnvVar, b corev1.EnvVar) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
@@ -519,22 +544,9 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForPeerPodsConfig(action KataDa
 								Privileged: &runPrivileged,
 								RunAsUser:  &runAsUser,
 							},
-							Command: []string{"/bin/bash", "/scripts/osc-configs-script.sh"},
-							Args:    []string{string(action)},
-							Env: []corev1.EnvVar{
-								{
-									Name: "NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "CLI_IMAGE",
-									Value: cliImageString,
-								},
-							},
+							Command:      []string{"/bin/bash", "/scripts/osc-configs-script.sh"},
+							Args:         []string{string(action)},
+							Env:          envVars,
 							VolumeMounts: volumeMounts,
 						},
 					},
@@ -550,14 +562,14 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForPeerPodsConfig(action KataDa
 // The DaemonSet's Pod contains three containers: one installs the binaries, one modifies the node labels, and one sets the runtime log level.
 func (r *KataConfigOpenShiftReconciler) daemonSetForKataInstall(action KataDaemonSetAction) (*appsv1.DaemonSet, error) {
 	// This image contains the binaries for kata-containers
-	extensionImageString, err := GetImageForComponent(rhelCoreOsExtensionsImageName, r.Client)
+	extensionImages, err := r.GetNodeImages(rhelCoreOsExtensionsImageName, "EXTENSION_IMAGE")
 	if err != nil {
 		r.Log.Error(err, "couldn't get extension image")
 		return nil, err
 	}
 
 	// This image contains kubectl and makes changing the node labels easier
-	cliImageString, err := GetImageForComponent(cliImageName, r.Client)
+	cliImages, err := r.GetNodeImages(cliImageName, "CLI_IMAGE")
 	if err != nil {
 		r.Log.Error(err, "couldn't get cli image")
 		return nil, err
@@ -593,17 +605,23 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForKataInstall(action KataDaemo
 			},
 		},
 		{
-			Name:  "EXTENSION_IMAGE",
-			Value: extensionImageString,
-		},
-		{
-			Name:  "CLI_IMAGE",
-			Value: cliImageString,
-		},
-		{
 			Name:  "NODE_LABEL",
 			Value: kataInstallationDaemonSetLabel,
 		},
+	}
+
+	for name, value := range extensionImages {
+		kataInstallEnv = append(kataInstallEnv, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+
+	for name, value := range cliImages {
+		kataInstallEnv = append(kataInstallEnv, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
 	}
 
 	// Add addon environment variables if ConfigMap exists
@@ -611,6 +629,11 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForKataInstall(action KataDaemo
 	if addonEnvVars != nil {
 		kataInstallEnv = append(kataInstallEnv, addonEnvVars...)
 	}
+
+	// Sort the envvars, so the order is always the same, otherwise kubernetes thinks the DaemonSet changed and rollout new Pods
+	slices.SortStableFunc[[]corev1.EnvVar, corev1.EnvVar](kataInstallEnv, func(a corev1.EnvVar, b corev1.EnvVar) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/image_component.go
+++ b/controllers/image_component.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	semver "github.com/Masterminds/semver/v3"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/oc/pkg/cli/admin/release"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
@@ -21,6 +23,7 @@ import (
 )
 
 const defaultGraphURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
+const IBMCloudWorkerVersionLabel = "ibm-cloud.kubernetes.io/worker-version"
 
 // Cache for the loaded images
 var (
@@ -57,6 +60,67 @@ type versionGraph struct {
 type versionNode struct {
 	Version string `json:"version"`
 	Payload string `json:"payload"`
+}
+
+// GetNodeImages builds a map from node-derived keys to container image strings
+// for the specified componentName, applying cloud-provider-specific logic.
+func (r *KataConfigOpenShiftReconciler) GetNodeImages(componentName string, prefix string) (map[string]string, error) {
+	provider, err := getCloudProviderFromInfra(r.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := r.getNodesWithLabels(r.getNodeSelectorAsMap())
+	if err != nil {
+		return nil, err
+	}
+
+	images := make(map[string]string)
+
+	var getImage func(corev1.Node) (string, error)
+
+	switch provider {
+	case IBMCloudProvider:
+		getImage = func(node corev1.Node) (string, error) {
+			rawVersion, ok := node.Labels[IBMCloudWorkerVersionLabel]
+			if !ok {
+				return "", fmt.Errorf("worker node does not have %s label, not able to determine worker node version", IBMCloudWorkerVersionLabel)
+			}
+			version, _, _ := strings.Cut(rawVersion, "_")
+
+			image, err := GetImageForComponent(componentName, version, defaultGraphURL, r.Client)
+			if err != nil {
+				return "", fmt.Errorf("failed to get component image for provider %s: %w", provider, err)
+			}
+
+			return image, nil
+		}
+	default:
+		getImage = func(_ corev1.Node) (string, error) {
+			image, err := GetImageForComponent(componentName, "", "", r.Client)
+			if err != nil {
+				return "", fmt.Errorf("failed to get component image for provider %s: %w", provider, err)
+			}
+			return image, nil
+		}
+	}
+
+	for _, node := range nodes.Items {
+		image, err := getImage(node)
+		if err != nil {
+			return nil, err
+		}
+		images[formatImageKey(prefix, node.GetName())] = image
+	}
+	return images, nil
+}
+
+// formatImageKey builds a stable, uppercase node key in the format:
+// "<prefix>_<NODE_NAME_UPPER>", where hyphens in the node name are replaced with underscores.
+// Example: prefix="CLI_IMAGE", nodeName="worker-1" => "CLI_IMAGE_WORKER_1".
+func formatImageKey(prefix, nodeName string) string {
+	replaced := strings.ReplaceAll(nodeName, "-", "_")
+	return prefix + "_" + strings.ToUpper(replaced)
 }
 
 // GetImageForComponent returns the container image for componentName from a specified

--- a/controllers/image_component.go
+++ b/controllers/image_component.go
@@ -2,30 +2,104 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"sync"
 
+	semver "github.com/Masterminds/semver/v3"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/oc/pkg/cli/admin/release"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetImageForComponent retrieves the Docker image for a specified component.
-// It uses the OpenShift client to fetch the cluster version and then loads the release info.
-// It searches for the componentName in the release info and returns the corresponding Docker image.
-func GetImageForComponent(componentName string, client client.Client) (string, error) {
-	// Fetch the cluster version
-	clusterVersion := &configv1.ClusterVersion{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
-	if err != nil {
-		return "", fmt.Errorf("failed to get cluster version: %w", err)
+const defaultGraphURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
+
+// Cache for the loaded images
+var (
+	imageCache = make(map[string]map[string]string)
+	cacheMu    sync.RWMutex
+)
+
+func getCachedImage(componentName, versionKey string) (string, bool) {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
+	if inner, ok := imageCache[componentName]; ok {
+		if img, ok := inner[versionKey]; ok {
+			return img, true
+		}
+	}
+	return "", false
+}
+
+func setCachedImage(componentName, versionKey, image string) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	inner, ok := imageCache[componentName]
+	if !ok {
+		inner = make(map[string]string)
+		imageCache[componentName] = inner
+	}
+	inner[versionKey] = image
+}
+
+type versionGraph struct {
+	Nodes []versionNode `json:"nodes"`
+}
+
+type versionNode struct {
+	Version string `json:"version"`
+	Payload string `json:"payload"`
+}
+
+// GetImageForComponent returns the container image for componentName from a specified
+// OpenShift release payload. If version is provided, the function attempts to resolve
+// the release payload, then loads release info for that payload. If version is empty
+// it falls back to the cluster's release image.
+func GetImageForComponent(componentName string, version string, graphURL string, k8sClient client.Client) (string, error) {
+	var versionKey string
+	if version != "" {
+		versionKey = version
+	} else {
+		// Use cluster's desired release image when version is not specified
+		clusterVersion := &configv1.ClusterVersion{}
+		if err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+			return "", fmt.Errorf("failed to get cluster version: %w", err)
+		}
+		versionKey = clusterVersion.Status.Desired.Image
+		if versionKey == "" {
+			return "", fmt.Errorf("no release image found in cluster version")
+		}
 	}
 
-	releaseImage := clusterVersion.Status.Desired.Image
-	if releaseImage == "" {
-		return "", fmt.Errorf("no release image found in cluster version")
+	// Check cache
+	if img, ok := getCachedImage(componentName, versionKey); ok {
+		return img, nil
+	}
+
+	// Resolve release image
+	var releaseImage string
+	if version != "" {
+		// Resolve release image from upgrade graph if a version is specified
+		payload, err := getPayloadFromGraph(version, graphURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve version payload from upgrade graph: %w", err)
+		}
+		if payload == "" {
+			return "", fmt.Errorf("couldn't find the provided version in the upgrade graph")
+		}
+
+		releaseImage = payload
+	} else {
+		// Use cluster's desired release image when version is not specified
+		releaseImage = versionKey
 	}
 
 	// Create IOStreams
@@ -40,8 +114,7 @@ func GetImageForComponent(componentName string, client client.Client) (string, e
 	// Load release info (set retrieveImages to false for faster loading)
 	releaseInfo, err := infoOptions.LoadReleaseInfo(releaseImage, false)
 	if err != nil {
-		fmt.Printf("Error loading release info: %v\n", err)
-		return "", err
+		return "", fmt.Errorf("error loading release info: %w", err)
 	}
 
 	// Search for the componentName and return
@@ -49,6 +122,7 @@ func GetImageForComponent(componentName string, client client.Client) (string, e
 		if tag.Name == componentName {
 			// we found the short name in ImageStream
 			if tag.From != nil && tag.From.Kind == "DockerImage" {
+				setCachedImage(componentName, versionKey, tag.From.Name)
 				return tag.From.Name, nil
 			}
 		}
@@ -56,4 +130,78 @@ func GetImageForComponent(componentName string, client client.Client) (string, e
 
 	// Didn't find it
 	return "", fmt.Errorf("empty result for image name")
+}
+
+// getPayloadFromGraph tries to map a semantic version (e.g., "4.14.24") to the
+// exact release payload image using the upgrade graph. It queries the "stable"
+// channel for the given 4.x minor.
+// Based on github.com/openshift/oc/pkg/cli/admin/release
+func getPayloadFromGraph(version string, graphURL string) (string, error) {
+	if len(graphURL) == 0 {
+		graphURL = defaultGraphURL
+	}
+	u, err := url.Parse(graphURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the version and ensure it’s an OCP 4.x version for channel lookup
+	semanticVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("invalid semantic version %s: %w", version, err)
+	}
+	if semanticVersion.Major() != uint64(4) {
+		return "", fmt.Errorf("only OpenShift 4.x versions are supported")
+	}
+
+	// Build a client with a proper User-Agent
+	transport, err := transport.HTTPWrappersForConfig(
+		&transport.Config{
+			UserAgent: rest.DefaultKubernetesUserAgent() + "(release-info)",
+		},
+		http.DefaultTransport,
+	)
+	if err != nil {
+		return "", err
+	}
+	httpClient := &http.Client{Transport: transport}
+
+	u.RawQuery = url.Values{
+		"channel": []string{fmt.Sprintf("%s-%d.%d", "stable", semanticVersion.Major(), semanticVersion.Minor())},
+	}.Encode()
+
+	request, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Accept", "application/json")
+
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("could not get %s version graph", u.String())
+	}
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var versions versionGraph
+	if err := json.Unmarshal(data, &versions); err != nil {
+		return "", err
+	}
+
+	for _, node := range versions.Nodes {
+		if node.Version == version && len(node.Payload) > 0 {
+			return node.Payload, nil
+		}
+	}
+
+	// No payload was found
+	return "", fmt.Errorf("version %s not present in stable channel", version)
 }

--- a/controllers/image_component.go
+++ b/controllers/image_component.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/oc/pkg/cli/admin/release"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetImageForComponent retrieves the Docker image for a specified component.
+// It uses the OpenShift client to fetch the cluster version and then loads the release info.
+// It searches for the componentName in the release info and returns the corresponding Docker image.
+func GetImageForComponent(componentName string, client client.Client) (string, error) {
+	// Fetch the cluster version
+	clusterVersion := &configv1.ClusterVersion{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to get cluster version: %w", err)
+	}
+
+	releaseImage := clusterVersion.Status.Desired.Image
+	if releaseImage == "" {
+		return "", fmt.Errorf("no release image found in cluster version")
+	}
+
+	// Create IOStreams
+	streams := genericiooptions.IOStreams{
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
+
+	// Create InfoOptions
+	infoOptions := release.NewInfoOptions(streams)
+
+	// Load release info (set retrieveImages to false for faster loading)
+	releaseInfo, err := infoOptions.LoadReleaseInfo(releaseImage, false)
+	if err != nil {
+		fmt.Printf("Error loading release info: %v\n", err)
+		return "", err
+	}
+
+	// Search for the componentName and return
+	for _, tag := range releaseInfo.References.Spec.Tags {
+		if tag.Name == componentName {
+			// we found the short name in ImageStream
+			if tag.From != nil && tag.From.Kind == "DockerImage" {
+				return tag.From.Name, nil
+			}
+		}
+	}
+
+	// Didn't find it
+	return "", fmt.Errorf("empty result for image name")
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -13,14 +13,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	"github.com/openshift/oc/pkg/cli/admin/release"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -239,52 +237,6 @@ func updateConfigMap(client client.Client, logger logr.Logger, cmName string, na
 	} else {
 		return nil
 	}
-}
-
-// GetImageForComponent retrieves the Docker image for a specified component.
-// It uses the OpenShift client to fetch the cluster version and then loads the release info.
-// It searches for the componentName in the release info and returns the corresponding Docker image.
-func GetImageForComponent(componentName string, client client.Client) (string, error) {
-	// Fetch the cluster version
-	clusterVersion := &configv1.ClusterVersion{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
-	if err != nil {
-		return "", fmt.Errorf("failed to get cluster version: %w", err)
-	}
-
-	releaseImage := clusterVersion.Status.Desired.Image
-	if releaseImage == "" {
-		return "", fmt.Errorf("no release image found in cluster version")
-	}
-
-	// Create IOStreams
-	streams := genericiooptions.IOStreams{
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
-	}
-
-	// Create InfoOptions
-	infoOptions := release.NewInfoOptions(streams)
-
-	// Load release info (set retrieveImages to false for faster loading)
-	releaseInfo, err := infoOptions.LoadReleaseInfo(releaseImage, false)
-	if err != nil {
-		fmt.Printf("Error loading release info: %v\n", err)
-		return "", err
-	}
-
-	// Search for the componentName and return
-	for _, tag := range releaseInfo.References.Spec.Tags {
-		if tag.Name == componentName {
-			// we found the short name in ImageStream
-			if tag.From != nil && tag.From.Kind == "DockerImage" {
-				return tag.From.Name, nil
-			}
-		}
-	}
-
-	// Didn't find it
-	return "", fmt.Errorf("empty result for image name")
 }
 
 // labelNodes updates the labels of nodes matching the given selector.

--- a/scripts/kata-install/lib.sh
+++ b/scripts/kata-install/lib.sh
@@ -51,7 +51,10 @@ function extract_container_image() {
 
 client_tools() {
 	mkdir -p "/usr/bin"
-	extract_container_image "$CLI_IMAGE" "/usr/bin/oc /usr/bin/kubectl" "/usr/bin" "/tmp/regauth/auth.json"
+	local upper_node_name="${NODE_NAME^^}"
+	upper_node_name="${upper_node_name//-/_}"
+	local envarName="CLI_IMAGE_$upper_node_name"
+	extract_container_image "$(printenv -- "$envarName")" "/usr/bin/oc /usr/bin/kubectl" "/usr/bin" "/tmp/regauth/auth.json"
 	chmod +x /usr/bin/oc
 	chmod +x /usr/bin/kubectl
 }

--- a/scripts/kata-install/osc-configs-script.sh
+++ b/scripts/kata-install/osc-configs-script.sh
@@ -130,11 +130,6 @@ main() {
 		exit 1
 	}
 
-	[[ -z "${CLI_IMAGE:-}" ]] && {
-		echo "ERROR: CLI_IMAGE env var must be set."
-		exit 1
-	}
-
 	local action="${1:-}"
 	case "$action" in
 	install)

--- a/scripts/kata-install/osc-kata-install.sh
+++ b/scripts/kata-install/osc-kata-install.sh
@@ -187,98 +187,12 @@ uninstall() {
 	wait_for_reboot_clear
 }
 
-get_cloud_provider() {
-	local provider
-
-	# Run kubectl: capture rc and stdout
-	if ! provider="$(kubectl get configmap/peer-pods-cm \
-		-n openshift-sandboxed-containers-operator \
-		-o jsonpath='{.data.CLOUD_PROVIDER}')"; then
-		return
-	fi
-
-	# Reject empty/whitespace-only results
-	if [[ -z "${provider//[[:space:]]/}" ]]; then
-		error "get_cloud_provider: CLOUD_PROVIDER not set in configmap/peer-pods-cm"
-		return
-	fi
-
-	echo "${provider}"
-}
-
-# Reads worker version label and extracts the OpenShift version (prefix before '_').
-get_worker_node_version_ibmcloud() {
-	local version
-	local raw_version
-
-	if ! raw_version="$(kubectl get "nodes/${NODE_NAME}" \
-		-o jsonpath='{.metadata.labels.ibm-cloud\.kubernetes\.io/worker-version}')"; then
-		error "get_worker_node_version_ibmcloud: kubectl failed to read worker-version label on node ${NODE_NAME}"
-		return
-	fi
-
-	if [[ -z "${raw_version//[[:space:]]/}" ]]; then
-		error "get_worker_node_version_ibmcloud: worker-version label is empty on node ${NODE_NAME}"
-		return
-	fi
-
-	# Extract the part before the first underscore
-	version="${raw_version%%_*}"
-
-	if [[ -z "${version//[[:space:]]/}" ]]; then
-		error "get_worker_node_version_ibmcloud: cannot parse '${raw_version}' as an OpenShift version"
-		return
-	fi
-
-	echo "${version}"
-}
-
-# get_extension_image VERSION
-# Resolves the rhel-coreos-extensions image for a given release VERSION.
-get_extension_image() {
-	[[ -n ${1-} ]] || {
-		error "get_extension_image: usage: get_extension_image VERSION"
-		return
-	}
-
-	local version=$1
-	local image
-
-	if ! image="$(oc adm release info --image-for rhel-coreos-extensions "$version")"; then
-		error "get_extension_image: 'oc adm release info' failed for version: $version"
-		return
-	fi
-
-	if [[ -z "${image//[[:space:]]/}" ]]; then
-		error "get_extension_image: empty image string for version: $version"
-		return
-	fi
-
-	echo "${image}"
-}
-
-# FIXME : This logic should be moved into the Operator
 rpm-extensions() {
-	local provider
-	local extension_image
-
-	provider="$(get_cloud_provider)"
-
-	case "${provider}" in
-	ibmcloud)
-		local version
-		version="$(get_worker_node_version_ibmcloud)"
-		extension_image="$(get_extension_image $version)"
-		;;
-
-	*)
-		extension_image=$EXTENSION_IMAGE
-		;;
-
-	esac
-
 	mkdir -p "/usr/share/rpm-ostree/extensions"
-	extract_container_image "$extension_image" "/usr/share/rpm-ostree/extensions" "/usr/share/rpm-ostree" "/tmp/regauth/auth.json"
+	local upper_node_name="${NODE_NAME^^}"
+	upper_node_name="${upper_node_name//-/_}"
+	local envarName="EXTENSION_IMAGE_$upper_node_name"
+	extract_container_image "$(printenv -- "$envarName")" "/usr/share/rpm-ostree/extensions" "/usr/share/rpm-ostree" "/tmp/regauth/auth.json"
 }
 
 main() {
@@ -291,16 +205,6 @@ main() {
 	#        echo "ERROR: LOG_LEVEL env var must be set."
 	#        exit 1
 	#}
-
-	[[ -z "${CLI_IMAGE:-}" ]] && {
-		echo "ERROR: CLI_IMAGE env var must be set."
-		exit 1
-	}
-
-	[[ -z "${EXTENSION_IMAGE:-}" ]] && {
-		echo "ERROR: EXTENSION_IMAGE env var must be set."
-		exit 1
-	}
 
 	local action="${1:-}"
 


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
This fixes issues where worker nodes run a different OCP version than the control plane. This can cause issues with the DaemonSet installation mode.
**- What I did**
Introduced new image component logic. By default, the control plane version is used for all images, but based on the provider, it is now possible to get any component image for any version. Each node now receives a separate image string, and environment variable names include the node name to ensure uniqueness.
**- How to verify it**
Deploy the Operator in DaemonSet mode. Verify that installation pods use the correct image for each node.
**- Description for the changelog**
Support node-specific extension images in DaemonSet mode
