### PR TITLE
Introduce the Prowjob analyzer tool

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,9 @@
+# Local settings
+settings.local.json
+
+# Temporary plan files
+*_PLAN.md
+
+# Python cache
+__pycache__/
+*.pyc

--- a/.claude/PROWJOB_ANALYZER_PLAN.md
+++ b/.claude/PROWJOB_ANALYZER_PLAN.md
@@ -1,0 +1,249 @@
+# Prow Job Analyzer Implementation Plan
+
+## Overview
+Create a Claude Code slash command `/prowjob-analyze` that analyzes OSC Prow job results to determine if human intervention is needed, extract metadata, and provide detailed failure analysis.
+
+## User Requirements Summary
+- **Scope**: OSC-specific analyzer with Kata/PeerPods knowledge
+- **Output**: Human-readable markdown by default (--json flag for machine format)
+- **Behavior**: Wait and retry if job still running (artifacts not ready)
+- **Integration**: Claude Code slash command in this repository
+
+## Implementation Architecture
+
+### Technology Stack
+- **Primary Language**: Python 3 (better JSON/YAML handling than bash)
+- **Command Interface**: Claude Code slash command (`.claude/commands/prowjob-analyze.md`)
+- **Pattern**: Modular design similar to must-gather plugin
+
+### File Structure
+```
+.claude/
+└── commands/
+    └── prowjob-analyze.md              # Slash command definition
+
+scripts/
+└── prowjob-analyzer/                   # Analyzer directory
+    ├── analyze.py                      # Main orchestrator
+    ├── lib/                            # Analysis modules
+    │   ├── __init__.py
+    │   ├── fetcher.py                 # Fetch artifacts from GCS
+    │   ├── parser.py                  # Parse prowjob.json, test-results.yaml
+    │   ├── metadata_extractor.py      # Extract job metadata
+    │   ├── failure_analyzer.py        # Analyze failures
+    │   └── report_generator.py        # Generate reports
+    └── README.md                       # Documentation
+```
+
+## Core Components
+
+### 1. URL Parser and Artifact Fetcher (`lib/fetcher.py`)
+**Purpose**: Convert Prow UI URLs to GCS artifact URLs and fetch files
+
+**Key Patterns** (validated from existing test scripts):
+- Input: `https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{JOB_NAME}/{BUILD_ID}`
+- Artifacts: Same URL + `/artifacts/{VARIANT}/...`
+- Variant extraction: Parse from job name (e.g., `aws-ipi-peerpods`)
+
+**Functions**:
+- `parse_prow_url(url)` - Extract job name and build ID
+- `fetch_artifact(url, path)` - Download artifact with retry logic
+- `wait_for_artifacts(url, timeout=300)` - Poll until artifacts ready
+
+### 2. Metadata Extractor (`lib/metadata_extractor.py`)
+**Purpose**: Extract all job metadata from prowjob.json and artifacts
+
+**Metadata to Extract**:
+- Provider (AWS, Azure, GCP) - from job name
+- OCP version - from prowjob.json spec
+- Build tag/image - from job environment variables
+- Workload type (kata, peerpods, coco) - from job name
+- Trigger source (Konflux, periodic, presubmit) - from prowjob.json
+- Kata RPM version - from `sandboxed-containers-operator-get-kata-rpm` step artifacts
+- Variant - extracted from job name for artifact paths
+
+### 3. Pass/Fail Determiner (`lib/parser.py`)
+**Purpose**: Determine job status and parse test results
+
+**Status Determination**:
+- Parse `prowjob.json` for overall status
+- Parse `test-results.yaml` for test outcomes (failures: 0 = pass)
+- Distinguish: success, failure, timeout, error, aborted
+
+### 4. Failure Analyzer (`lib/failure_analyzer.py`)
+**Purpose**: Identify WHERE and WHY failure occurred
+
+**Analysis Logic**:
+- **Test Step Failures**: Parse test-results.yaml, categorize by sig/area
+- **Prow Step Failures**: Check prowjob.json for failed steps
+- **Pattern Recognition**: Detect OOM, timeout, network, image pull errors
+- **Human Intervention Check**: Apply heuristics to determine if automated retry would help
+
+**Common Patterns to Detect**:
+- Timeout (context deadline exceeded)
+- OOM (OOMKilled, out of memory)
+- Network (connection refused, i/o timeout)
+- Infrastructure (cluster provisioning failures)
+- Configuration (wrong parameters, version mismatches)
+
+### 5. Report Generator (`lib/report_generator.py`)
+**Purpose**: Generate human-readable markdown and optional JSON reports
+
+**Human Report Structure**:
+```markdown
+# Prow Job Analysis
+
+## Status
+✅ Passed / ❌ Failed / ⏱️ Timeout
+
+## Job Overview
+- Job Name: ...
+- Build ID: ...
+- Duration: ...
+- URL: [Link]
+
+## Environment
+- Provider: AWS
+- OCP Version: 4.19
+- Workload: PeerPods
+- Kata RPM: 3.21.0-3.rhaos4.19.el9
+- Build: quay.io/...@sha256:...
+- Trigger: Konflux
+
+## Test Results
+- Total: 36
+- Passed: 35
+- Failed: 1
+- Skipped: 0
+
+## [If Failed] Failure Analysis
+### Failure Location: Test Step / Prow Step / Infrastructure
+
+### Failed Tests (grouped by category)
+#### Deployment (3 tests)
+- Test name 1
+- Test name 2
+
+### Root Cause
+- Pattern: timeout
+- Suggested Actions: ...
+
+## Human Intervention Required
+✅ Yes / ⏸️ Safe to Retry / ❌ No (infra issue)
+
+## Artifacts
+- [Test Results](link)
+- [Logs](link)
+- [Must-Gather](link)
+```
+
+**JSON Report**: Structured data for automation (with --json flag)
+
+## Implementation Plan
+
+### Phase 1: Basic Infrastructure (Files to Create)
+1. **`.claude/commands/prowjob-analyze.md`** - Slash command definition
+   - Command syntax and usage examples
+   - Invoke Python script with URL parameter
+
+2. **`.claude/scripts/prowjob-analyzer/analyze.py`** - Main script
+   - CLI argument parsing (URL, --json, --verbose, --wait)
+   - Coordinate all analysis modules
+   - Error handling and user feedback
+
+3. **`.claude/scripts/prowjob-analyzer/lib/fetcher.py`** - Artifact fetcher
+   - URL parsing and validation
+   - Artifact download with retry
+   - Wait for in-progress jobs (poll with timeout)
+
+### Phase 2: Analysis Logic
+4. **`.claude/scripts/prowjob-analyzer/lib/parser.py`** - Data parser
+   - Parse prowjob.json (job status, spec, env vars)
+   - Parse test-results.yaml (test outcomes)
+   - Utility functions for YAML/JSON
+
+5. **`.claude/scripts/prowjob-analyzer/lib/metadata_extractor.py`** - Metadata extraction
+   - Extract provider, OCP version, workload from job name/spec
+   - Fetch Kata RPM version from step artifacts
+   - Build variant path for artifacts
+
+### Phase 3: Failure Analysis
+6. **`.claude/scripts/prowjob-analyzer/lib/failure_analyzer.py`** - Failure analysis
+   - Identify failure location (test vs prow step)
+   - Categorize failing tests
+   - Pattern recognition for common failures
+   - Human intervention determination
+
+### Phase 4: Reporting
+7. **`.claude/scripts/prowjob-analyzer/lib/report_generator.py`** - Report generation
+   - Generate markdown report
+   - Generate JSON report (optional)
+   - Format test failures with grouping
+   - Add artifact links
+
+8. **`.claude/scripts/prowjob-analyzer/README.md`** - Documentation
+   - Usage instructions
+   - Architecture overview
+   - Development guide
+
+## Key Technical Decisions
+
+### URL Handling
+- Use existing test scripts as reference (`tests/test-get-files.sh`)
+- Follow redirects with curl/requests
+- Variant extraction: Parse job name to get `{provider}-ipi-{workload}`
+
+### Artifact Paths
+Based on validated patterns:
+```
+{PROWJOB_URL}/prowjob.json                                           # Job metadata
+{PROWJOB_URL}/finished.json                                          # Completion data
+{PROWJOB_URL}/artifacts/{VARIANT}/openshift-extended-test/artifacts/test-results.yaml
+{PROWJOB_URL}/artifacts/{VARIANT}/openshift-extended-test/artifacts/extended.log
+{PROWJOB_URL}/artifacts/{VARIANT}/sandboxed-containers-operator-get-kata-rpm/artifacts/kata-rpm-version.txt
+{PROWJOB_URL}/artifacts/{VARIANT}/sandboxed-containers-operator-gather-must-gather/artifacts/
+```
+
+### Error Handling
+- **In-Progress Jobs**: Poll for up to 5 minutes, show progress
+- **Missing Artifacts**: Graceful degradation, analyze what's available
+- **Network Errors**: Retry with exponential backoff (3 attempts)
+- **Invalid URLs**: Validate format, suggest correct pattern
+
+### OSC-Specific Features
+- Recognize OSC job patterns (job name prefixes)
+- Extract Kata RPM version (OSC-specific step)
+- Understand workload types (kata, peerpods, coco)
+- Categorize tests by sig-kata patterns
+- Check version mismatches (EXPECTED_OPERATOR_VERSION)
+
+## Dependencies
+- Python 3 (available)
+- `pyyaml` - YAML parsing
+- `requests` - HTTP client (or use urllib3 built-in)
+
+## Testing Strategy
+- Test with real Prow job URLs from user examples
+- Handle both passing and failing jobs
+- Verify all metadata extraction
+- Validate report format
+- Test edge cases (in-progress, missing artifacts, timeouts)
+
+## Critical Files Created
+1. `.claude/commands/prowjob-analyze.md` - Slash command definition
+2. `scripts/prowjob-analyzer/analyze.py` - Main analyzer script
+3. `scripts/prowjob-analyzer/lib/fetcher.py` - Artifact fetcher
+4. `scripts/prowjob-analyzer/lib/parser.py` - Data parser
+5. `scripts/prowjob-analyzer/lib/metadata_extractor.py` - Metadata extraction
+6. `scripts/prowjob-analyzer/lib/failure_analyzer.py` - Failure analysis
+7. `scripts/prowjob-analyzer/lib/report_generator.py` - Report generation
+8. `scripts/prowjob-analyzer/README.md` - Documentation
+
+## Success Criteria
+- `/prowjob-analyze <URL>` command works in Claude Code
+- Extracts all required metadata accurately
+- Correctly determines pass/fail status
+- Identifies failure locations and provides details
+- Generates readable reports with artifact links
+- Handles in-progress jobs gracefully
+- OSC-specific analysis (Kata RPM, workload types)

