### PR TITLE
controllers: Validates kata version aginst the Kata RPM version present in the extension image.

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -415,7 +415,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{
+		RequeueAfter: 10 * time.Minute,
+	}, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) addPeerPodsConfigDaemonSet() error {

--- a/scripts/kata-install/osc-kata-addons-install.sh
+++ b/scripts/kata-install/osc-kata-addons-install.sh
@@ -47,51 +47,31 @@ update_config() {
 #   0 on success
 #######################################
 install_addons() {
-    local addon_image="${ADDON_IMAGE:?}"
-    
-    echo "Installing addon artifacts from: $addon_image"
-    
     local kernel_src="${ADDON_KERNEL_PATH:?}"
+	local kernel_file
+    kernel_file="$(basename "$kernel_src")"
 
-    if [ -z "$kernel_src" ]; then
-        echo "ERROR: ADDON_KERNEL_PATH is mandatory but was not provided." >&2
+    local staged_dir="/host/var/lib/kata/addons"
+    local staged_kernel="${staged_dir}/${kernel_src}"
+
+    if [[ ! -f "$staged_kernel" ]]; then
+        echo "ERROR: Staged kernel not found: $staged_kernel" >&2
         exit 1
     fi
     
-    # Standard installation directory
     local install_dir="/host/etc/kata-containers"
-    local temp_dir="/tmp/kata-addons-$$"
-    local auth_file="/tmp/regauth/auth.json"
-    
-    mkdir -p "$install_dir"
-    mkdir -p "$temp_dir"
-    
-    local kernel_installed=""
-    local kernel_path=""
-    
-    # Extract and install kernel
-	echo "Extracting kernel from: $kernel_src"
-	
-	# Reuse extract_container_image from lib.sh
-	if extract_container_image "$addon_image" "$kernel_src" "$temp_dir" "$auth_file"; then
-		local kernel_file=$(basename "$kernel_src")
-		if [ -f "$temp_dir/$kernel_file" ]; then
-			kernel_installed="$install_dir/$kernel_file"
-			kernel_path="/etc/kata-containers/$kernel_file"
-			cp "$temp_dir/$kernel_file" "$kernel_installed"
-			chmod 644 "$kernel_installed"
-			echo "Kernel installed: $kernel_installed"
+	local kernel_installed="${install_dir}/${kernel_file}"
+    local kernel_path="/etc/kata-containers/${kernel_file}"
 
-			# Print checksum of the installed kernel
-			echo "Kernel image $kernel_file checksum (sha256):"
-			sha256sum "$kernel_installed"
-		fi
-	fi
+	cp "$staged_kernel" "$kernel_installed"
 
+	rm -rf $staged_dir
+
+    echo "Kernel installed: $kernel_installed"
+    echo "Kernel image $kernel_file checksum (sha256):"
+    sha256sum "$kernel_installed"
     
-    # Cleanup
-    rm -rf "$temp_dir"
-    
+	# Update kata configuration
     update_config "$kernel_path"
 
     echo "Addon installation completed"

--- a/scripts/kata-install/osc-kata-install.sh
+++ b/scripts/kata-install/osc-kata-install.sh
@@ -83,6 +83,42 @@ set_status_uninstalled() {
 	label_node "uninstalled"
 }
 
+extract_kata_version_from_rpm() {
+    local rpm="$1"
+    basename "$rpm" | sed -E 's/^kata-containers-([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/'
+}
+
+extract_kata_addon_image() {
+    local addon_image="$1"
+	local addon_stage_dir="/host/var/lib/kata/addons"
+
+	mkdir -p $addon_stage_dir
+
+    extract_container_image \
+        "$addon_image" \
+        "/artifacts" \
+        "$addon_stage_dir" \
+        "/tmp/regauth/auth.json" >/dev/null
+
+
+    if [[ ! -f "$addon_stage_dir/artifacts/version.json" ]]; then
+        echo "ERROR: version.json not found in addon image"
+        exit 1
+    fi
+
+	dnf install -y jq >/dev/null 2>&1
+
+    local kata_version
+	kata_version=$(jq -r '.kata_version' "$addon_stage_dir/artifacts/version.json")
+
+    if [[ -z "$kata_version" || "$kata_version" == "null" ]]; then
+        echo "ERROR: kata_version missing in version.json"
+        exit 1
+    fi
+
+    echo "$kata_version"
+}
+
 install() {
 	# Initial wait: avoid doing anything if a previous staged update is pending
 	wait_for_reboot_clear
@@ -102,6 +138,20 @@ install() {
 		if [[ -z "$rpm_path" ]]; then
 			echo "No RPM found for $package"
 			continue
+		fi
+
+		if [[ "$package" == "kata-containers" && -n "${ADDON_IMAGE:-}" ]]; then
+            rpm_kata_version=$(extract_kata_version_from_rpm "$rpm_path")
+			addon_kata_version=$(extract_kata_addon_image "$ADDON_IMAGE")
+
+			if [[ "$addon_kata_version" != "$rpm_kata_version" ]]; then
+				echo "ERROR: Kata version mismatch between addon image and host RPM"
+				echo "Addon image kata version: $addon_kata_version"
+				echo "Host kata RPM version:    $rpm_kata_version"
+				exit 1
+			fi
+
+			echo "Addon image kata version validated: $addon_kata_version"
 		fi
 
 		# Get available version


### PR DESCRIPTION
The extension image contains the Kata RPM. Extension images vary with the OCP version, which means the Kata version can change across releases. To ensure correctness, we must verify that the Kata version specified in the YAML matches the version bundled in the extension image.

This change adds an explicit Kata version field to the controller YAML and validates it against the Kata RPM version present in the extension image.

- Introduces a kataVersion field in the controller YAML.
- During reconciliation, compares the YAML-defined Kata version with the Kata RPM version found in the extension image.
- Fails reconciliation if the versions do not match
- Relies on the existing ConfigMap reconcile loop (every 10 minutes) to re-check and pick up any updated ConfigMaps automatically.

**Current behavior**

- The OSC DaemonSet always consumes the current extension image provided by the cluster.
- When an OCP upgrade happens, the extension image may change.

If the addon artifact image is not updated and the OSC version remains the same, this can introduce a new Kata RPM version even though:

- The OSC version has not changed
- The addon artifact image was built and tested against a specific Kata version

As a result, when customers upgrade OCP but continue using an older addon artifact image, OSC may silently install a Kata version that:

- Was never validated with the running OSC version
- Does not match the Kata version expected by the addon artifact image

**Upgrade scenario**

- OSC 1.11 is installed and tested with Kata 3.21
- The addon artifact image includes Kata 3.21
- If The cluster is upgraded from OCP 4.20.6 → 4.21.8 and the extension image now contains Kata 3.22 for example, OSC is not upgraded, and the addon artifact image is not updated
- During reconciliation, OSC installs Kata 3.22 from the new extension image
- This creates a version mismatch between the addon artifact image and the tested OSC stack.
Currently, this mismatch happens silently, with no validation or guardrails.

**This PR adds an explicit validation step to prevent unintended Kata version drift:**

- Adds a kataVersion field to the add-on YAML

During reconciliation:

- Extracts the Kata RPM version from the extension image
- Compares it against the YAML-defined kataVersion
- Fails reconciliation if the versions do not match
- Uses the existing ConfigMap reconciliation loop (every 10 minutes) to automatically re-check and apply updates when the ConfigMap is corrected

https://issues.redhat.com/browse/KATA-4557