### PR TITLE
Enable cm-helper to detect bash from $PATH

### DIFF
--- a/scripts/cm-helpers/pp-cm-helper.sh
+++ b/scripts/cm-helpers/pp-cm-helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ENV_FILE=$(mktemp -t pp-cm-env-XXXX.env)
 IS_ARO=false


### PR DESCRIPTION
The hard-coded path doesn't work always. For example on Mac

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