--- a/.claude/commands/prowjob-analyze.md
+++ b/.claude/commands/prowjob-analyze.md
@@ -1,0 +1,266 @@
+---
+name: prowjob-analyze
+description: Analyze OpenShift Prow job results to determine status, extract metadata, and identify failures
+allowed-tools:
+  - Bash(python3 scripts/prowjob-analyzer/analyze.py:*)
+  - Bash(python3 scripts/prowjob-analyzer/failed_tests_report.py:*)
+---
+
+Analyze a Prow job to determine its status and provide detailed failure analysis.
+
+**Workflow:**
+1. Run the main analyzer to get overall job status and metadata
+2. Based on which step failed, decide if further analysis is needed
+
+Execute the following steps:
+
+**Step 1: Run main analyzer**
+```bash
+python3 scripts/prowjob-analyzer/analyze.py --no-wait "$@"
+```
+
+**Step 2: Analyze the output**
+- Review the analysis report from Step 1
+- Check the "Failure Analysis" section to see which step(s) failed
+- Check if there are "Failed Tests" listed
+
+**Step 3: Determine next action based on failed step**
+
+**Case A: Tests failed** (Failed Step is `openshift-extended-test` AND Failed Tests are listed)
+- This means the job ran through infrastructure setup and failed during test execution
+- Run detailed test analysis:
+```bash
+python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> <TEST_NAME_1> <TEST_NAME_2> ...
+```
+Use the exact test names from the "Failed Tests" section.
+
+**Case B: Infrastructure/setup step failed** (Failed Step is NOT `openshift-extended-test`)
+- Examples: `ipi-install-install`, `sandboxed-containers-operator-peerpods-param-cm`, etc.
+- This means tests never ran - job failed before reaching the test step
+- Do NOT run failed_tests_report.py
+- Provide summary explaining that the job failed at infrastructure/setup stage
+- Point user to the specific step's artifacts for investigation
+
+**Case C: Multiple steps failed**
+- If `openshift-extended-test` is among the failed steps AND has failing tests, run test analysis
+- Otherwise, treat as Case B
+
+---
+
+## About
+
+Comprehensive Prow job analysis with two-level investigation:
+
+**Level 1: Overall Analysis** (analyze.py)
+- Extracts job metadata (provider, OCP version, Kata RPM, catalog, etc.)
+- Determines overall job status (pass/fail/timeout)
+- Identifies which step(s) failed
+- Lists failing tests if tests ran and failed
+- Provides links to all artifacts
+
+**Level 2: Detailed Test Debugging** (failed_tests_report.py - only when tests failed)
+- Only runs if `openshift-extended-test` step failed with failing tests
+- Extracts full test logs and failure summaries from build-log.txt
+- Reports test metadata: elapsed time, category, author, priority
+- Provides complete log context for each failing test
+- Supports filtering specific tests by name or ID
+
+**Important:** If the job failed at an earlier step (like `ipi-install-install`),
+tests never ran and test analysis is not applicable. The analyzer will correctly
+identify which infrastructure/setup step failed.
+
+---
+
+## OSC Test Design and Execution
+
+### Test Framework and Organization
+
+**Framework**: Tests use the Ginkgo v2 BDD (Behavior-Driven Development) framework with Gomega assertions, integrated with Kubernetes e2e test infrastructure.
+
+**Test Suite Location**: All OSC tests are grouped under the `[sig-kata]` descriptor in the test suite. Test code resides in `openshift-tests-private/test/extended/kata/` with test templates in `test/extended/testdata/kata/`.
+
+**Test Naming Convention**: Each test follows a structured naming pattern:
+```
+Author:<developer>-<Priority>-<CaseID>-<Description> [Tags]
+```
+
+Examples:
+- `Author:tbuskey-High-C00077-Version in operator CSV should match expected version [Serial]`
+- `Author:vvoronko-High-C00349-deploy peerpod with non-existing image annotation [Serial]`
+
+Where:
+- **Author**: Test developer's username
+- **Priority**: High/Medium/Low
+- **CaseID**: Unique test case identifier (e.g., C00077, C00349)
+- **Description**: Human-readable test purpose
+- **Tags**: Execution characteristics (Serial, Slow, Disruptive)
+
+### Workload Types and Runtime Classes
+
+OSC supports three distinct workload types, controlled by configuration:
+
+1. **kata**: Traditional Kata Containers (VM-isolated pods on cluster nodes)
+   - Runtime class: `kata`
+   - Tests tagged with standard kata behavior
+
+2. **peer-pods**: Cloud-provider remote VMs (PeerPods architecture)
+   - Runtime class: `kata-remote`
+   - Tests verify cloud-specific features (AWS, Azure, GCP)
+   - Includes instance type, vCPU/memory annotations, custom images
+
+3. **coco**: Confidential Containers with attestation
+   - Runtime class: `kata-remote`
+   - Tests verify Trustee integration and attestation
+   - Requires KBS (Key Broker Service) configuration
+
+### Test Execution Flow
+
+**Setup Phase** (BeforeEach):
+1. Check for test configuration in `osc-config` ConfigMap (namespace: default)
+2. Subscribe to OSC operator from catalog source
+3. Create KataConfig custom resource
+4. Wait for operator installation and runtime installation on nodes
+5. **Node reboots occur** during KataConfig creation/deletion (can take >20 minutes per node)
+6. If configured to install Kata RPM: Install specific Kata runtime version on nodes
+7. **Workload-specific setup**:
+   - If peer-pods enabled: Create `peer-pods-cm` ConfigMap with cloud provider-specific configuration
+   - If coco workload: Update `peer-pods-cm` with confidential instance type and set INITDATA property containing Trustee access information and other attestation configuration
+
+**Critical Setup Behavior**:
+- Every test runs BeforeEach which includes the setup phase
+- If the first test's setup succeeds, it marks setup as complete and subsequent tests skip the setup
+- If the first test's setup fails, ALL subsequent tests will attempt the full setup phase again
+- Since setup includes node reboots (>20 minutes), repeated setup attempts across all tests can cause:
+  - Extremely long job execution times
+  - Job timeouts (tests trying setup instead of running actual test logic)
+- This explains why infrastructure failures can cause the entire job to timeout
+
+**Test Execution**:
+- Tests run sequentially due to `[Serial]` tag (shared cluster state)
+- Tests automatically skip when workload type or platform doesn't match test requirements
+- Each test creates isolated namespace via `oc.SetupProject()`
+- Workloads deployed from YAML templates with variable substitution
+- Tests verify using `oc` CLI commands and Kubernetes client-go
+- Cleanup in deferred functions (defer deleteKataResource)
+
+**Configuration Overrides**:
+Tests use hardcoded defaults that can be overridden via `osc-config` ConfigMap:
+- Operator channel (stable)
+- Catalog source (redhat-operators or custom)
+- Runtime class name (kata, kata-remote)
+- Enable peer pods (true/false)
+- Workload type to test (kata, peer-pods, coco)
+- Expected operator version
+- Install Kata RPM (true/false)
+- Enable GPU to include Nvidia GPU drivers in podvm image and run GPU tests
+- Set initdata for the OSC operator
+- Must-gather image
+- Import podvm image from URL instead of building it from scratch
+- Point OSC operator to an existing external Trustee instance
+
+### Test Categories
+
+**Operator Lifecycle**:
+- Installation and subscription verification (C00113, C00193)
+- Version validation (C00077)
+- Multiple KataConfig prevention (C00156)
+- Upgrade scenarios (manual/automated)
+- Deletion with running workloads (C00317)
+
+**Workload Deployment**:
+- Basic pod/deployment creation and deletion (C00102)
+- RuntimeClass verification
+- Security context validation
+- Resource requests and limits (C00350, C00355)
+
+**PeerPods-Specific**:
+- Instance type annotations (C00099)
+- vCPU and memory annotations (C00131)
+- Custom tags (C00320)
+- Image annotations - existing (C00347), empty (C00348), non-existing (C00349)
+- PodVM image verification (C00095)
+
+**Scaling and Operations**:
+- Deployment scale-up (C00122)
+- Deployment scale-down (C00123)
+- Service exposure (C00100)
+- Cluster limits (C00133)
+
+**Monitoring and Metrics**:
+- Namespace monitoring labels (C00112)
+- Pod metrics validation (C00142)
+- `oc adm top pod` functionality (C00143)
+- Monitor operator deletion (C00160)
+
+**Special Features**:
+- FIPS validation (C00094)
+- GPU workloads on PeerPods (C00210)
+- Confidential containers with cosigned images (C00316)
+- SELinux-enabled pods (422081)
+- EmptyDir with sizeLimit (C00355)
+
+### Test Execution Tags
+
+**[Serial]**: All tests run serially (no parallel execution)
+- Reason: Shared cluster state (KataConfig, operator installation)
+
+**[Slow]**: Tests that exceed normal timeout
+- KataConfig creation/deletion (node reboots)
+- Typically require `--timeout 120m` or longer
+
+**[Disruptive]**: Tests that affect cluster state
+- KataConfig deletion (reboots all worker nodes)
+- Operator uninstall
+- Upgrade operations
+
+### Common Failure Patterns
+
+**Infrastructure Failures** (tests don't run):
+- Cluster provisioning issues
+- Operator installation failures
+- KataConfig creation timeout (node reboot issues)
+- Catalog source not available
+- Pod scheduling failures (node eligibility, taints)
+- **Setup phase failures causing all tests to retry setup (leads to timeouts)**
+
+**Common Feature Failures**:
+- Image pull errors
+- Timeout waiting for pod ready
+- Assertion failures (version mismatch, incorrect behavior)
+- Resource constraints (memory, CPU limits)
+
+**PeerPods-Specific Failures**:
+- Cloud provider API failures
+- PodVM image creation failures
+- Instance type not available in region
+- Network connectivity to cloud metadata service
+- Annotation parsing errors
+
+**CoCo-Specific Failures**:
+- Trustee connectivity issues
+- Attestation failures
+- INITDATA configuration errors
+- KBS (Key Broker Service) unavailable
+
+---
+
+**Usage:**
+```
+/prowjob-analyze <PROW_JOB_URL>
+```
+
+**Example:**
+```
+/prowjob-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+```
+
+**Output:**
+- Comprehensive analysis report in markdown format
+- Identifies which step(s) failed
+- For test failures: Detailed debugging information for each failing test
+- For infrastructure failures: Guidance on which step failed and where to investigate
+- Links to all relevant artifacts
+
+**Options:**
+- `--json`: Output machine-readable JSON format (for both scripts)
+- `--verbose`: Show detailed progress information

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+# Python cache
+prowjob-analyzer/lib/__pycache__/

--- a/scripts/prowjob-analyzer/README.md
+++ b/scripts/prowjob-analyzer/README.md
@@ -1,0 +1,384 @@
+# Prow Job Analyzer
+
+A tool for analyzing OpenShift Prow job results, specifically tailored for OpenShift Sandboxed Containers (OSC) testing.
+
+## Overview
+
+The Prow Job Analyzer provides comprehensive analysis of Prow job runs, extracting metadata, determining pass/fail status, and identifying failure locations and root causes.
+
+## Features
+
+### Two-Level Analysis System
+
+**Level 1: Overall Job Analysis** (`analyze.py`):
+- **Metadata Extraction**: Automatically extracts provider, OCP version, workload type, Kata RPM version, and build information
+- **Status Determination**: Accurately determines if a job passed, failed, timed out, or encountered errors
+- **Failed Step Detection**: Identifies which actual Prow step(s) failed by checking each step's finished.json
+- **Test Summary**: Lists failing tests if tests executed
+- **Multiple Output Formats**: Generates both human-readable markdown and machine-parsable JSON reports
+- **In-Progress Job Handling**: Can wait for running jobs to complete before analysis
+
+**Level 2: Detailed Test Analysis** (`failed_tests_report.py`):
+- **Full Test Logs**: Extracts complete test execution logs from build-log.txt
+- **Failure Summaries**: Parses "Summarizing N Failure" sections for each test
+- **Test Metadata**: Reports test case ID, author, priority, elapsed time, category
+- **Selective Analysis**: Can analyze specific tests by name or test all failed tests
+- **Pattern Recognition**: Helps identify common failure patterns (timeouts, OOM, network issues, etc.)
+
+### Claude Code Integration
+
+- **Intelligent Workflow**: Automatically determines if tests ran or infrastructure failed
+- **Smart Decision**: Runs detailed test analysis only when appropriate (Case A vs Case B)
+- **Interactive & Non-Interactive**: Supports both quick analysis and deeper investigation modes
+
+## Usage
+
+### Quick Start: Claude Launcher (Recommended)
+
+The easiest way to analyze a Prow job is using the Claude launcher script from anywhere:
+
+```bash
+# Non-interactive mode (default) - get results and exit
+./scripts/prowjob-analyzer/analyze-claude.py https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+
+# Interactive mode - open Claude session for follow-up questions
+./scripts/prowjob-analyzer/analyze-claude.py -i <PROW_JOB_URL>
+
+# Or from within the prowjob-analyzer directory
+cd scripts/prowjob-analyzer
+./analyze-claude.py <PROW_JOB_URL>
+```
+
+The launcher script:
+- Automatically finds the project root directory
+- Launches Claude Code with the `/prowjob-analyze` command
+- No need to manually navigate or type the command
+- Runs in non-interactive mode by default (fast results)
+- Use `-i` for interactive mode to ask follow-up questions
+
+**Options:**
+- `--interactive, -i`: Launch Claude in interactive mode (default: non-interactive)
+- `--verbose, -v`: Show verbose output for debugging
+
+### Via Claude Code Slash Command
+
+If you already have Claude Code open in the project directory:
+
+```
+/prowjob-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+```
+
+The analyzer supports both job URL patterns:
+- **Periodic/Postsubmit**: `https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{JOB_NAME}/{BUILD_ID}`
+- **Presubmit/Rehearsal**: `https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/{ORG}_{REPO}/{PR}/{JOB_NAME}/{BUILD_ID}`
+
+### Direct CLI Usage
+
+You can also run the analyzer scripts directly:
+
+**Level 1: Overall Analysis**
+```bash
+# Basic usage
+./analyze.py <PROW_JOB_URL>
+
+# Generate JSON output
+./analyze.py --json <PROW_JOB_URL> > report.json
+
+# Verbose mode with no wait for in-progress jobs
+./analyze.py --verbose --no-wait <PROW_JOB_URL>
+
+# Custom wait timeout (in seconds)
+./analyze.py --wait 600 <PROW_JOB_URL>
+```
+
+**Level 2: Detailed Test Analysis** (only when tests failed)
+```bash
+# Analyze all failed tests
+./failed_tests_report.py <PROW_JOB_URL>
+
+# Analyze specific tests by name or ID
+./failed_tests_report.py <PROW_JOB_URL> "C00077" "C00349"
+
+# Full test names work too
+./failed_tests_report.py <PROW_JOB_URL> "[sig-kata] Author:vvoronko-High-C00349-deploy peerpod with non-existing image annotation [Serial]"
+
+# JSON output
+./failed_tests_report.py --json <PROW_JOB_URL> > test-report.json
+```
+
+### Options
+
+**analyze.py:**
+- `--json`: Output machine-readable JSON format instead of human-readable markdown
+- `--verbose, -v`: Enable verbose logging for debugging
+- `--wait SECONDS`: Set timeout for waiting for in-progress jobs (default: 300 seconds)
+- `--no-wait`: Don't wait for in-progress jobs (analyze immediately)
+
+**failed_tests_report.py:**
+- `--json`: Output machine-readable JSON format
+- `--verbose, -v`: Enable verbose logging for debugging
+
+## Output
+
+### Level 1: Overall Job Analysis Report (analyze.py)
+
+The default output is a comprehensive markdown report including:
+
+- **Job Status**: Overall success/failure with emoji indicators
+- **Job Overview**: Job name, build ID, duration, trigger source
+- **Environment**: Provider, OCP version, workload type, Kata RPM version, build information
+- **Test Results**: Total, passed, failed, and skipped test counts with categorized failure breakdown
+- **Failure Analysis**: Which step(s) actually failed (e.g., `openshift-extended-test`, `ipi-install-install`)
+- **Failed Tests**: List of tests that failed (grouped by category) with test IDs, authors, and priorities
+- **Artifacts**: Direct links to all relevant artifacts (test results, logs, must-gather data)
+
+### Level 2: Detailed Test Report (failed_tests_report.py)
+
+Per-test detailed analysis including:
+
+- **Test Identification**: Test case ID (e.g., C00349), author, priority
+- **Execution Details**: Elapsed time, category
+- **Failure Summary**: Extracted error messages and failure reasons
+- **Full Test Logs**: Complete test execution logs from start to failure
+- Supports analyzing all failed tests or specific tests by name/ID
+
+### JSON Reports
+
+Both scripts support `--json` flag for structured output suitable for automation:
+
+**analyze.py JSON:**
+```json
+{
+  "version": "1.0",
+  "timestamp": "2025-12-16T...",
+  "prowjob": {...},
+  "metadata": {...},
+  "test_results": {...},
+  "failure_analysis": {
+    "failed_steps": "openshift-extended-test",
+    "failing_tests": [...]
+  },
+  "artifacts": {...}
+}
+```
+
+**failed_tests_report.py JSON:**
+```json
+{
+  "job_url": "...",
+  "tests_analyzed": 2,
+  "failed_tests": [
+    {
+      "test_name": "...",
+      "test_case_number": "C00349",
+      "elapsed_time": "10m13s",
+      "category": "peer_pods",
+      "author": "vvoronko",
+      "priority": "High",
+      "failure_summary": "...",
+      "full_logs": "..."
+    }
+  ]
+}
+```
+
+## Architecture
+
+The analyzer is built with a modular architecture:
+
+```
+prowjob-analyzer/
+├── analyze-claude.py           # Claude launcher wrapper script
+├── analyze.py                  # Level 1: Overall job analysis
+├── failed_tests_report.py      # Level 2: Detailed test analysis
+└── lib/                        # Analysis modules
+    ├── fetcher.py             # Artifact fetching and URL parsing
+    ├── parser.py              # prowjob.json and test-results.yaml parsing
+    ├── metadata_extractor.py  # Metadata extraction
+    ├── failure_analyzer.py    # Failure step detection and test categorization
+    └── report_generator.py    # Report generation (markdown/JSON)
+```
+
+### Key Components
+
+**User-Facing Scripts:**
+1. **analyze-claude.py**: Wrapper script that launches Claude Code with the `/prowjob-analyze` command
+   - Finds project root automatically
+   - Supports interactive (`-i`) and non-interactive modes
+   - Validates Prow URLs
+
+2. **analyze.py**: Level 1 analysis - overall job status and metadata
+   - Fetches prowjob.json, finished.json, test-results.yaml
+   - Determines which step(s) failed
+   - Lists failing tests (if tests ran)
+   - Generates comprehensive report with metadata and artifact links
+
+3. **failed_tests_report.py**: Level 2 analysis - detailed test debugging
+   - Extracts full test logs from build-log.txt
+   - Parses failure summaries
+   - Reports test metadata (ID, author, priority, elapsed time)
+   - Only runs when tests actually executed and failed
+
+**Library Modules:**
+1. **Fetcher**: URL parsing, artifact downloading with retry logic, step detection
+2. **Parser**: prowjob.json and test-results.yaml parsing, job status determination
+3. **Metadata Extractor**: Provider, OCP version, workload type, Kata RPM extraction
+4. **Failure Analyzer**: Failed step identification, test categorization
+5. **Report Generator**: Markdown and JSON report formatting
+
+### Claude Code Workflow
+
+When using `/prowjob-analyze` command, Claude follows this workflow:
+
+1. **Run analyze.py** - Get overall job status and identify failed steps
+2. **Examine Failure Analysis** - Check which step(s) failed
+3. **Decision Logic**:
+   - **Case A**: If `openshift-extended-test` failed AND tests are listed → Run `failed_tests_report.py` for detailed test logs
+   - **Case B**: If other step failed (e.g., `ipi-install-install`) → Tests never ran, explain infrastructure failure
+   - **Case C**: If multiple steps failed → Intelligent decision based on whether tests executed
+4. **Report Results** - Present analysis with artifact links and next steps
+
+## Requirements
+
+- Python 3.6+
+- `pyyaml` library (for parsing test-results.yaml)
+
+### Installing Dependencies
+
+```bash
+# Using pip
+pip install pyyaml
+
+# Or using system package manager (Fedora/RHEL)
+sudo dnf install python3-pyyaml
+```
+
+## Exit Codes
+
+- `0`: Job passed successfully
+- `1`: Job failed, timed out, or was aborted
+- `2`: Analysis error (cannot fetch artifacts, invalid URL, etc.)
+
+## Examples
+
+### Passing Job
+
+```bash
+./analyze.py https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1998111460479209472
+```
+
+Output:
+```markdown
+# Prow Job Analysis Report
+
+## Status: ✅ SUCCESS
+
+## Job Overview
+- **Job Name**: periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods
+- **Provider**: AWS
+- **OCP Version**: 4.19
+- **Workload**: peerpods
+...
+```
+
+### Failed Periodic Job
+
+```bash
+./analyze.py https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata/1998111457991987200
+```
+
+Output will include failure analysis with categorized failing tests, detected patterns, and root cause analysis.
+
+### Presubmit/Rehearsal Job
+
+```bash
+./analyze.py https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/72608/rehearse-72608-periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-azure-ipi-coco/2001012534630420480
+```
+
+Output for rehearsal jobs includes the PR context:
+```markdown
+## Job Overview
+- **Job Name**: rehearse-72608-periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-azure-ipi-coco
+- **Trigger**: rehearsal
+- **Provider**: Azure
+- **Workload**: confidential-containers
+...
+```
+
+## OSC-Specific Features
+
+The analyzer is tailored for OSC jobs with special handling for:
+
+- **Workload Types**: Recognizes kata, peerpods, and confidential-containers (coco) workloads
+- **Kata RPM Version**: Extracts RPM version from job artifacts or identifies node-default usage
+- **Catalog Information**: Extracts catalog source image, version, and build date
+- **Test Categorization**: Groups failing tests by OSC-relevant categories (operator lifecycle, workload deployment, peerpods-specific, coco-specific, etc.)
+- **Test Metadata Parsing**: Extracts test case IDs (C#####), authors, and priorities from test names
+- **Step-Level Detection**: Identifies which actual Prow step failed (e.g., `ipi-install-install`, `sandboxed-containers-operator-create-kataconfig`, `openshift-extended-test`)
+- **Special Step Handling**: Cross-checks test-results.yaml for openshift-extended-test step (which may report success in finished.json even when tests fail)
+- **OSC Test Context**: Understands OSC test execution flow, setup phases, and common failure patterns
+
+## Troubleshooting
+
+### "Failed to fetch prowjob.json"
+
+- Check that the Prow job URL is correct
+- Verify the job has completed (or use --wait to wait for completion)
+- Ensure you have network access to prow.ci.openshift.org
+
+### "pyyaml not available"
+
+Install the pyyaml library:
+```bash
+pip install pyyaml
+```
+
+### Job Still Running
+
+Use the `--wait` option to wait for job completion:
+```bash
+./analyze.py --wait 600 <URL>  # Wait up to 10 minutes
+```
+
+## Development
+
+### Running Tests
+
+```bash
+# Test with a known passing job
+./analyze.py <passing-job-url>
+
+# Test with a known failing job
+./analyze.py <failing-job-url>
+
+# Test JSON output
+./analyze.py --json <job-url> | jq .
+```
+
+### Adding New Failure Patterns
+
+Edit `lib/failure_analyzer.py` and add patterns to the `FAILURE_PATTERNS` dictionary:
+
+```python
+FAILURE_PATTERNS = {
+    'new_pattern': [
+        r'regex pattern 1',
+        r'regex pattern 2',
+    ],
+}
+```
+
+## Contributing
+
+When modifying the analyzer:
+
+1. Test with both passing and failing jobs
+2. Verify both human-readable and JSON output formats
+3. Update this README if adding new features
+4. Ensure error handling for missing artifacts
+
+## References
+
+- [Prow Documentation](https://docs.prow.k8s.io/)
+- [OpenShift CI Documentation](https://docs.ci.openshift.org/)
+- [OSC Job Definitions](https://github.com/openshift/release/tree/master/ci-operator/config/openshift/sandboxed-containers-operator)

--- a/scripts/prowjob-analyzer/analyze-claude.py
+++ b/scripts/prowjob-analyzer/analyze-claude.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Claude Prowjob Analyzer Launcher
+
+Wrapper script to launch Claude Code with the /prowjob-analyze command.
+Automatically finds the project root and invokes Claude with the correct command.
+
+Usage:
+    ./analyze-claude.py <PROW_JOB_URL>
+
+Example:
+    ./analyze-claude.py https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+"""
+
+import sys
+import os
+import subprocess
+import argparse
+from pathlib import Path
+
+
+def find_git_root():
+    """Find the git root directory."""
+    current = Path.cwd()
+
+    # Try from current directory upwards
+    for parent in [current] + list(current.parents):
+        if (parent / '.git').exists():
+            return parent
+
+    # If not found, try from script location upwards
+    script_dir = Path(__file__).resolve().parent
+    for parent in [script_dir] + list(script_dir.parents):
+        if (parent / '.git').exists():
+            return parent
+
+    raise RuntimeError("Could not find git root directory (no .git directory found)")
+
+
+def validate_prow_url(url):
+    """Basic validation of Prow job URL."""
+    if not url.startswith('https://prow.ci.openshift.org/view/gs/'):
+        print(f"Warning: URL doesn't look like a valid Prow job URL", file=sys.stderr)
+        print(f"Expected format: https://prow.ci.openshift.org/view/gs/...", file=sys.stderr)
+        response = input("Continue anyway? [y/N] ")
+        if response.lower() != 'y':
+            sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Launch Claude Code to analyze a Prow job',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  # Non-interactive mode (default)
+  %(prog)s https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+
+  # Interactive mode (opens Claude session)
+  %(prog)s -i <URL>
+
+  # With verbose output
+  %(prog)s --verbose <URL>
+        '''
+    )
+
+    parser.add_argument(
+        'url',
+        help='Prow job URL to analyze'
+    )
+
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Show verbose output (for debugging)'
+    )
+
+    parser.add_argument(
+        '--interactive', '-i',
+        action='store_true',
+        help='Launch Claude in interactive mode (default: non-interactive)'
+    )
+
+    args = parser.parse_args()
+
+    # Validate URL
+    validate_prow_url(args.url)
+
+    # Find project root
+    try:
+        git_root = find_git_root()
+        if args.verbose:
+            print(f"Found git root: {git_root}", file=sys.stderr)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Change to project root
+    os.chdir(git_root)
+    if args.verbose:
+        print(f"Changed to directory: {os.getcwd()}", file=sys.stderr)
+
+    # Prepare the Claude command
+    claude_command = f"/prowjob-analyze {args.url}"
+
+    mode = "interactive" if args.interactive else "non-interactive"
+    print(f"\nLaunching Claude Code in {mode} mode with command:", file=sys.stderr)
+    print(f"  {claude_command}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    # Check if claude command exists
+    try:
+        subprocess.run(['which', 'claude'], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        print("Error: 'claude' command not found in PATH", file=sys.stderr)
+        print("Please install Claude Code CLI: https://claude.ai/code", file=sys.stderr)
+        sys.exit(1)
+
+    # Launch Claude with the command
+    try:
+        if args.interactive:
+            # Interactive mode: pipe the command to claude
+            cmd = f'echo "{claude_command}" | claude'
+
+            if args.verbose:
+                print(f"Executing: {cmd}", file=sys.stderr)
+
+            # Execute the command in interactive mode
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                text=True,
+                cwd=git_root
+            )
+        else:
+            # Non-interactive mode: use claude -p
+            cmd = ['claude', '-p', claude_command]
+
+            if args.verbose:
+                print(f"Executing: {' '.join(cmd)}", file=sys.stderr)
+
+            # Execute the command in non-interactive mode
+            result = subprocess.run(
+                cmd,
+                text=True,
+                cwd=git_root
+            )
+
+        sys.exit(result.returncode)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user", file=sys.stderr)
+        sys.exit(130)
+    except Exception as e:
+        print(f"Error launching Claude: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prowjob-analyzer/analyze.py
+++ b/scripts/prowjob-analyzer/analyze.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Prow Job Analyzer
+
+Analyzes OpenShift Prow job results for OSC testing.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+# Add lib directory to path
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+
+from lib.fetcher import (
+    parse_prow_url,
+    fetch_json_artifact,
+    fetch_artifact,
+    wait_for_artifacts,
+    extract_variant_from_job_name,
+)
+from lib.parser import (
+    parse_prowjob,
+    parse_test_results,
+    get_job_status,
+)
+from lib.metadata_extractor import extract_metadata
+from lib.failure_analyzer import analyze_failure
+from lib.report_generator import generate_human_report, generate_json_report
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+def setup_logging(verbose: bool = False):
+    """Configure logging."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(levelname)s: %(message)s'
+    )
+
+
+def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
+    """
+    Analyze a Prow job from its URL.
+
+    Args:
+        url: Prow job URL
+        wait_timeout: Timeout for waiting for artifacts (seconds)
+
+    Returns:
+        Analysis results as dict, or None on error
+    """
+    try:
+        # Parse URL
+        logger.info(f"Parsing Prow job URL...")
+        base_url, job_name, build_id = parse_prow_url(url)
+        logger.info(f"Job: {job_name}")
+        logger.info(f"Build ID: {build_id}")
+
+    except ValueError as e:
+        logger.error(str(e))
+        return None
+
+    # Wait for artifacts if needed
+    if wait_timeout > 0:
+        logger.info("Checking if artifacts are ready...")
+        if not wait_for_artifacts(base_url, timeout=wait_timeout):
+            logger.warning("Artifacts not ready yet, attempting analysis anyway...")
+
+    # Fetch prowjob.json
+    logger.info("Fetching prowjob.json...")
+    prowjob_json = fetch_json_artifact(base_url, "prowjob.json")
+
+    if not prowjob_json:
+        logger.error("Failed to fetch prowjob.json - cannot analyze job")
+        return None
+
+    # Parse prowjob
+    logger.info("Parsing prowjob data...")
+    prowjob_data = parse_prowjob(prowjob_json)
+
+    # Extract metadata
+    logger.info("Extracting metadata...")
+    metadata = extract_metadata(prowjob_data, base_url)
+    logger.info(f"Provider: {metadata['provider']}, OCP: {metadata['ocp_version']}, Workload: {metadata['workload_type']}")
+
+    # Fetch test results if available
+    logger.info("Fetching test results...")
+    test_results = None
+    variant = metadata.get('variant')
+
+    if variant and variant != 'unknown':
+        test_results_path = f"artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml"
+        test_results_content = fetch_artifact(base_url, test_results_path)
+
+        if test_results_content:
+            test_results = parse_test_results(test_results_content)
+            if test_results:
+                logger.info(f"Test results found: {test_results.get('failures', 0)} failures")
+        else:
+            logger.warning("test-results.yaml not found (might be a prow step failure)")
+
+    # Determine job status
+    status = get_job_status(prowjob_json, test_results)
+    logger.info(f"Job status: {status}")
+
+    # Analyze failures if job failed
+    failure_analysis = None
+    if status != 'success':
+        logger.info("Analyzing failure...")
+        failure_analysis = analyze_failure(prowjob_data, base_url, test_results, metadata)
+        logger.info(f"Failed step(s): {failure_analysis.get('failure_location')}")
+        logger.info(f"Failing tests: {len(failure_analysis.get('failing_tests', []))}")
+        logger.info(f"Detected patterns: {failure_analysis.get('detected_patterns')}")
+
+    return {
+        'prowjob_data': prowjob_data,
+        'metadata': metadata,
+        'status': status,
+        'test_results': test_results,
+        'failure_analysis': failure_analysis,
+        'base_url': base_url,
+    }
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description='Analyze OpenShift Prow job results for OSC testing',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  %(prog)s https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
+
+  %(prog)s --json <URL> > report.json
+
+  %(prog)s --verbose --no-wait <URL>
+        '''
+    )
+
+    parser.add_argument(
+        'url',
+        help='Prow job URL'
+    )
+
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output machine-readable JSON format'
+    )
+
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose logging'
+    )
+
+    parser.add_argument(
+        '--wait',
+        type=int,
+        default=300,
+        metavar='SECONDS',
+        help='Wait timeout for in-progress jobs in seconds (default: 300, 0 to disable)'
+    )
+
+    parser.add_argument(
+        '--no-wait',
+        action='store_true',
+        help='Do not wait for in-progress jobs (same as --wait 0)'
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    setup_logging(args.verbose)
+
+    # Determine wait timeout
+    wait_timeout = 0 if args.no_wait else args.wait
+
+    # Analyze job
+    results = analyze_prowjob(args.url, wait_timeout=wait_timeout)
+
+    if results is None:
+        logger.error("Analysis failed")
+        sys.exit(2)
+
+    # Generate report
+    if args.json:
+        logger.info("Generating JSON report...")
+        report = generate_json_report(
+            results['prowjob_data'],
+            results['metadata'],
+            results['status'],
+            results['test_results'],
+            results['failure_analysis'],
+            results['base_url']
+        )
+    else:
+        logger.info("Generating human-readable report...")
+        report = generate_human_report(
+            results['prowjob_data'],
+            results['metadata'],
+            results['status'],
+            results['test_results'],
+            results['failure_analysis'],
+            results['base_url']
+        )
+
+    # Output report
+    print("\n" + "="*80 + "\n")
+    print(report)
+
+    # Exit code based on job status
+    if results['status'] == 'success':
+        sys.exit(0)
+    elif results['status'] in ['failure', 'timeout', 'aborted']:
+        sys.exit(1)
+    else:
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prowjob-analyzer/failed_tests_report.py
+++ b/scripts/prowjob-analyzer/failed_tests_report.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Failed Tests Report Script
+
+Generates detailed reports for failed tests from a Prow job, including
+full test logs and failure summaries extracted from build-log.txt.
+
+Usage:
+    python3 failed_tests_report.py <PROW_JOB_URL> [TEST_NAME1 TEST_NAME2 ...]
+    python3 failed_tests_report.py --json <PROW_JOB_URL> [TEST_NAME1 TEST_NAME2 ...]
+"""
+
+import sys
+import argparse
+import logging
+import json
+import re
+from typing import Dict, List, Optional
+
+# Add lib to path
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+
+from lib.fetcher import (
+    parse_prow_url,
+    fetch_artifact,
+    extract_variant_from_job_name,
+)
+from lib.parser import (
+    parse_prowjob,
+    parse_test_results,
+    extract_failing_tests,
+    parse_test_case_info,
+    categorize_test_by_name,
+)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def extract_test_logs_from_build_log(build_log_content: str, test_name: str) -> Optional[Dict]:
+    """
+    Extract full test logs and failure summary for a specific test from build-log.txt.
+
+    Args:
+        build_log_content: Content of build-log.txt
+        test_name: Name of the test to extract
+
+    Returns:
+        Dictionary with full_logs and failure_summary, or None if not found
+    """
+    lines = build_log_content.split('\n')
+    
+    # Escape special regex characters in test name
+    escaped_test = re.escape(test_name)
+    
+    # Find start: started: ({stats}) "{test name}"
+    start_pattern = rf'started:.*"{escaped_test}"'
+    # Find end: failed: ({elapsed time}) {date} "{test name}"
+    end_pattern = rf'failed:.*"{escaped_test}"'
+    
+    start_idx = None
+    end_idx = None
+    
+    for i, line in enumerate(lines):
+        if start_idx is None and re.search(start_pattern, line, re.IGNORECASE):
+            start_idx = i
+            logger.debug(f"Found test start at line {i}: {line[:80]}")
+        elif start_idx is not None and re.search(end_pattern, line, re.IGNORECASE):
+            end_idx = i
+            logger.debug(f"Found test end at line {i}: {line[:80]}")
+            break
+    
+    if start_idx is None:
+        logger.warning(f"Could not find start of test logs for: {test_name}")
+        return None
+    
+    if end_idx is None:
+        logger.warning(f"Could not find end of test logs for: {test_name}")
+        # Use remaining content if we found the start
+        end_idx = len(lines) - 1
+
+    # Extract elapsed time from the failed line
+    # Pattern: failed: (10m13s) 2025-11-11T00:01:49 "{test name}"
+    elapsed_time = "unknown"
+    if end_idx is not None and end_idx < len(lines):
+        end_line = lines[end_idx]
+        elapsed_match = re.search(r'failed:\s*\(([^)]+)\)', end_line, re.IGNORECASE)
+        if elapsed_match:
+            elapsed_time = elapsed_match.group(1)
+
+    # Extract full test logs
+    full_logs_lines = lines[start_idx:end_idx + 1]
+    full_logs = '\n'.join(full_logs_lines)
+
+    # Extract failure summary from full logs
+    # Find "Summarizing {N} Failure" and extract until end, excluding timestamp lines
+    failure_summary_lines = []
+    in_summary = False
+
+    for line in full_logs_lines:
+        if re.search(r'Summarizing \d+ Failure', line):
+            in_summary = True
+            continue
+
+        if in_summary:
+            # Skip lines that start with timestamp pattern (e.g., "Dec 08 15:20:36.914")
+            if re.match(r'^[A-Z][a-z]{2} \d{2} \d{2}:\d{2}:\d{2}\.\d{3}', line):
+                continue
+            failure_summary_lines.append(line)
+
+    failure_summary = '\n'.join(failure_summary_lines).strip()
+
+    return {
+        'full_logs': full_logs,
+        'failure_summary': failure_summary,
+        'elapsed_time': elapsed_time
+    }
+
+
+def analyze_failed_tests(
+    base_url: str,
+    variant: str,
+    test_names: Optional[List[str]] = None
+) -> List[Dict]:
+    """
+    Analyze failed tests and generate detailed reports.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant
+        test_names: Optional list of specific test names to analyze (None = all failed tests)
+
+    Returns:
+        List of dictionaries with detailed test information
+    """
+    results = []
+    
+    # Fetch test-results.yaml to get list of failed tests
+    logger.info("Fetching test results...")
+    test_results_path = f"artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml"
+    test_results_content = fetch_artifact(base_url, test_results_path)
+    
+    if not test_results_content:
+        logger.error("Could not fetch test-results.yaml")
+        return results
+    
+    test_results = parse_test_results(test_results_content)
+    if not test_results:
+        logger.error("Could not parse test-results.yaml")
+        return results
+    
+    # Get list of failed tests
+    all_failed_tests = extract_failing_tests(test_results)
+    
+    if not all_failed_tests:
+        logger.info("No failed tests found in test-results.yaml")
+        return results
+    
+    # Filter to specific tests if requested
+    if test_names:
+        # Match by full name or by test case ID (C#####)
+        tests_to_analyze = []
+        for test in all_failed_tests:
+            test_name = test['name']
+            test_case_id = test.get('test_case_number', '')
+            
+            # Check if this test matches any of the requested names/IDs
+            for requested in test_names:
+                if requested in test_name or (test_case_id and requested in test_case_id):
+                    tests_to_analyze.append(test)
+                    break
+        
+        if not tests_to_analyze:
+            logger.warning(f"None of the requested tests found in failed tests list")
+            logger.info(f"Available failed tests: {[t['name'] for t in all_failed_tests]}")
+            return results
+    else:
+        tests_to_analyze = all_failed_tests
+    
+    logger.info(f"Analyzing {len(tests_to_analyze)} failed test(s)...")
+    
+    # Fetch build-log.txt
+    build_log_path = f"artifacts/{variant}/openshift-extended-test/build-log.txt"
+    logger.info(f"Fetching build log from {build_log_path}...")
+    
+    build_log_content = fetch_artifact(base_url, build_log_path)
+    if not build_log_content:
+        logger.error("Could not fetch build-log.txt")
+        return results
+    
+    build_log_text = build_log_content.decode('utf-8', errors='ignore')
+    logger.info(f"Build log size: {len(build_log_text)} characters")
+    
+    # Process each test
+    for test in tests_to_analyze:
+        test_name = test['name']
+        logger.info(f"Processing test: {test_name}")
+        
+        # Extract test logs
+        test_logs = extract_test_logs_from_build_log(build_log_text, test_name)
+
+        if not test_logs:
+            logger.warning(f"Could not extract logs for test: {test_name}")
+            test_logs = {'full_logs': '', 'failure_summary': '', 'elapsed_time': 'unknown'}
+
+        # Parse test case info (already done in extract_failing_tests, but get it again)
+        test_info = parse_test_case_info(test_name)
+        category = categorize_test_by_name(test_name)
+
+        result = {
+            'test_name': test_name,
+            'test_case_number': test_info['test_case_number'],
+            'elapsed_time': test_logs['elapsed_time'],
+            'category': category,
+            'author': test_info['author'],
+            'priority': test_info['priority'],
+            'failure_summary': test_logs['failure_summary'],
+            'full_logs': test_logs['full_logs'],
+        }
+        
+        results.append(result)
+    
+    return results
+
+
+def generate_markdown_report(test_results: List[Dict], base_url: str) -> str:
+    """
+    Generate markdown report for failed tests.
+
+    Args:
+        test_results: List of test analysis results
+        base_url: Base URL of the Prow job
+
+    Returns:
+        Markdown formatted report
+    """
+    report = "# Failed Tests Report\n\n"
+    report += f"**Job URL**: {base_url}\n\n"
+    report += f"**Tests Analyzed**: {len(test_results)}\n\n"
+    report += "---\n\n"
+    
+    for idx, test in enumerate(test_results, 1):
+        report += f"## Test {idx}: {test['test_name']}\n\n"
+        
+        # Metadata
+        if test['test_case_number']:
+            report += f"- **Test Case ID**: {test['test_case_number']}\n"
+        report += f"- **Elapsed Time**: {test['elapsed_time']}\n"
+        report += f"- **Category**: {test['category']}\n"
+        if test['author']:
+            report += f"- **Author**: {test['author']}\n"
+        if test['priority']:
+            report += f"- **Priority**: {test['priority']}\n"
+        report += "\n"
+        
+        # Failure summary
+        if test['failure_summary']:
+            report += "### Failure Summary\n\n"
+            report += "```\n"
+            report += test['failure_summary']
+            report += "\n```\n\n"
+        
+        # Full logs
+        if test['full_logs']:
+            report += "### Full Test Logs\n\n"
+            report += "```\n"
+            report += test['full_logs']
+            report += "\n```\n\n"
+        
+        report += "---\n\n"
+    
+    return report
+
+
+def generate_json_report(test_results: List[Dict], base_url: str) -> str:
+    """
+    Generate JSON report for failed tests.
+
+    Args:
+        test_results: List of test analysis results
+        base_url: Base URL of the Prow job
+
+    Returns:
+        JSON formatted report
+    """
+    report = {
+        'job_url': base_url,
+        'tests_analyzed': len(test_results),
+        'failed_tests': test_results,
+    }
+    
+    return json.dumps(report, indent=2)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description='Generate detailed report for failed tests from a Prow job'
+    )
+    parser.add_argument('url', help='Prow job URL')
+    parser.add_argument('tests', nargs='*', help='Test names or IDs to analyze (omit to analyze all failed tests)')
+    parser.add_argument('--json', action='store_true', help='Output JSON format instead of markdown')
+    parser.add_argument('--verbose', action='store_true', help='Enable verbose logging')
+    
+    args = parser.parse_args()
+    
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    
+    try:
+        # Parse Prow URL
+        logger.info("Parsing Prow job URL...")
+        base_url, job_name, build_id = parse_prow_url(args.url)
+        logger.info(f"Job: {job_name}")
+        logger.info(f"Build ID: {build_id}")
+        
+        # Extract variant from job name
+        variant = extract_variant_from_job_name(job_name)
+        if not variant:
+            logger.error("Could not determine job variant from job name")
+            sys.exit(1)
+        
+        logger.info(f"Variant: {variant}")
+        
+        # Analyze failed tests
+        test_results = analyze_failed_tests(base_url, variant, args.tests if args.tests else None)
+        
+        if not test_results:
+            logger.error("No test results could be analyzed")
+            sys.exit(1)
+        
+        # Generate report
+        if args.json:
+            report = generate_json_report(test_results, base_url)
+        else:
+            report = generate_markdown_report(test_results, base_url)
+        
+        print(report)
+    
+    except KeyboardInterrupt:
+        logger.info("\nInterrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prowjob-analyzer/lib/__init__.py
+++ b/scripts/prowjob-analyzer/lib/__init__.py
@@ -1,0 +1,27 @@
+"""
+Prow Job Analyzer Library
+
+This package provides modules for analyzing OpenShift Prow job results,
+specifically tailored for OpenShift Sandboxed Containers (OSC) testing.
+"""
+
+__version__ = "1.0.0"
+
+from .fetcher import parse_prow_url, fetch_artifact, wait_for_artifacts
+from .parser import parse_prowjob, parse_test_results, get_job_status
+from .metadata_extractor import extract_metadata
+from .failure_analyzer import analyze_failure
+from .report_generator import generate_human_report, generate_json_report
+
+__all__ = [
+    "parse_prow_url",
+    "fetch_artifact",
+    "wait_for_artifacts",
+    "parse_prowjob",
+    "parse_test_results",
+    "get_job_status",
+    "extract_metadata",
+    "analyze_failure",
+    "generate_human_report",
+    "generate_json_report",
+]

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -1,0 +1,307 @@
+"""
+Failure Analyzer Module
+
+Analyzes failures to identify location, patterns, and root causes.
+"""
+
+import re
+import logging
+from typing import Dict, List, Optional
+from collections import defaultdict
+from .parser import categorize_test_by_name, extract_failing_tests
+from .fetcher import fetch_artifact, get_failed_steps
+
+logger = logging.getLogger(__name__)
+
+# Common failure patterns
+FAILURE_PATTERNS = {
+    'timeout': [
+        r'context deadline exceeded',
+        r'timeout waiting for',
+        r'operation timed out',
+        r'i/o timeout',
+        r'timed out after',
+    ],
+    'oom': [
+        r'OOMKilled',
+        r'out of memory',
+        r'cannot allocate memory',
+        r'memory limit exceeded',
+    ],
+    'network': [
+        r'connection refused',
+        r'network unreachable',
+        r'no route to host',
+        r'connection reset',
+        r'dial tcp.*: i/o timeout',
+    ],
+    'image_pull': [
+        r'ImagePullBackOff',
+        r'ErrImagePull',
+        r'failed to pull image',
+        r'manifest unknown',
+    ],
+    'quota': [
+        r'quota exceeded',
+        r'insufficient quota',
+        r'resource quota',
+        r'limit range',
+    ],
+    'infrastructure': [
+        r'cluster.*not ready',
+        r'node.*not ready',
+        r'failed to provision',
+        r'cluster installation failed',
+    ],
+    'kata_init': [
+        r'kata.*failed to start',
+        r'runtime kata.*error',
+        r'qemu.*failed',
+        r'failed to create sandbox',
+    ],
+}
+
+
+def identify_failure_location(
+    prowjob_data: Dict,
+    test_results: Optional[Dict],
+    base_url: str,
+    variant: str
+) -> str:
+    """
+    Identify which step(s) failed in the job.
+
+    Logic:
+    - If test-results.yaml doesn't exist: tests didn't run, job failed before tests
+    - If test-results.yaml exists with failures > 0: job failed at test execution
+    - We rely on finished.json in each step's artifacts to determine which steps failed
+
+    Args:
+        prowjob_data: Parsed prowjob data
+        test_results: Parsed test results (if available)
+        base_url: Base URL of Prow job
+        variant: Job variant
+
+    Returns:
+        Name of failed step(s), comma-separated if multiple, or status like 'timeout'/'unknown'
+    """
+    state = prowjob_data.get('state', '').lower()
+
+    # Check if job timed out
+    if 'timeout' in state or state == 'aborted':
+        return 'timeout'
+
+    # Check if it's a Prow infrastructure failure
+    if state in ['error', 'errored']:
+        return 'infrastructure'
+
+    # Get actual failed steps from artifacts by checking each step's finished.json
+    if variant and variant != 'unknown':
+        failed_steps = get_failed_steps(base_url, variant)
+
+        if failed_steps:
+            # Return only the steps that actually failed
+            return ', '.join(failed_steps)
+        else:
+            # No failed steps detected from artifacts
+            # This can happen if we can't parse the artifacts properly
+            if state == 'failure':
+                logger.warning("Job failed but couldn't detect failed steps from artifacts")
+                return 'unknown'
+
+    # If variant is unknown, we can't check step artifacts
+    return 'unknown'
+
+
+
+
+def check_log_for_patterns(log_content: str) -> List[str]:
+    """
+    Check log content for known failure patterns.
+
+    Args:
+        log_content: Log file content as string
+
+    Returns:
+        List of detected pattern names
+    """
+    detected_patterns = []
+
+    for pattern_name, regexes in FAILURE_PATTERNS.items():
+        for regex in regexes:
+            if re.search(regex, log_content, re.IGNORECASE):
+                detected_patterns.append(pattern_name)
+                break  # Only add each pattern once
+
+    return detected_patterns
+
+
+def categorize_failing_tests(test_results: Dict) -> Dict[str, List[Dict]]:
+    """
+    Group failing tests by category.
+
+    Args:
+        test_results: Parsed test results
+
+    Returns:
+        Dictionary mapping category to list of failing tests
+    """
+    failing_tests = extract_failing_tests(test_results)
+    categorized = defaultdict(list)
+
+    for test in failing_tests:
+        category = categorize_test_by_name(test['name'])
+        categorized[category].append(test)
+
+    return dict(categorized)
+
+
+def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[str], metadata: Dict) -> Dict:
+    """
+    Attempt to determine root cause of failure.
+
+    Args:
+        failing_tests: List of failing tests
+        detected_patterns: List of detected failure patterns
+        metadata: Job metadata
+
+    Returns:
+        Dictionary with root cause analysis
+    """
+    root_cause = {
+        'primary_pattern': None,
+        'likely_cause': '',
+        'confidence': 'low',
+        'suggested_actions': [],
+    }
+
+    # Analyze patterns
+    if 'timeout' in detected_patterns:
+        root_cause['primary_pattern'] = 'timeout'
+        root_cause['likely_cause'] = 'Test execution exceeded time limits'
+        root_cause['confidence'] = 'medium'
+        root_cause['suggested_actions'] = [
+            'Check if cluster resources are sufficient',
+            'Review slow-running tests',
+            'Consider increasing timeout if tests are valid',
+        ]
+    elif 'oom' in detected_patterns:
+        root_cause['primary_pattern'] = 'oom'
+        root_cause['likely_cause'] = 'Out of memory condition'
+        root_cause['confidence'] = 'high'
+        root_cause['suggested_actions'] = [
+            'Increase memory limits for pods',
+            'Check for memory leaks in application',
+            'Review cluster capacity',
+        ]
+    elif 'kata_init' in detected_patterns:
+        root_cause['primary_pattern'] = 'kata_init'
+        root_cause['likely_cause'] = 'Kata runtime initialization failure'
+        root_cause['confidence'] = 'high'
+        root_cause['suggested_actions'] = [
+            'Check Kata runtime logs',
+            'Verify RPM compatibility',
+            'Review node configuration',
+        ]
+    elif 'network' in detected_patterns:
+        root_cause['primary_pattern'] = 'network'
+        root_cause['likely_cause'] = 'Network connectivity issues'
+        root_cause['confidence'] = 'medium'
+        root_cause['suggested_actions'] = [
+            'Check network policies',
+            'Verify DNS resolution',
+            'Review firewall rules',
+        ]
+    elif 'image_pull' in detected_patterns:
+        root_cause['primary_pattern'] = 'image_pull'
+        root_cause['likely_cause'] = 'Failed to pull container images'
+        root_cause['confidence'] = 'high'
+        root_cause['suggested_actions'] = [
+            'Verify image exists and is accessible',
+            'Check image pull secrets',
+            'Review registry connectivity',
+        ]
+
+    # Check for version mismatch (OSC-specific)
+    if any('version' in test['name'].lower() for test in failing_tests):
+        root_cause['likely_cause'] = 'Operator version mismatch'
+        root_cause['confidence'] = 'high'
+        root_cause['suggested_actions'].append(
+            f"Update EXPECTED_OPERATOR_VERSION to {metadata.get('expected_operator_version', 'correct value')}"
+        )
+
+    # If many tests failed, might be infrastructure
+    if len(failing_tests) > 10:
+        root_cause['likely_cause'] = 'Widespread test failures suggest infrastructure or configuration issue'
+        root_cause['confidence'] = 'medium'
+        root_cause['suggested_actions'].append('Review cluster health and OSC installation logs')
+
+    return root_cause
+
+
+def analyze_failure(
+    prowjob_data: Dict,
+    base_url: str,
+    test_results: Optional[Dict],
+    metadata: Dict
+) -> Dict:
+    """
+    Comprehensive failure analysis.
+
+    Args:
+        prowjob_data: Parsed prowjob data
+        base_url: Base URL for fetching artifacts
+        test_results: Parsed test results
+        metadata: Extracted metadata
+
+    Returns:
+        Dictionary with complete failure analysis
+    """
+    analysis = {
+        'failure_location': 'unknown',
+        'failing_tests': [],
+        'failing_tests_by_category': {},
+        'detected_patterns': [],
+        'root_cause': {},
+    }
+
+    # Identify failure location (actual step name(s))
+    variant = metadata.get('variant', '')
+    analysis['failure_location'] = identify_failure_location(
+        prowjob_data,
+        test_results,
+        base_url,
+        variant
+    )
+
+    # Get failing tests if available
+    if test_results:
+        failing_tests = extract_failing_tests(test_results)
+        analysis['failing_tests'] = failing_tests
+        analysis['failing_tests_by_category'] = categorize_failing_tests(test_results)
+
+    # Fetch and analyze logs for patterns
+    variant = metadata.get('variant', '')
+    if variant:
+        # Try to fetch extended test log
+        extended_log_path = f"artifacts/{variant}/openshift-extended-test/artifacts/extended.log"
+        log_content = fetch_artifact(base_url, extended_log_path)
+
+        if log_content:
+            try:
+                log_text = log_content.decode('utf-8', errors='ignore')
+                # Limit to last 100KB to avoid processing huge logs
+                if len(log_text) > 100000:
+                    log_text = log_text[-100000:]
+                analysis['detected_patterns'] = check_log_for_patterns(log_text)
+            except Exception as e:
+                logger.warning(f"Failed to analyze log: {e}")
+
+    # Determine root cause
+    analysis['root_cause'] = determine_root_cause(
+        analysis['failing_tests'],
+        analysis['detected_patterns'],
+        metadata
+    )
+
+    return analysis

--- a/scripts/prowjob-analyzer/lib/fetcher.py
+++ b/scripts/prowjob-analyzer/lib/fetcher.py
@@ -1,0 +1,413 @@
+"""
+Artifact Fetcher Module
+
+Handles URL parsing and fetching artifacts from Prow/GCS.
+"""
+
+import re
+import time
+import json
+import logging
+from typing import Dict, Optional, Tuple, List
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+logger = logging.getLogger(__name__)
+
+
+def parse_prow_url(url: str) -> Tuple[str, str, str]:
+    """
+    Parse a Prow job URL to extract job name and build ID.
+    Supports both periodic and presubmit (PR rehearsal) job URLs.
+
+    Args:
+        url: Prow UI URL (https://prow.ci.openshift.org/view/gs/...)
+
+    Returns:
+        Tuple of (base_url, job_name, build_id)
+
+    Raises:
+        ValueError: If URL format is invalid
+    """
+    # Try presubmit/PR pattern first (more specific)
+    # Format: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/{ORG}_{REPO}/{PR_NUMBER}/{JOB_NAME}/{BUILD_ID}
+    pr_pattern = r'https://prow\.ci\.openshift\.org/view/gs/([^/]+)/pr-logs/pull/([^/]+)/([^/]+)/([^/]+)/([^/\?]+)'
+    match = re.match(pr_pattern, url)
+
+    if match:
+        bucket = match.group(1)
+        org_repo = match.group(2)
+        pr_number = match.group(3)
+        job_name = match.group(4)
+        build_id = match.group(5)
+
+        # Construct base URL for presubmit jobs
+        base_url = f"https://prow.ci.openshift.org/view/gs/{bucket}/pr-logs/pull/{org_repo}/{pr_number}/{job_name}/{build_id}"
+        logger.debug(f"Parsed as presubmit job: PR {org_repo}#{pr_number}")
+        return base_url, job_name, build_id
+
+    # Try periodic/postsubmit pattern
+    # Format: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{JOB_NAME}/{BUILD_ID}
+    periodic_pattern = r'https://prow\.ci\.openshift\.org/view/gs/([^/]+)/([^/]+)/([^/]+)/([^/\?]+)'
+    match = re.match(periodic_pattern, url)
+
+    if match:
+        bucket = match.group(1)
+        log_type = match.group(2)
+        job_name = match.group(3)
+        build_id = match.group(4)
+
+        # Construct base URL for periodic/postsubmit jobs
+        base_url = f"https://prow.ci.openshift.org/view/gs/{bucket}/{log_type}/{job_name}/{build_id}"
+        logger.debug(f"Parsed as periodic/postsubmit job")
+        return base_url, job_name, build_id
+
+    # No pattern matched
+    raise ValueError(
+        f"Invalid Prow URL format. Expected one of:\n"
+        f"  Periodic: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/{{JOB_NAME}}/{{BUILD_ID}}\n"
+        f"  Presubmit: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/{{ORG}}_{{REPO}}/{{PR}}/{{JOB_NAME}}/{{BUILD_ID}}\n"
+        f"Got: {url}"
+    )
+
+
+def extract_variant_from_job_name(job_name: str) -> Optional[str]:
+    """
+    Extract the variant from job name for artifact path construction.
+
+    For OSC jobs, the variant is typically: {provider}-ipi-{workload}
+    Example: periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods
+    Variant: aws-ipi-peerpods
+
+    Args:
+        job_name: Prow job name
+
+    Returns:
+        Variant string or None if not found
+    """
+    # Look for known patterns in OSC job names
+    # Pattern: ...downstream-candidate-{VARIANT}
+    pattern = r'downstream-candidate([0-9]+)?-(.+)$'
+    match = re.search(pattern, job_name)
+
+    if match:
+        return match.group(2)
+
+    # Try alternative patterns for other job types
+    # Pattern: ...{provider}-ipi-{workload}
+    providers = ['aro', 'aws', 'azure', 'gcp', 'ibmcloud', 'vsphere']
+    for provider in providers:
+        pattern = f'({provider}-ipi-[^-]+)'
+        match = re.search(pattern, job_name)
+        if match:
+            return match.group(1)
+
+    logger.warning(f"Could not extract variant from job name: {job_name}")
+    return None
+
+
+def discover_gcs_url_from_prow(prow_url: str) -> Optional[str]:
+    """
+    Discover the actual GCS web URL by parsing Prow's HTML response.
+
+    Args:
+        prow_url: Prow view URL that may return HTML
+
+    Returns:
+        Discovered GCS web URL, or None if not found
+    """
+    try:
+        req = Request(prow_url, headers={'User-Agent': 'prowjob-analyzer/1.0'})
+        with urlopen(req, timeout=30) as response:
+            content_type = response.headers.get('Content-Type', '')
+
+            if 'text/html' in content_type:
+                # Parse HTML to extract GCS web URL
+                html = response.read().decode('utf-8', errors='ignore')
+                # Look for gcsweb URL in the HTML
+                match = re.search(r'https://[^"\s]*gcsweb[^"\s]*', html)
+                if match:
+                    gcs_url = match.group(0).rstrip('/')
+                    logger.debug(f"Discovered GCS URL: {gcs_url}")
+                    return gcs_url
+
+    except Exception as e:
+        logger.debug(f"Failed to discover GCS URL from {prow_url}: {e}")
+
+    return None
+
+
+def fetch_artifact(base_url: str, artifact_path: str, max_retries: int = 3) -> Optional[bytes]:
+    """
+    Fetch an artifact from Prow/GCS with retry logic.
+    Dynamically discovers the GCS web URL if Prow returns HTML.
+
+    Args:
+        base_url: Base URL of the Prow job
+        artifact_path: Relative path to the artifact (e.g., "prowjob.json")
+        max_retries: Maximum number of retry attempts
+
+    Returns:
+        Artifact content as bytes, or None if not found
+    """
+    url = f"{base_url}/{artifact_path}"
+
+    for attempt in range(max_retries):
+        try:
+            logger.debug(f"Fetching {url} (attempt {attempt + 1}/{max_retries})")
+            req = Request(url, headers={'User-Agent': 'prowjob-analyzer/1.0'})
+
+            with urlopen(req, timeout=30) as response:
+                content_type = response.headers.get('Content-Type', '')
+                content = response.read()
+
+                # Check if we got HTML instead of the actual artifact
+                if 'text/html' in content_type and attempt == 0:
+                    logger.debug(f"Got HTML response, discovering GCS URL...")
+                    # Try to discover the actual GCS URL from the HTML
+                    gcs_url = discover_gcs_url_from_prow(url)
+                    if gcs_url:
+                        # Retry with the discovered GCS URL
+                        logger.debug(f"Retrying with discovered GCS URL: {gcs_url}")
+                        req = Request(gcs_url, headers={'User-Agent': 'prowjob-analyzer/1.0'})
+                        with urlopen(req, timeout=30) as gcs_response:
+                            gcs_content_type = gcs_response.headers.get('Content-Type', '')
+                            content = gcs_response.read()
+
+                            # If we still got HTML from GCS, the file doesn't exist
+                            if 'text/html' in gcs_content_type:
+                                logger.debug(f"GCS also returned HTML - artifact not found")
+                                return None
+
+                            logger.debug(f"Successfully fetched from GCS ({len(content)} bytes)")
+                            return content
+                    else:
+                        # Could not discover GCS URL and got HTML - file doesn't exist
+                        logger.debug(f"Could not discover GCS URL - artifact not found")
+                        return None
+
+                # If we got HTML after retry or without Prow redirect, file doesn't exist
+                if 'text/html' in content_type:
+                    logger.debug(f"Got HTML response - artifact not found")
+                    return None
+
+                logger.debug(f"Successfully fetched {url} ({len(content)} bytes)")
+                return content
+
+        except HTTPError as e:
+            if e.code == 404:
+                logger.debug(f"Artifact not found: {url}")
+                return None
+            elif e.code in (500, 502, 503, 504) and attempt < max_retries - 1:
+                wait_time = 2 ** attempt  # Exponential backoff
+                logger.warning(f"Server error {e.code}, retrying in {wait_time}s...")
+                time.sleep(wait_time)
+            else:
+                logger.error(f"HTTP error fetching {url}: {e.code} {e.reason}")
+                return None
+
+        except URLError as e:
+            if attempt < max_retries - 1:
+                wait_time = 2 ** attempt
+                logger.warning(f"Network error, retrying in {wait_time}s: {e}")
+                time.sleep(wait_time)
+            else:
+                logger.error(f"Failed to fetch {url}: {e}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Unexpected error fetching {url}: {e}")
+            return None
+
+    return None
+
+
+def fetch_json_artifact(base_url: str, artifact_path: str) -> Optional[Dict]:
+    """
+    Fetch and parse a JSON artifact.
+
+    Args:
+        base_url: Base URL of the Prow job
+        artifact_path: Relative path to the JSON artifact
+
+    Returns:
+        Parsed JSON as dict, or None if not found or invalid
+    """
+    content = fetch_artifact(base_url, artifact_path)
+    if content is None:
+        return None
+
+    try:
+        return json.loads(content.decode('utf-8'))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.error(f"Failed to parse JSON from {artifact_path}: {e}")
+        return None
+
+
+def check_artifacts_ready(base_url: str) -> bool:
+    """
+    Check if job artifacts are ready (job has finished).
+
+    Args:
+        base_url: Base URL of the Prow job
+
+    Returns:
+        True if artifacts are ready, False otherwise
+    """
+    # Check for finished.json which indicates the job has completed
+    finished = fetch_json_artifact(base_url, "finished.json")
+    return finished is not None
+
+
+def wait_for_artifacts(base_url: str, timeout: int = 300, poll_interval: int = 10) -> bool:
+    """
+    Wait for job artifacts to become available.
+
+    Args:
+        base_url: Base URL of the Prow job
+        timeout: Maximum time to wait in seconds (default: 5 minutes)
+        poll_interval: Time between polls in seconds (default: 10 seconds)
+
+    Returns:
+        True if artifacts became ready, False if timeout
+    """
+    start_time = time.time()
+
+    logger.info(f"Waiting for job artifacts (timeout: {timeout}s)...")
+
+    while (time.time() - start_time) < timeout:
+        if check_artifacts_ready(base_url):
+            elapsed = time.time() - start_time
+            logger.info(f"Artifacts ready after {elapsed:.1f}s")
+            return True
+
+        remaining = timeout - (time.time() - start_time)
+        logger.info(f"Job still running, checking again in {poll_interval}s (timeout in {remaining:.0f}s)...")
+        time.sleep(poll_interval)
+
+    logger.warning(f"Timeout waiting for artifacts after {timeout}s")
+    return False
+
+
+def get_artifact_url(base_url: str, artifact_path: str) -> str:
+    """
+    Generate a GCS web URL for an artifact.
+
+    Args:
+        base_url: Base URL of the Prow job
+        artifact_path: Relative path to the artifact
+
+    Returns:
+        Full URL to the artifact
+    """
+    return f"{base_url}/{artifact_path}"
+
+
+def get_step_directories(base_url: str, variant: str) -> List[str]:
+    """
+    Get list of step directories from artifacts.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant (e.g., "aws-ipi-peerpods")
+
+    Returns:
+        List of step directory names
+    """
+    artifacts_url = f"{base_url}/artifacts/{variant}/"
+
+    try:
+        logger.debug(f"Fetching step directories from {artifacts_url}")
+        req = Request(artifacts_url, headers={'User-Agent': 'prowjob-analyzer/1.0'})
+        with urlopen(req, timeout=30) as response:
+            content_type = response.headers.get('Content-Type', '')
+            html_content = response.read().decode('utf-8', errors='ignore')
+            logger.debug(f"Fetched {len(html_content)} bytes, content-type: {content_type}")
+
+            # Check if we got HTML redirect page instead of directory listing
+            if 'text/html' in content_type and 'gcsweb' not in html_content[:1000]:
+                logger.debug("Got Prow HTML page, discovering GCS URL...")
+                gcs_url = discover_gcs_url_from_prow(artifacts_url)
+                if gcs_url:
+                    logger.debug(f"Retrying with GCS URL: {gcs_url}")
+                    req = Request(gcs_url, headers={'User-Agent': 'prowjob-analyzer/1.0'})
+                    with urlopen(req, timeout=30) as gcs_response:
+                        html_content = gcs_response.read().decode('utf-8', errors='ignore')
+                        logger.debug(f"Fetched {len(html_content)} bytes from GCS")
+
+            # Extract directory names from HTML listing
+            # Pattern: href="/gcs/.../artifacts/{variant}/STEP_NAME/"
+            # We want to extract just the STEP_NAME part
+            pattern = rf'href="[^"]*/{variant}/([a-z0-9-]+)/"'
+            matches = re.findall(pattern, html_content)
+            logger.debug(f"Regex pattern matched {len(matches)} times")
+
+            # Remove duplicates and filter out parent directory references
+            step_dirs = []
+            seen = set()
+            for m in matches:
+                if m not in seen and m not in ['..', 'artifacts']:
+                    step_dirs.append(m)
+                    seen.add(m)
+
+            logger.debug(f"Found {len(step_dirs)} step directories in {variant}: {step_dirs[:5]}")
+            return step_dirs
+
+    except Exception as e:
+        logger.warning(f"Failed to get step directories from {artifacts_url}: {e}")
+        return []
+
+
+def get_failed_steps(base_url: str, variant: str) -> List[str]:
+    """
+    Identify which steps failed by checking their finished.json files.
+
+    Special handling for openshift-extended-test: Also checks test-results.yaml
+    since this step may report as passed even when tests failed.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant (e.g., "aws-ipi-peerpods")
+
+    Returns:
+        List of failed step names
+    """
+    step_dirs = get_step_directories(base_url, variant)
+    failed_steps = []
+
+    for step in step_dirs:
+        finished_path = f"artifacts/{variant}/{step}/finished.json"
+        finished_data = fetch_json_artifact(base_url, finished_path)
+
+        if finished_data:
+            # Check if step failed according to finished.json
+            passed = finished_data.get('passed', True)
+            result = finished_data.get('result', '').upper()
+
+            step_failed = not passed or result == 'FAILURE'
+
+            # Special case: openshift-extended-test may report as passed
+            # even when tests failed. Check test-results.yaml to be sure.
+            if step == 'openshift-extended-test' and not step_failed:
+                test_results_path = f"artifacts/{variant}/{step}/artifacts/test-results.yaml"
+                test_results_content = fetch_artifact(base_url, test_results_path)
+
+                if test_results_content:
+                    # Import here to avoid circular dependency
+                    from .parser import parse_test_results
+
+                    test_results = parse_test_results(test_results_content)
+                    if test_results:
+                        failures = test_results.get('failures', 0)
+                        errors = test_results.get('errors', 0)
+
+                        if failures > 0 or errors > 0:
+                            step_failed = True
+                            logger.debug(f"Step {step} has test failures: failures={failures}, errors={errors}")
+
+            if step_failed:
+                failed_steps.append(step)
+                logger.debug(f"Step {step} failed: passed={passed}, result={result}")
+
+    logger.debug(f"Found {len(failed_steps)} failed steps: {failed_steps}")
+    return failed_steps

--- a/scripts/prowjob-analyzer/lib/metadata_extractor.py
+++ b/scripts/prowjob-analyzer/lib/metadata_extractor.py
@@ -1,0 +1,510 @@
+"""
+Metadata Extractor Module
+
+Extracts job metadata from prowjob.json and related artifacts.
+"""
+
+import re
+import json
+import logging
+from typing import Dict, Optional
+from .fetcher import fetch_artifact, extract_variant_from_job_name
+
+logger = logging.getLogger(__name__)
+
+
+def extract_provider(job_name: str) -> str:
+    """
+    Extract cloud provider from job name.
+
+    Args:
+        job_name: Prow job name
+
+    Returns:
+        Provider name (aws, azure, gcp, etc.) or 'unknown'
+    """
+    providers = {
+        'aro': 'Aro',
+        'aws': 'AWS',
+        'azure': 'Azure',
+        'gcp': 'GCP',
+        'ibmcloud': 'IBM Cloud',
+        'vsphere': 'vSphere',
+        'openstack': 'OpenStack',
+        'baremetal': 'Bare Metal',
+    }
+
+    job_lower = job_name.lower()
+    for key, value in providers.items():
+        if key in job_lower:
+            return value
+
+    return 'unknown'
+
+
+def extract_workload_type(job_name: str) -> str:
+    """
+    Extract workload type from job name.
+
+    Args:
+        job_name: Prow job name
+
+    Returns:
+        Workload type (kata, peerpods, coco, etc.) or 'unknown'
+    """
+    job_lower = job_name.lower()
+
+    if 'peerpods' in job_lower or 'peer-pods' in job_lower:
+        return 'peerpods'
+    elif 'coco' in job_lower or 'confidential' in job_lower:
+        return 'confidential-containers'
+    elif 'kata' in job_lower:
+        return 'kata'
+    else:
+        return 'unknown'
+
+
+def extract_ocp_version_from_release_artifact(base_url: str) -> Optional[str]:
+    """
+    Extract exact OCP version from release-images-latest artifact.
+
+    Args:
+        base_url: Base URL of the Prow job
+
+    Returns:
+        OCP version string (e.g., "4.17.45") or None if not found
+    """
+    release_artifact_path = "artifacts/release/artifacts/release-images-latest"
+    content = fetch_artifact(base_url, release_artifact_path)
+
+    if content:
+        try:
+            # Check if we got HTML (directory listing) instead of JSON
+            content_str = content.decode('utf-8', errors='ignore')
+            if content_str.strip().startswith('<!doctype') or content_str.strip().startswith('<html'):
+                logger.debug("Got HTML instead of release-images-latest, file doesn't exist")
+                return None
+
+            # Parse JSON ImageStream
+            data = json.loads(content_str)
+
+            # Extract version from metadata.name
+            if 'metadata' in data and 'name' in data['metadata']:
+                version = data['metadata']['name']
+                logger.debug(f"Found OCP version from release artifact: {version}")
+                return version
+
+        except json.JSONDecodeError as e:
+            logger.debug(f"Failed to parse release-images-latest as JSON: {e}")
+        except Exception as e:
+            logger.debug(f"Failed to extract OCP version from release artifact: {e}")
+
+    return None
+
+
+def extract_ocp_version(prowjob_data: Dict, base_url: str = None) -> str:
+    """
+    Extract OCP version from release artifact or prowjob metadata.
+
+    Args:
+        prowjob_data: Parsed prowjob.json
+        base_url: Optional base URL for fetching release artifact
+
+    Returns:
+        OCP version string (e.g., "4.17.45") or 'unknown'
+    """
+    # First try to get exact version from release artifact
+    if base_url:
+        version = extract_ocp_version_from_release_artifact(base_url)
+        if version:
+            return version
+        logger.debug("Falling back to prowjob metadata for OCP version")
+
+    # Try to extract from environment variables
+    env_vars = prowjob_data.get('env_vars', {})
+
+    # Check for common OCP version variables
+    for var_name in ['OPENSHIFT_VERSION', 'OCP_VERSION', 'RELEASE_IMAGE_LATEST']:
+        if var_name in env_vars:
+            value = env_vars[var_name]
+            # Try to extract version number (e.g., "4.19" from various formats)
+            match = re.search(r'(\d+\.\d+)', value)
+            if match:
+                return match.group(1)
+
+    # Try to extract from job name
+    # Pattern: ...ocp-4.19-... or ...4-19-...
+    job_name = prowjob_data.get('job_name', '')
+    match = re.search(r'(?:ocp-)?(\d+)[-\.](\d+)', job_name)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+
+    # Try labels
+    labels = prowjob_data.get('metadata', {}).get('labels', {})
+    if 'prow.k8s.io/release' in labels:
+        return labels['prow.k8s.io/release']
+
+    return 'unknown'
+
+
+def parse_catalog_tag(catalog_image: str) -> Dict:
+    """
+    Parse catalog image tag to extract version and timestamp.
+
+    Handles multiple tag formats:
+    - version-timestamp: 1.11.1-1765791442
+    - version with v prefix: v1.11.1
+    - plain version: 1.11.1
+    - latest: latest
+    - git SHA: abc123def456
+    - sha256 digest: sha256:41ca9598b816ddc784de8f345e7e586c2630747f2d10c1a45ad5e082ff228a1f
+
+    Args:
+        catalog_image: Full catalog image string (e.g., quay.io/.../osc-test-fbc:1.11.1-1765791442)
+
+    Returns:
+        Dictionary with parsed catalog information
+    """
+    from datetime import datetime, timezone
+
+    catalog_info = {
+        'full_tag': '',
+        'base_version': '',
+        'timestamp': '',
+        'build_date': '',
+    }
+
+    if not catalog_image:
+        return catalog_info
+
+    # Check if using digest format (with @)
+    if '@' in catalog_image:
+        # Format: quay.io/example@sha256:41ca9598b816ddc784de8f345e7e586c2630747f2d10c1a45ad5e082ff228a1f
+        tag = catalog_image.split('@')[-1]
+        catalog_info['full_tag'] = tag
+
+        # Extract hash without algorithm prefix (sha256:)
+        if ':' in tag:
+            algorithm, hash_value = tag.split(':', 1)
+            catalog_info['base_version'] = hash_value
+        else:
+            catalog_info['base_version'] = tag
+
+        catalog_info['build_date'] = 'unknown'
+        return catalog_info
+
+    # Check if using tag format (with :)
+    if ':' not in catalog_image:
+        return catalog_info
+
+    # Extract tag from image
+    tag = catalog_image.split(':')[-1]
+    catalog_info['full_tag'] = tag
+
+    # Try version-timestamp format (e.g., "1.11.1-1765791442")
+    match = re.match(r'^([\d.]+)-(\d+)$', tag)
+    if match:
+        catalog_info['base_version'] = match.group(1)
+        catalog_info['timestamp'] = match.group(2)
+
+        # Convert timestamp to UTC datetime
+        try:
+            timestamp_int = int(match.group(2))
+            dt = datetime.fromtimestamp(timestamp_int, tz=timezone.utc)
+            catalog_info['build_date'] = dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+        except (ValueError, OSError) as e:
+            logger.debug(f"Failed to convert timestamp {match.group(2)}: {e}")
+            catalog_info['build_date'] = 'invalid-timestamp'
+        return catalog_info
+
+    # Try version with v prefix (e.g., "v1.11.1")
+    match = re.match(r'^v([\d.]+)$', tag)
+    if match:
+        catalog_info['base_version'] = match.group(1)
+        catalog_info['build_date'] = 'unknown'
+        return catalog_info
+
+    # Try plain version (e.g., "1.11.1")
+    match = re.match(r'^[\d.]+$', tag)
+    if match:
+        catalog_info['base_version'] = tag
+        catalog_info['build_date'] = 'unknown'
+        return catalog_info
+
+    # Check for "latest"
+    if tag == 'latest':
+        catalog_info['base_version'] = 'latest'
+        catalog_info['build_date'] = 'unknown'
+        return catalog_info
+
+    # Check for git SHA (40 hex characters for full SHA, or shorter for abbreviated)
+    if re.match(r'^[0-9a-f]{7,40}$', tag):
+        catalog_info['base_version'] = tag
+        catalog_info['build_date'] = 'unknown'
+        return catalog_info
+
+    # Default: unknown format, keep as-is
+    catalog_info['base_version'] = tag
+    catalog_info['build_date'] = 'unknown'
+
+    return catalog_info
+
+
+def extract_build_info(prowjob_data: Dict) -> Dict:
+    """
+    Extract build/catalog information from prowjob.
+
+    Args:
+        prowjob_data: Parsed prowjob.json
+
+    Returns:
+        Dictionary with build information
+    """
+    env_vars = prowjob_data.get('env_vars', {})
+
+    catalog_image = env_vars.get('CATALOG_SOURCE_IMAGE', '')
+
+    build_info = {
+        'catalog_source_image': catalog_image,
+        'catalog_source_name': env_vars.get('CATALOG_SOURCE_NAME', ''),
+        'expected_operator_version': env_vars.get('EXPECTED_OPERATOR_VERSION', ''),
+    }
+
+    # Parse catalog tag for version and timestamp
+    catalog_info = parse_catalog_tag(catalog_image)
+    build_info.update(catalog_info)
+
+    # Determine release stage from job name
+    job_name = prowjob_data.get('job_name', '')
+    build_info['release_stage'] = ''
+    if 'downstream-candidate' in job_name:
+        build_info['release_stage'] = 'candidate'
+    elif 'downstream-release' in job_name:
+        build_info['release_stage'] = 'release'
+
+    return build_info
+
+
+def extract_trigger_source(prowjob_data: Dict) -> str:
+    """
+    Extract trigger source for the job.
+
+    Args:
+        prowjob_data: Parsed prowjob.json
+
+    Returns:
+        Trigger source (periodic, presubmit, postsubmit, manual, konflux, rehearsal, etc.)
+    """
+    job_type = prowjob_data.get('type', '').lower()
+    job_name = prowjob_data.get('job_name', '')
+
+    # Check metadata
+    labels = prowjob_data.get('metadata', {}).get('labels', {})
+    annotations = prowjob_data.get('metadata', {}).get('annotations', {})
+
+    # Check for Konflux trigger via gangway API
+    # Konflux-submitted jobs have these annotations even when they appear as periodic
+    if annotations.get('ci.openshift.io/executor') == 'gangway' and 'ci.openshift.io/konflux-repo' in annotations:
+        return 'konflux'
+
+    # Check for Konflux integration test label (older method)
+    if 'prow.k8s.io/integration-test' in labels or 'konflux' in str(labels).lower():
+        return 'konflux'
+
+    # Check for rehearsal (presubmit PR testing)
+    if 'rehearse' in job_name.lower():
+        return 'rehearsal'
+
+    # Check for clusterbot
+    env_vars = prowjob_data.get('env_vars', {})
+    if 'CLUSTER_TYPE' in env_vars or 'clusterbot' in str(annotations).lower():
+        return 'clusterbot'
+
+    # Standard Prow job types
+    if job_type in ['periodic', 'presubmit', 'postsubmit']:
+        return job_type
+
+    return 'manual'
+
+
+def extract_kata_rpm_version(base_url: str, variant: str) -> Optional[str]:
+    """
+    Extract Kata RPM version from job artifacts.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant for artifact path
+
+    Returns:
+        Kata RPM version string or None if not found
+    """
+    # Try to fetch kata-rpm-version.txt
+    rpm_version_path = f"artifacts/{variant}/sandboxed-containers-operator-get-kata-rpm/artifacts/kata-rpm-version.txt"
+    content = fetch_artifact(base_url, rpm_version_path)
+
+    if content:
+        try:
+            # Check if we got HTML (directory listing) instead of text
+            content_str = content.decode('utf-8', errors='ignore')
+            if content_str.strip().startswith('<!doctype') or content_str.strip().startswith('<html'):
+                logger.debug("Got HTML instead of kata-rpm-version.txt, file doesn't exist")
+            else:
+                version = content_str.strip()
+                if version and len(version) < 200:  # Sanity check - version shouldn't be too long
+                    logger.debug(f"Found Kata RPM version: {version}")
+                    return version
+        except Exception as e:
+            logger.debug(f"Failed to parse kata-rpm-version.txt: {e}")
+
+    # Alternative: parse from build log
+    build_log_path = f"artifacts/{variant}/sandboxed-containers-operator-get-kata-rpm/artifacts/build-log.txt"
+    content = fetch_artifact(base_url, build_log_path)
+
+    if content:
+        try:
+            log_text = content.decode('utf-8', errors='ignore')
+            # Don't try to parse if it's HTML
+            if not (log_text.strip().startswith('<!doctype') or log_text.strip().startswith('<html')):
+                # Look for RPM version patterns
+                match = re.search(r'kata[a-z-]*\s+(\d+\.\d+\.\d+-\d+\..*)', log_text)
+                if match:
+                    version = match.group(1)
+                    logger.debug(f"Extracted Kata RPM version from log: {version}")
+                    return version
+        except Exception as e:
+            logger.debug(f"Failed to parse build log: {e}")
+
+    logger.debug("Kata RPM version not found (may be using node default)")
+    return None
+
+
+def extract_catalog_from_extended_log(base_url: str, variant: str) -> Optional[str]:
+    """
+    Extract catalog source image from extended.log.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant for artifact path
+
+    Returns:
+        Catalog source image string or None if not found
+    """
+    extended_log_path = f"artifacts/{variant}/openshift-extended-test/artifacts/extended.log"
+    content = fetch_artifact(base_url, extended_log_path)
+
+    if content:
+        try:
+            log_text = content.decode('utf-8', errors='ignore')
+            # Look for catalog source image patterns
+            # Pattern: "catalog source image & tag: quay.io/.../osc-test-fbc:1.11.1-1765791442"
+            match = re.search(r'catalog source image & tag:\s+([^\s]+)', log_text)
+            if match:
+                catalog_image = match.group(1)
+                logger.debug(f"Found catalog source in extended.log: {catalog_image}")
+                return catalog_image
+        except Exception as e:
+            logger.debug(f"Failed to parse extended.log for catalog source: {e}")
+
+    return None
+
+
+def extract_ocp_channel(base_url: str, variant: str) -> Optional[str]:
+    """
+    Extract OCP channel from ipi-install-install build-log.txt.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant for artifact path
+
+    Returns:
+        OCP channel string (e.g., "stable-4.20") or None if not found
+    """
+    build_log_path = f"artifacts/{variant}/ipi-install-install/build-log.txt"
+    content = fetch_artifact(base_url, build_log_path)
+
+    if content:
+        try:
+            log_text = content.decode('utf-8', errors='ignore')
+            # Don't try to parse if it's HTML
+            if not (log_text.strip().startswith('<!doctype') or log_text.strip().startswith('<html')):
+                # Look for "Setting channel to" line which shows the final channel used
+                match = re.search(r'Setting channel to ((?:stable|fast|candidate|eus)-\d+\.\d+)', log_text)
+                if match:
+                    channel = match.group(1)
+                    logger.debug(f"Found OCP channel: {channel}")
+                    return channel
+
+                # Fallback: look for any channel pattern
+                match = re.search(r'(stable|fast|candidate|eus)-\d+\.\d+', log_text)
+                if match:
+                    channel = match.group(0)
+                    logger.debug(f"Found OCP channel (fallback): {channel}")
+                    return channel
+        except Exception as e:
+            logger.debug(f"Failed to parse ipi-install-install build-log.txt for OCP channel: {e}")
+
+    return None
+
+
+def extract_metadata(prowjob_data: Dict, base_url: str) -> Dict:
+    """
+    Extract all metadata from prowjob and artifacts.
+
+    Args:
+        prowjob_data: Parsed prowjob.json with job_info
+        base_url: Base URL for fetching artifacts
+
+    Returns:
+        Dictionary with all extracted metadata
+    """
+    job_name = prowjob_data.get('job_name', '')
+    variant = extract_variant_from_job_name(job_name)
+
+    metadata = {
+        'provider': extract_provider(job_name),
+        'workload_type': extract_workload_type(job_name),
+        'ocp_version': extract_ocp_version(prowjob_data, base_url),
+        'trigger_source': extract_trigger_source(prowjob_data),
+        'variant': variant or 'unknown',
+        'job_name': job_name,
+        'build_id': prowjob_data.get('build_id', 'unknown'),
+    }
+
+    # Extract build information
+    build_info = extract_build_info(prowjob_data)
+
+    # If catalog source not in env vars, try to extract from extended.log
+    if not build_info.get('catalog_source_image') and variant:
+        catalog_from_log = extract_catalog_from_extended_log(base_url, variant)
+        if catalog_from_log:
+            build_info['catalog_source_image'] = catalog_from_log
+            # Re-parse catalog tag with the newly found image
+            catalog_info = parse_catalog_tag(catalog_from_log)
+            build_info.update(catalog_info)
+
+    metadata.update(build_info)
+
+    # Extract Kata RPM version if variant is known
+    if variant:
+        kata_rpm_version = extract_kata_rpm_version(base_url, variant)
+        if kata_rpm_version:
+            metadata['kata_rpm_version'] = kata_rpm_version
+            metadata['kata_rpm_source'] = 'installed'
+        else:
+            metadata['kata_rpm_version'] = 'node-default'
+            metadata['kata_rpm_source'] = 'node'
+    else:
+        metadata['kata_rpm_version'] = 'unknown'
+        metadata['kata_rpm_source'] = 'unknown'
+
+    # Extract OCP channel if variant is known
+    if variant:
+        ocp_channel = extract_ocp_channel(base_url, variant)
+        if ocp_channel:
+            metadata['ocp_channel'] = ocp_channel
+        else:
+            metadata['ocp_channel'] = 'unknown'
+    else:
+        metadata['ocp_channel'] = 'unknown'
+
+    return metadata

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -1,0 +1,317 @@
+"""
+Parser Module
+
+Handles parsing of prowjob.json and test-results.yaml files.
+"""
+
+import logging
+from typing import Dict, Optional, List
+from datetime import datetime
+
+try:
+    import yaml
+except ImportError:
+    # Fallback if pyyaml not available
+    yaml = None
+
+logger = logging.getLogger(__name__)
+
+
+def parse_prowjob(prowjob_data: Dict) -> Dict:
+    """
+    Parse prowjob.json and extract key information.
+
+    Args:
+        prowjob_data: Parsed prowjob.json content
+
+    Returns:
+        Dictionary with extracted prowjob information
+    """
+    spec = prowjob_data.get('spec', {})
+    status = prowjob_data.get('status', {})
+    metadata = prowjob_data.get('metadata', {})
+
+    job_info = {
+        'job_name': spec.get('job', 'unknown'),
+        'type': spec.get('type', 'unknown'),  # periodic, presubmit, postsubmit
+        'cluster': spec.get('cluster', 'unknown'),
+        'build_id': status.get('build_id', metadata.get('name', 'unknown')),
+        'state': status.get('state', 'unknown'),  # success, failure, pending, etc.
+        'url': status.get('url', ''),
+        'start_time': status.get('startTime', ''),
+        'completion_time': status.get('completionTime', ''),
+        'duration_seconds': 0,
+        'pod_name': status.get('pod_name', ''),
+        'metadata': metadata,  # Include full metadata (contains labels and annotations)
+    }
+
+    # Calculate duration
+    if job_info['start_time'] and job_info['completion_time']:
+        try:
+            start = datetime.fromisoformat(job_info['start_time'].replace('Z', '+00:00'))
+            end = datetime.fromisoformat(job_info['completion_time'].replace('Z', '+00:00'))
+            job_info['duration_seconds'] = int((end - start).total_seconds())
+        except Exception as e:
+            logger.warning(f"Failed to calculate duration: {e}")
+
+    # Extract environment variables (useful for metadata extraction)
+    env_vars = {}
+    pod_spec = spec.get('pod_spec', {})
+    containers = pod_spec.get('containers', [])
+    if containers:
+        for env_var in containers[0].get('env', []):
+            env_vars[env_var.get('name', '')] = env_var.get('value', '')
+
+    job_info['env_vars'] = env_vars
+
+    return job_info
+
+
+def parse_test_results(test_results_content: bytes) -> Optional[Dict]:
+    """
+    Parse test-results.yaml file.
+
+    Args:
+        test_results_content: Raw bytes content of test-results.yaml
+
+    Returns:
+        Parsed test results as dict, or None if parsing fails
+    """
+    if yaml is None:
+        logger.error("pyyaml not available, cannot parse test-results.yaml")
+        return None
+
+    if not test_results_content:
+        return None
+
+    try:
+        content_str = test_results_content.decode('utf-8')
+        data = yaml.safe_load(content_str)
+
+        # Handle nested structure - test-results.yaml often has top-level key
+        # like "openshift-extended-test" containing the actual data
+        if data and isinstance(data, dict):
+            # Check if there's a single top-level key with the actual test data
+            if len(data) == 1:
+                first_key = list(data.keys())[0]
+                first_value = data[first_key]
+                if isinstance(first_value, dict) and 'total' in first_value:
+                    # This is the nested structure, unwrap it
+                    return first_value
+
+        return data
+    except (yaml.YAMLError, UnicodeDecodeError) as e:
+        logger.error(f"Failed to parse test-results.yaml: {e}")
+        return None
+
+
+def get_job_status(prowjob_data: Dict, test_results: Optional[Dict] = None) -> str:
+    """
+    Determine overall job status.
+
+    Args:
+        prowjob_data: Parsed prowjob.json
+        test_results: Optional parsed test-results.yaml
+
+    Returns:
+        Status string: 'success', 'failure', 'timeout', 'error', 'aborted', 'pending'
+    """
+    status = prowjob_data.get('status', {})
+    state = status.get('state', '').lower()
+
+    # Map Prow states to our status
+    if state == 'success':
+        # Double-check with test results if available
+        if test_results and test_results.get('failures', 0) > 0:
+            return 'failure'
+        return 'success'
+    elif state == 'failure':
+        return 'failure'
+    elif state == 'aborted':
+        return 'aborted'
+    elif state == 'pending':
+        return 'pending'
+    elif state == 'error':
+        return 'error'
+    else:
+        # Try to infer from test results
+        if test_results:
+            if test_results.get('failures', 0) == 0:
+                return 'success'
+            else:
+                return 'failure'
+        return 'unknown'
+
+
+def parse_test_case_info(test_name: str) -> Dict:
+    """
+    Parse test case number and description from test name.
+
+    Test names typically follow patterns like:
+    "[sig-kata] Kata Author:user-Priority-C12345-test description [Serial]"
+
+    Args:
+        test_name: Full test name
+
+    Returns:
+        Dictionary with test_case_number and description
+    """
+    import re
+
+    info = {
+        'test_case_number': '',
+        'description': '',
+        'priority': '',
+        'author': '',
+    }
+
+    # Extract test case number (C##### pattern)
+    case_match = re.search(r'-C(\d+)-', test_name)
+    if case_match:
+        info['test_case_number'] = f"C{case_match.group(1)}"
+
+    # Extract priority (High, Medium, Low)
+    priority_match = re.search(r'-(High|Medium|Low)-', test_name)
+    if priority_match:
+        info['priority'] = priority_match.group(1)
+
+    # Extract author
+    author_match = re.search(r'Author:([^-]+)-', test_name)
+    if author_match:
+        info['author'] = author_match.group(1)
+
+    # Extract description (after C##### until [Serial] or end)
+    # Pattern: -C#####-description [optional tags]
+    desc_match = re.search(r'-C\d+-(.*?)(?:\s*\[|$)', test_name)
+    if desc_match:
+        info['description'] = desc_match.group(1).strip()
+    else:
+        # Fallback: try to extract anything after the last - until [
+        desc_match2 = re.search(r'-([^-\[]+)(?:\s*\[|$)', test_name)
+        if desc_match2:
+            info['description'] = desc_match2.group(1).strip()
+
+    # If no description found, use full test name
+    if not info['description']:
+        info['description'] = test_name
+
+    return info
+
+
+def extract_failing_tests(test_results: Dict) -> List[Dict]:
+    """
+    Extract list of failing tests from test-results.yaml.
+
+    Args:
+        test_results: Parsed test-results.yaml
+
+    Returns:
+        List of failing test dictionaries with name and details
+    """
+    failing_tests = []
+
+    if not test_results:
+        return failing_tests
+
+    # Check for 'failingScenarios' list (simpler format)
+    failing_scenarios = test_results.get('failingScenarios', [])
+    if failing_scenarios:
+        for test_name in failing_scenarios:
+            case_info = parse_test_case_info(test_name)
+            failing_tests.append({
+                'name': test_name,
+                'duration': 0,
+                'failure_message': '',
+                'system_out': '',
+                'system_err': '',
+                'test_case_number': case_info['test_case_number'],
+                'description': case_info['description'],
+                'priority': case_info['priority'],
+                'author': case_info['author'],
+            })
+        return failing_tests
+
+    # Fall back to 'tests' list (detailed format)
+    tests = test_results.get('tests', [])
+
+    for test in tests:
+        # Check if test failed
+        if test.get('state') == 'failed' or test.get('failed', False):
+            test_name = test.get('name', 'unknown')
+            case_info = parse_test_case_info(test_name)
+
+            failing_tests.append({
+                'name': test_name,
+                'duration': test.get('duration', 0),
+                'failure_message': test.get('failureMessage', ''),
+                'system_out': test.get('systemOut', ''),
+                'system_err': test.get('systemErr', ''),
+                'test_case_number': case_info['test_case_number'],
+                'description': case_info['description'],
+                'priority': case_info['priority'],
+                'author': case_info['author'],
+            })
+
+    return failing_tests
+
+
+def categorize_test_by_name(test_name: str) -> str:
+    """
+    Categorize a test based on its name.
+
+    Args:
+        test_name: Full test name
+
+    Returns:
+        Category string (e.g., 'deployment', 'networking', 'storage', etc.)
+    """
+    test_lower = test_name.lower()
+
+    # OSC/Kata specific categorization
+    if 'deploy' in test_lower or 'create' in test_lower or 'delete' in test_lower:
+        return 'deployment'
+    elif 'network' in test_lower or 'service' in test_lower or 'expose' in test_lower:
+        return 'networking'
+    elif 'storage' in test_lower or 'volume' in test_lower or 'pv' in test_lower:
+        return 'storage'
+    elif 'cpu' in test_lower or 'memory' in test_lower or 'resource' in test_lower or 'overhead' in test_lower:
+        return 'resources'
+    elif 'log' in test_lower or 'cli' in test_lower:
+        return 'cli_logging'
+    elif 'scale' in test_lower:
+        return 'scaling'
+    elif 'image' in test_lower or 'annotation' in test_lower:
+        return 'images_annotations'
+    elif 'version' in test_lower or 'csv' in test_lower:
+        return 'versioning'
+    elif 'operator' in test_lower:
+        return 'operator'
+    elif 'peerpod' in test_lower or 'peer-pod' in test_lower:
+        return 'peerpods'
+    elif 'kata' in test_lower:
+        return 'kata_runtime'
+    else:
+        return 'other'
+
+
+def format_duration(seconds: int) -> str:
+    """
+    Format duration in seconds to human-readable format.
+
+    Args:
+        seconds: Duration in seconds
+
+    Returns:
+        Formatted string (e.g., "1h 23m 45s")
+    """
+    if seconds < 60:
+        return f"{seconds}s"
+    elif seconds < 3600:
+        minutes = seconds // 60
+        secs = seconds % 60
+        return f"{minutes}m {secs}s"
+    else:
+        hours = seconds // 3600
+        minutes = (seconds % 3600) // 60
+        secs = seconds % 60
+        return f"{hours}h {minutes}m {secs}s"

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -1,0 +1,338 @@
+"""
+Report Generator Module
+
+Generates human-readable markdown and machine-parsable JSON reports.
+"""
+
+import json
+import logging
+from typing import Dict, List, Optional
+from datetime import datetime
+from .parser import format_duration
+from .fetcher import get_artifact_url
+
+logger = logging.getLogger(__name__)
+
+
+def format_status_emoji(status: str) -> str:
+    """Get emoji for job status."""
+    status_emojis = {
+        'success': '✅',
+        'failure': '❌',
+        'timeout': '⏱️',
+        'error': '💥',
+        'aborted': '🛑',
+        'pending': '⏳',
+        'unknown': '❓',
+    }
+    return status_emojis.get(status.lower(), '❓')
+
+
+def generate_test_results_section(test_results: Dict, failure_analysis: Dict) -> str:
+    """Generate test results section for report."""
+    if not test_results:
+        return "\n## Test Results\n\nNo test results available.\n"
+
+    # Handle different test results formats
+    total = test_results.get('total', 0)
+    if total == 0:
+        # Fallback to 'tests' field or count of test list
+        total = test_results.get('tests', 0) if isinstance(test_results.get('tests'), int) else len(test_results.get('tests', []))
+    failures = test_results.get('failures', 0)
+    passed = total - failures
+    skipped = test_results.get('skipped', 0)
+
+    section = "\n## Test Results\n\n"
+    section += f"- **Total Tests**: {total}\n"
+    section += f"- **Passed**: {passed} ✅\n"
+    section += f"- **Failed**: {failures} {'❌' if failures > 0 else ''}\n"
+    section += f"- **Skipped**: {skipped}\n"
+
+    # Add failing tests breakdown if any
+    if failures > 0:
+        failing_tests_by_cat = failure_analysis.get('failing_tests_by_category', {})
+        if failing_tests_by_cat:
+            section += "\n### Failed Tests\n\n"
+            for category, tests in sorted(failing_tests_by_cat.items()):
+                section += f"#### {category.replace('_', ' ').title()} ({len(tests)} tests)\n\n"
+                for test in tests:
+                    test_case_num = test.get('test_case_number', '')
+                    description = test.get('description', '')
+                    test_name = test.get('name', 'Unknown')
+
+                    # Display test case number and description if available
+                    if test_case_num and description:
+                        section += f"- **{test_case_num}**: {description}\n"
+                        # Add priority and author if available
+                        if test.get('priority'):
+                            section += f"  - Priority: {test['priority']}\n"
+                        if test.get('author'):
+                            section += f"  - Author: {test['author']}\n"
+                    else:
+                        # Fallback to showing test name
+                        if len(test_name) > 100:
+                            test_name = test_name[:97] + "..."
+                        section += f"- `{test_name}`\n"
+                section += "\n"
+
+    return section
+
+
+def generate_failure_analysis_section(failure_analysis: Dict, base_url: str, variant: str) -> str:
+    """Generate failure analysis section."""
+    if not failure_analysis:
+        return ""
+
+    section = "\n## Failure Analysis\n\n"
+
+    # Failure location (now shows actual step name(s))
+    location = failure_analysis.get('failure_location', 'unknown')
+    section += f"**Failed Step(s)**: `{location}`\n\n"
+
+    # Add context based on special statuses
+    if location == 'timeout':
+        section += "The job exceeded its execution timeout.\n\n"
+    elif location == 'infrastructure':
+        section += "The job failed due to infrastructure issues.\n\n"
+    elif location == 'unknown':
+        section += "Could not determine which step failed.\n\n"
+
+    return section
+
+
+def generate_artifacts_section(base_url: str, variant: str, test_results_available: bool) -> str:
+    """Generate artifacts links section."""
+    section = "\n## Artifacts\n\n"
+
+    section += f"- [Prow Job]({base_url})\n"
+    section += f"- [prowjob.json]({get_artifact_url(base_url, 'prowjob.json')})\n"
+    section += f"- [finished.json]({get_artifact_url(base_url, 'finished.json')})\n"
+
+    if variant and variant != 'unknown':
+        section += f"- [Test Results]({get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml')})\n"
+        section += f"- [Extended Test Logs]({get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/extended.log')})\n"
+        section += f"- [Must-Gather]({get_artifact_url(base_url, f'artifacts/{variant}/sandboxed-containers-operator-gather-must-gather/artifacts/')})\n"
+
+    return section
+
+
+def generate_human_report(
+    prowjob_data: Dict,
+    metadata: Dict,
+    status: str,
+    test_results: Optional[Dict],
+    failure_analysis: Optional[Dict],
+    base_url: str
+) -> str:
+    """
+    Generate human-readable markdown report.
+
+    Args:
+        prowjob_data: Parsed prowjob data
+        metadata: Extracted metadata
+        status: Overall job status
+        test_results: Test results (if available)
+        failure_analysis: Failure analysis (if failed)
+        base_url: Base URL of Prow job
+
+    Returns:
+        Markdown formatted report
+    """
+    report = "# Prow Job Analysis Report\n\n"
+
+    # Status
+    status_emoji = format_status_emoji(status)
+    report += f"## Status: {status_emoji} {status.upper()}\n\n"
+
+    # Job Overview
+    report += "## Job Overview\n\n"
+    report += f"- **Job Name**: `{metadata['job_name']}`\n"
+    report += f"- **Snowflake ID**: `{metadata['build_id']}`\n"
+    report += f"- **Trigger**: {metadata['trigger_source']}\n"
+
+    # Show release stage if available
+    if metadata.get('release_stage'):
+        report += f"- **Release Stage**: {metadata['release_stage']}\n"
+
+    duration = prowjob_data.get('duration_seconds', 0)
+    if duration > 0:
+        report += f"- **Duration**: {format_duration(duration)}\n"
+
+    start_time = prowjob_data.get('start_time', '')
+    if start_time:
+        report += f"- **Started**: {start_time}\n"
+
+    report += f"- **URL**: {base_url}\n"
+
+    # Environment
+    report += "\n## Environment\n\n"
+    report += f"- **Provider**: {metadata['provider']}\n"
+    report += f"- **OCP Version**: {metadata['ocp_version']}\n"
+    report += f"- **OCP Channel**: {metadata.get('ocp_channel', 'unknown')}\n"
+    report += f"- **Workload**: {metadata['workload_type']}\n"
+    report += f"- **Variant**: {metadata['variant']}\n"
+
+    if metadata.get('kata_rpm_version'):
+        rpm_version = metadata['kata_rpm_version']
+        rpm_source = metadata.get('kata_rpm_source', 'unknown')
+        if rpm_version != 'node-default':
+            report += f"- **Kata RPM**: {rpm_version} ({rpm_source})\n"
+        else:
+            report += f"- **Kata RPM**: Using node default (not installed by job)\n"
+
+    if metadata.get('catalog_source_image'):
+        catalog = metadata['catalog_source_image']
+
+        # For digest format (@sha256:...), show only the image name without digest
+        if '@' in catalog:
+            catalog_display = catalog.split('@')[0]
+        else:
+            catalog_display = catalog
+
+        # Shorten long catalog images
+        if len(catalog_display) > 80:
+            catalog_display = "..." + catalog_display[-77:]
+
+        report += f"- **Catalog Image**: `{catalog_display}`\n"
+
+        # Display full tag if available
+        if metadata.get('full_tag'):
+            report += f"- **Catalog Tag**: `{metadata['full_tag']}`\n"
+
+            # Display base version if available
+            if metadata.get('base_version'):
+                report += f"- **Catalog Version**: {metadata['base_version']}\n"
+
+            # Always display build date
+            build_date = metadata.get('build_date', 'unknown')
+            if build_date == 'invalid-timestamp':
+                build_date = 'unknown'
+            if build_date == 'unknown':
+                report += f"- **Catalog Build Date**: Unknown\n"
+            else:
+                report += f"- **Catalog Build Date**: {build_date}\n"
+
+    # Always show expected operator version, even if empty
+    expected_ver = metadata.get('expected_operator_version', '')
+    if expected_ver:
+        report += f"- **Expected Operator Version**: {expected_ver}\n"
+    else:
+        report += f"- **Expected Operator Version**: (not set)\n"
+
+    # Test Results
+    if test_results:
+        report += generate_test_results_section(test_results, failure_analysis or {})
+
+    # Failure Analysis (if failed)
+    if status != 'success' and failure_analysis:
+        report += generate_failure_analysis_section(failure_analysis, base_url, metadata.get('variant', ''))
+
+    # Artifacts
+    report += generate_artifacts_section(base_url, metadata.get('variant', ''), test_results is not None)
+
+    return report
+
+
+def generate_json_report(
+    prowjob_data: Dict,
+    metadata: Dict,
+    status: str,
+    test_results: Optional[Dict],
+    failure_analysis: Optional[Dict],
+    base_url: str
+) -> str:
+    """
+    Generate machine-parsable JSON report.
+
+    Args:
+        prowjob_data: Parsed prowjob data
+        metadata: Extracted metadata
+        status: Overall job status
+        test_results: Test results (if available)
+        failure_analysis: Failure analysis (if failed)
+        base_url: Base URL of Prow job
+
+    Returns:
+        JSON formatted report
+    """
+    report = {
+        'version': '1.0',
+        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'prowjob': {
+            'url': base_url,
+            'name': metadata['job_name'],
+            'build_id': metadata['build_id'],
+            'status': status,
+            'trigger': metadata['trigger_source'],
+            'release_stage': metadata.get('release_stage', ''),
+            'duration_seconds': prowjob_data.get('duration_seconds', 0),
+            'start_time': prowjob_data.get('start_time', ''),
+            'completion_time': prowjob_data.get('completion_time', ''),
+        },
+        'metadata': {
+            'provider': metadata['provider'],
+            'ocp_version': metadata['ocp_version'],
+            'ocp_channel': metadata.get('ocp_channel', 'unknown'),
+            'workload_type': metadata['workload_type'],
+            'kata_rpm_version': metadata.get('kata_rpm_version', 'unknown'),
+            'kata_rpm_source': metadata.get('kata_rpm_source', 'unknown'),
+            'variant': metadata['variant'],
+            'catalog_source_image': metadata.get('catalog_source_image', ''),
+            'catalog_full_tag': metadata.get('full_tag', ''),
+            'catalog_version': metadata.get('base_version', ''),
+            'catalog_build_date': metadata.get('build_date', ''),
+            'catalog_timestamp': metadata.get('timestamp', ''),
+            'expected_operator_version': metadata.get('expected_operator_version', ''),
+        },
+    }
+
+    # Test results summary
+    if test_results:
+        # Handle different test results formats
+        total = test_results.get('total', 0)
+        if total == 0:
+            # Fallback to 'tests' field or count of test list
+            total = test_results.get('tests', 0) if isinstance(test_results.get('tests'), int) else len(test_results.get('tests', []))
+        failures = test_results.get('failures', 0)
+
+        report['test_results'] = {
+            'total': total,
+            'passed': total - failures,
+            'failed': failures,
+            'skipped': test_results.get('skipped', 0),
+        }
+
+    # Failure analysis
+    if failure_analysis:
+        failing_tests = failure_analysis.get('failing_tests', [])
+
+        report['failure_analysis'] = {
+            'failed_steps': failure_analysis.get('failure_location', 'unknown'),
+            'failing_tests': [
+                {
+                    'name': test.get('name', ''),
+                    'test_case_number': test.get('test_case_number', ''),
+                    'description': test.get('description', ''),
+                    'priority': test.get('priority', ''),
+                    'author': test.get('author', ''),
+                    'duration': test.get('duration', 0),
+                }
+                for test in failing_tests
+            ],
+            'detected_patterns': failure_analysis.get('detected_patterns', []),
+            'root_cause': failure_analysis.get('root_cause', {}),
+        }
+
+    # Artifacts
+    variant = metadata.get('variant', '')
+    report['artifacts'] = {
+        'prowjob_json': get_artifact_url(base_url, 'prowjob.json'),
+        'finished_json': get_artifact_url(base_url, 'finished.json'),
+    }
+
+    if variant and variant != 'unknown':
+        report['artifacts']['test_results'] = get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml')
+        report['artifacts']['extended_log'] = get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/extended.log')
+        report['artifacts']['must_gather'] = get_artifact_url(base_url, f'artifacts/{variant}/sandboxed-containers-operator-gather-must-gather/artifacts/')
+
+    return json.dumps(report, indent=2)

--- a/scripts/prowjob-analyzer/test_report.py
+++ b/scripts/prowjob-analyzer/test_report.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Test Report Script
+
+Provides detailed debugging information for specific test cases from a Prow job.
+Fetches test details, error messages, and log context to help debug failures.
+
+Usage:
+    python3 test_report.py <PROW_JOB_URL> <TEST_NAME1> [TEST_NAME2 ...]
+    python3 test_report.py --json <PROW_JOB_URL> <TEST_NAME1> [TEST_NAME2 ...]
+"""
+
+import sys
+import argparse
+import logging
+import json
+import re
+from typing import Dict, List, Optional
+
+# Add lib to path
+from lib.fetcher import parse_prow_url, fetch_artifact, extract_variant_from_job_name
+from lib.parser import parse_test_results, categorize_test_by_name
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def extract_test_details_from_log(log_content: str, test_name: str) -> Dict:
+    """
+    Extract detailed information about a specific test from build-log.txt.
+
+    Args:
+        log_content: Content of the build-log.txt file
+        test_name: Name of the test to search for
+
+    Returns:
+        Dictionary with test details and debugging information
+    """
+    details = {
+        'test_name': test_name,
+        'found': False,
+        'error_message': '',
+        'log_snippet': '',
+        'duration': '',
+        'patterns': [],
+    }
+
+    # Escape special regex characters in test name
+    escaped_test = re.escape(test_name)
+
+    # Search for the test in the log
+    # Common pattern: "fail [X.XXs]     TestName"
+    test_pattern = rf'(?:fail|FAIL)\s+\[([^\]]+)\]\s+{escaped_test}'
+    match = re.search(test_pattern, log_content, re.IGNORECASE)
+
+    if not match:
+        # Try without duration
+        test_pattern = rf'(?:fail|FAIL).*{escaped_test}'
+        match = re.search(test_pattern, log_content, re.IGNORECASE)
+
+    if match:
+        details['found'] = True
+        if match.lastindex and match.lastindex >= 1:
+            details['duration'] = match.group(1)
+
+        # Find position in log
+        match_pos = match.start()
+
+        # Extract context around the failure (500 chars before, 2000 chars after)
+        start = max(0, match_pos - 500)
+        end = min(len(log_content), match_pos + 2000)
+        context = log_content[start:end]
+
+        # Look for error messages in the context
+        error_lines = []
+        for line in context.split('\n'):
+            if any(keyword in line.lower() for keyword in ['error:', 'failed:', 'panic:', 'fatal:', 'exception:']):
+                error_lines.append(line.strip())
+
+        if error_lines:
+            details['error_message'] = '\n'.join(error_lines[:5])  # First 5 error lines
+
+        # Extract a clean log snippet (remove excessive whitespace)
+        snippet_lines = [line for line in context.split('\n') if line.strip()]
+        details['log_snippet'] = '\n'.join(snippet_lines[:30])  # First 30 non-empty lines
+
+        # Detect common failure patterns
+        patterns = []
+        context_lower = context.lower()
+        if 'timeout' in context_lower or 'deadline exceeded' in context_lower:
+            patterns.append('timeout')
+        if 'oomkilled' in context_lower or 'out of memory' in context_lower:
+            patterns.append('oom')
+        if 'connection refused' in context_lower or 'i/o timeout' in context_lower:
+            patterns.append('network')
+        if 'kata' in context_lower and 'failed' in context_lower:
+            patterns.append('kata_failure')
+        if 'image pull' in context_lower or 'imagepullbackoff' in context_lower:
+            patterns.append('image_pull')
+
+        details['patterns'] = patterns
+
+    return details
+
+
+def analyze_test_cases(base_url: str, variant: str, test_names: List[str]) -> List[Dict]:
+    """
+    Analyze specific test cases and gather debugging information.
+
+    Args:
+        base_url: Base URL of the Prow job
+        variant: Job variant for artifact paths
+        test_names: List of test names to analyze
+
+    Returns:
+        List of dictionaries with test analysis results
+    """
+    results = []
+
+    # Fetch build-log.txt from extended test artifacts
+    build_log_path = f"artifacts/{variant}/openshift-extended-test/build-log.txt"
+    logger.info(f"Fetching test logs from {build_log_path}...")
+
+    log_content = fetch_artifact(base_url, build_log_path)
+    if not log_content:
+        logger.error(f"Failed to fetch build log from {build_log_path}")
+        return results
+
+    try:
+        log_text = log_content.decode('utf-8', errors='ignore')
+    except Exception as e:
+        logger.error(f"Failed to decode build log: {e}")
+        return results
+
+    logger.info(f"Analyzing {len(test_names)} test case(s)...")
+
+    # Analyze each test
+    for test_name in test_names:
+        logger.info(f"Processing test: {test_name}")
+
+        details = extract_test_details_from_log(log_text, test_name)
+
+        # Add test categorization
+        details['category'] = categorize_test_by_name(test_name)
+
+        results.append(details)
+
+    return results
+
+
+def generate_markdown_report(test_results: List[Dict], base_url: str) -> str:
+    """
+    Generate human-readable markdown report for test cases.
+
+    Args:
+        test_results: List of test analysis results
+        base_url: Base URL of the Prow job
+
+    Returns:
+        Markdown formatted report
+    """
+    report = "# Test Debugging Report\n\n"
+    report += f"**Job URL**: {base_url}\n\n"
+    report += f"**Tests Analyzed**: {len(test_results)}\n\n"
+    report += "---\n\n"
+
+    for idx, test in enumerate(test_results, 1):
+        report += f"## Test {idx}: {test['test_name']}\n\n"
+
+        # Test metadata
+        report += f"- **Category**: {test['category']}\n"
+        if test['duration']:
+            report += f"- **Duration**: {test['duration']}\n"
+
+        if test['found']:
+            report += f"- **Status**: ❌ Found in logs\n"
+        else:
+            report += f"- **Status**: ⚠️ Not found in build log\n"
+
+        # Detected patterns
+        if test['patterns']:
+            report += f"- **Detected Patterns**: {', '.join(test['patterns'])}\n"
+
+        report += "\n"
+
+        # Error message
+        if test['error_message']:
+            report += "### Error Message\n\n"
+            report += "```\n"
+            report += test['error_message']
+            report += "\n```\n\n"
+
+        # Log snippet
+        if test['log_snippet']:
+            report += "### Log Context\n\n"
+            report += "```\n"
+            report += test['log_snippet']
+            report += "\n```\n\n"
+
+        # Debugging hints
+        if test['patterns']:
+            report += "### Debugging Hints\n\n"
+            for pattern in test['patterns']:
+                if pattern == 'timeout':
+                    report += "- **Timeout detected**: Check if resources are sufficient, review slow operations\n"
+                elif pattern == 'oom':
+                    report += "- **OOM detected**: Increase memory limits or investigate memory leaks\n"
+                elif pattern == 'network':
+                    report += "- **Network issue detected**: Check connectivity, firewall rules, DNS\n"
+                elif pattern == 'kata_failure':
+                    report += "- **Kata failure detected**: Check Kata runtime logs, VM configuration\n"
+                elif pattern == 'image_pull':
+                    report += "- **Image pull issue detected**: Verify image exists, check credentials\n"
+            report += "\n"
+
+        if not test['found']:
+            report += "### Note\n\n"
+            report += "Test not found in build log. This could mean:\n"
+            report += "- Test name doesn't match exactly (check spelling/case)\n"
+            report += "- Test didn't run or was skipped\n"
+            report += "- Test logs are in a different artifact\n\n"
+
+        report += "---\n\n"
+
+    return report
+
+
+def generate_json_report(test_results: List[Dict], base_url: str) -> Dict:
+    """
+    Generate JSON report for test cases.
+
+    Args:
+        test_results: List of test analysis results
+        base_url: Base URL of the Prow job
+
+    Returns:
+        Dictionary with test analysis in JSON format
+    """
+    return {
+        'job_url': base_url,
+        'tests_analyzed': len(test_results),
+        'test_results': test_results,
+    }
+
+
+def main():
+    """Main entry point for test report script."""
+    parser = argparse.ArgumentParser(
+        description='Generate detailed debugging report for specific test cases from a Prow job'
+    )
+    parser.add_argument('url', help='Prow job URL')
+    parser.add_argument('tests', nargs='+', help='Test names to analyze')
+    parser.add_argument('--json', action='store_true', help='Output JSON format instead of markdown')
+    parser.add_argument('--verbose', action='store_true', help='Enable verbose logging')
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    try:
+        # Parse Prow URL
+        logger.info("Parsing Prow job URL...")
+        base_url, job_name, build_id = parse_prow_url(args.url)
+        logger.info(f"Job: {job_name}")
+        logger.info(f"Build ID: {build_id}")
+
+        # Extract variant from job name
+        variant = extract_variant_from_job_name(job_name)
+        if not variant:
+            logger.error("Could not determine job variant from job name")
+            sys.exit(1)
+
+        logger.info(f"Variant: {variant}")
+
+        # Analyze test cases
+        test_results = analyze_test_cases(base_url, variant, args.tests)
+
+        if not test_results:
+            logger.error("No test results could be analyzed")
+            sys.exit(1)
+
+        # Generate report
+        if args.json:
+            report = generate_json_report(test_results, base_url)
+            print(json.dumps(report, indent=2))
+        else:
+            report = generate_markdown_report(test_results, base_url)
+            print(report)
+
+    except KeyboardInterrupt:
+        logger.info("\nInterrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

We are almost done with the QE testing migration from Jenkins so that most of our downstream CI job are now running on Prow. Also, there is already integration with Konflux to automatic trigger CI when new builds of the OSC (test) catalog happens.  The developers can also trigger jobs either via clusterbot or opening pull request to openshift/release repository. Thus, respite some needed improvements here and there (increase coverage included), triggering Prow jobs is no longer a big issue.

Understanding the result of a job is still a concern because our team still lacks of knowledge on Prow as well as QE's automated tests.

Let's have https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata/1998028866194509824 as an example. That job is marked as "passed" but in reality two tests failed...there are some nuances in our job implementation that explain that behavior, but a first look it seems confusing, huh? One of the tests that failed mention the version of the operator that doesn't match the expect, but what's exactly the build tested? Moreover, what kind of workload (kata, peerpods, coco) is tested? What's the platform? In summary, there are many question that could be only answered by an experienced developer on the Prow logs, workflow, and internals.

This PR introduces a new tool to help on the analysis of Prow jobs, aiming to provide detailed but high-level and use-friendly information as well as an initial assessment (and debug tips) on any fails that occurred.

**- What I did**

The tool was implemented as a slash-command for Claude (`/prowjob-analyze`) where the user passes the URL for the Prow job she/he wants analyzed.

It was created scripts and auxiliary libraries in `scripts/prowjob-analyzer`. These scripts are used to grab Prow log files and parse them, to extract the relevant information for analysis. Notice that they can be executed as stand-alone tools, if one cannot rely on Claude's analysis or be used by a different tool (reuse). Check out `scripts/prowjob-analyzer/README.md` for details about that part of the tool.

Then it was created a custom Claude command in `.claude/commands/prowjob-analyze.md` which in reality is just a prompt. That contains the algorithm and contexts to carry out the analysis. The scripts in `scripts/prowjob-analyzer` are used just for fetching information in a semi-structured way. 

**- How to verify it**

1. Open Claude in the repository's root directory
2. Send the message `/prowjob-analyze <Job URL>` where `<Job URL>` is the URL for the job's results

Alternatively you can use the wrapper script `scripts/prowjob-analyzer/analyze-claude.py` that will evoke Claude under the hoods.

**- For reviewers**

I don't expect you to review commit by commit; try to focus on the end result. I'm leaving the commits because there you can see the processes and decisions @tbuskey and I used to code it. Ah, btw, this tool was almost completely generated by Claude and the scripts were vibe coded.

We tested the scripts by running them against a list of jobs and comparing the output with expected values, all done manually.

**- Example **

Analysis of the job mentioned above:

```
> /prowjob-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-down
stream-candidate-azure-ipi-kata/1998028866194509824 

● I'll analyze this Prow job for you. Let me start by running the main analyzer to get the overall job status and metadata.

● Bash(python3 scripts/prowjob-analyzer/analyze.py --no-wait
      "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containe…)
  ⎿  Error: Exit code 1
     INFO: Parsing Prow job URL...
     INFO: Job: periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata
     INFO: Build ID: 1998028866194509824
     INFO: Fetching prowjob.json...
     INFO: Parsing prowjob data...
     INFO: Extracting metadata...
     INFO: Provider: Azure, OCP: 4.19.20, Workload: kata
     INFO: Fetching test results...
     INFO: Test results found: 2 failures
     … +73 lines (ctrl+o to see all)

● Good! The analyzer ran successfully and identified 2 failing tests. Now let me run the detailed test analysis for these failing tests.

● Bash(python3 scripts/prowjob-analyzer/failed_tests_report.py
      "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-contai…)
  ⎿ # Failed Tests Report                                                                                                                    

    **Job URL**: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-d
    … +454 lines (ctrl+o to expand)


● Analysis Summary

  This Prow job FAILED with 2 test failures out of 37 tests run (35 passed, 18 skipped).

  Job Metadata

  - Provider: Azure
  - OCP Version: 4.19.20
  - Workload Type: kata (traditional Kata Containers)
  - Duration: 1h 57m 50s
  - Catalog: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc@sha256:52623eb

  ---
  Failing Tests Analysis

  1. C00077 - Version Mismatch (Author: tbuskey, Category: versioning)

  Status: ❌ FAILED after 7.6s

  Root Cause: The test expected operator version 1.11.0 (from osc-config ConfigMap), but the installed CSV has version 1.11.1.

  Key Evidence:
  I1208 15:20:42.677448 kata.go:255] Error: expecting 1.11.0 but CSV has 1.11.1

  Configuration:
  - ConfigMap osc-config specifies: "operatorVer":"1.11.0"
  - Installed CSV: sandboxed-containers-operator.v1.11.1

  Why This Failed: The catalog image contains version 1.11.1, but the test configuration expects 1.11.0. This is a test configuration mismatch rather than a functional failure.

  Recommended Action: Update the osc-config ConfigMap to set operatorVer to 1.11.1, or ensure the catalog provides the correct version matching the test configuration.

  ---
  2. C00350 - CPU Hot-Plug Failure (Author: vvoronko, Category: deployment)

  Status: ❌ FAILED after 30.7s

  Root Cause: The test deployed a Kata pod with CPU limits expecting 2 CPUs, but the pod only had 1 CPU allocated.

  Key Evidence:
  fail [kata.go:1633]: Actual CPU count for the pod 1 isn't matching expected 2
  Expected <string>: 1
  to equal <string>: 2

  Timeline:
  1. Pod jwtrslmy-example-00350 was successfully scheduled to node ci-op-2bdb22cl-af9e4-fkc89-worker-eastus3-58tgg
  2. Container started successfully at 15:32:18
  3. Pod was killed at 15:32:24 (6 seconds after starting)
  4. Test verified CPU count and found only 1 CPU instead of expected 2

  Why This Failed: This appears to be a legitimate Kata runtime issue with CPU hot-plug functionality. The pod should have had its CPU limit honored (2 CPUs), but Kata only allocated 1 CPU. This could indicate:
  - Bug in Kata's CPU hot-plug implementation
  - Configuration issue with Azure-specific Kata settings
  - Kata version incompatibility with OCP 4.19.20

  Recommended Action:
  - Check Kata runtime logs and configuration on the worker node
  - Verify if CPU hot-plug is properly enabled in KataConfig
  - Test if this is Azure-specific or affects other providers
  - Check if this is a regression in the current Kata version

  ---
  Additional Context

  Patterns Detected: Network-related issues were flagged by the analyzer, though these specific failures don't appear network-related.

  Artifacts Available:
  - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata/1998028866194509824/artifacts/azure-ipi-kata/openshift-extended-test/artifacts/test-results.yaml
  - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata/1998028866194509824/artifacts/azure-ipi-kata/openshift-extended-test/artifacts/extended.log
  - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-azure-ipi-kata/1998028866194509824/artifacts/azure-ipi-kata/sandboxed-containers-operator-gather-must-gather/artifacts/

  Summary:
  - C00077 is a test configuration issue (version mismatch) - easy fix
  - C00350 is a functional failure in Kata CPU hot-plug - requires investigation
```