### PR TITLE
osc-podvm-builder: update RPM lockfile

### DIFF
--- a/config/peerpods/podvm/redhat.repo
+++ b/config/peerpods/podvm/redhat.repo
@@ -9,7170 +9,16 @@
 # a "yum repolist" to refresh available repos
 #
 
-[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-source-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-interconnect-textonly-1-for-middleware-rpms]
-name = Red Hat AMQ Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-extensions-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.17-rpms]
-name = Red Hat Container Development Kit 3.17 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.21-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.11-rpms]
-name = Red Hat Container Development Kit 3.11 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.20-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
-name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.15-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-debug-rpms]
-name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-source-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-rhui-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openliberty-textonly-1-for-middleware-rpms]
-name = Open Liberty Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-debug-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.20-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.21-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhosds-textonly-3-for-middleware-rpms]
-name = Red Hat OpenShift Dev Spaces 3 Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.20-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-extensions-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.5-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhem-0.7-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-source-rpms]
-name = Red Hat Container Development Kit 3.5 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.20-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.21-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jdv-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Virtualization Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-rhui-debug-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.18-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-debug-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-serverless-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Openshift Serverless 1 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Server Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.6-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-rpms]
-name = Red Hat Container Development Kit 3.5 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 6 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.10-rpms]
-name = Red Hat Container Development Kit 3.10 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.21-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.19-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rpms]
-name = Single Sign-On Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 5 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.21-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-source-rpms]
-name = Red Hat Container Development Kit 3.6 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-rhui-source-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[integration-camel-quarkus-textonly-1-for-middleware-rpms]
-name = Red Hat Integration - Camel Extensions for Quarkus
-baseurl = https://cdn.redhat.com/content/dist/middleware/integration-quarkus/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.19-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.21-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jpp-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Portal Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-textonly-1-for-middleware-rpms]
-name = OpenJDK Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.21-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-rpms]
-name = Red Hat Container Development Kit 3.4 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.8-rpms]
-name = Red Hat Container Development Kit 3.8 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.20-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.20-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.6-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.21-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.13-rpms]
-name = Red Hat Container Development Kit 3.13 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jon-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Operations Network Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhbop-textonly-1-for-middleware-rpms]
-name = Red Hat Build of OptaPlanner Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-source-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-serverless-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Openshift Serverless 1 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-rpms]
-name = Fast Datapath for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-extensions-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.20-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-textonly-for-middleware-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap-els/7.4/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-debug-rpms]
-name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-rpms]
-name = Red Hat Container Development Kit 3.6 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhem-0.7-for-rhel-9-$basearch-rpms]
-name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-debug-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhsi-textonly-1-for-middleware-rpms]
-name = Red Hat Service Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quarkus-textonly-1-for-middleware-rpms]
-name = Red Hat build of Quarkus Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-rpms]
-name = Red Hat Container Development Kit 3.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -7185,932 +31,8 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss AMQ Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Discovery 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-source-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-source-rpms]
-name = Red Hat Container Development Kit 2.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhcl-textonly-1-for-middleware-rpms]
-name = Red Hat Connectivity Link Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhcl/1/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.19-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-debug-rpms]
-name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.16-rpms]
-name = Red Hat Container Development Kit 3.16 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhem-0.7-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.21-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-serverless-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Openshift Serverless 1 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-extensions-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.7-rpms]
-name = Red Hat Container Development Kit 3.7 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8123,806 +45,50 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-atomic-7-cdk-2.3-debug-rpms]
-name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.15-rpms]
-name = Red Hat Container Development Kit 3.15 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.9-rpms]
-name = Red Hat Container Development Kit 3.9 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-debug-rpms]
-name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.21-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openshift-builds-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-els-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[wfk-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Framework Kit Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-for-rhel-9-textonly-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-debug-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.14-rpms]
-name = Red Hat Container Development Kit 3.14 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[rodoo-1-for-rhel-9-$basearch-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rhui-rpms]
-name = Single Sign-On Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8935,1016 +101,78 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-baseos-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.20-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/debug
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.21-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhose-textonly-1-for-middleware-rpms]
-name = Red Hat Middleware Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.6-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.2-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-source-rpms]
-name = Red Hat Container Development Kit 3.4 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Grid Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -9957,246 +185,8 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.20-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-extensions-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -10209,344 +199,1086 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhboac-hwt-textonly-1-for-middleware-rpms]
-name = Red Hat Build of Apache Camel HawtIO Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhboac-hwt/1/$basearch/os
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[fsw-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Fuse Service Works Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.21-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/debug
+[rhocp-ironic-4.21-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cert-manager-1.13-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+[ocp-tools-4.19-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-atomic-7-cdk-3.12-rpms]
-name = Red Hat Container Development Kit 3.12 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[lvms-4.16-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cnv-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[soa-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss SOA Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
 enabled = 0
 gpgcheck = 1
-gpgkey = file://
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-atomic-7-cdk-3.3-source-rpms]
-name = Red Hat Container Development Kit 3.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cnv-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-highavailability-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-rt-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-extensions-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Extensions (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/os
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.21-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -10559,8 +1291,932 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.19-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.6-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -10573,8 +2229,4278 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhboac-hwt-textonly-1-for-middleware-rpms]
+name = Red Hat Build of Apache Camel HawtIO Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhboac-hwt/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[integration-camel-quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat Integration - Camel Extensions for Quarkus
+baseurl = https://cdn.redhat.com/content/dist/middleware/integration-quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.21-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhcl-textonly-1-for-middleware-rpms]
+name = Red Hat Connectivity Link Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhcl/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.20-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.20-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.19-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.19 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -10587,8 +6513,4082 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7195434955234925496-key.pem
-sslclientcert = /etc/pki/entitlement/7195434955234925496.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhem-0.7-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Edge Manager 0.7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhem/0.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.20 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.21-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/extensions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.21-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.21 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.21/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoss/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.20-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.20 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-els-textonly-for-middleware-rpms]
+name = JBoss Enterprise Application Platform 7.4 ELS Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap-els/7.4/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-extensions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Extensions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/extensions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.21-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.21/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.20-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.21-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.21 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.21/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openshift-builds/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.18-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.18 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/8577042862075854225-key.pem
+sslclientcert = /etc/pki/entitlement/8577042862075854225.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0

--- a/config/peerpods/podvm/rpms.lock.yaml
+++ b/config/peerpods/podvm/rpms.lock.yaml
@@ -571,13 +571,13 @@ arches:
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/podman-5.6.0-9.el9_7.s390x.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/p/podman-5.6.0-11.el9_7.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
-    size: 15602600
-    checksum: sha256:219290b6f04c81d71324b16be1b2e907814569c66581099ac7138adcf22c91d4
+    size: 15601414
+    checksum: sha256:60a7d53db99f7968c612af1b767f539ab1744aa822b2c1a77d39a6d2dac82fb2
     name: podman
-    evr: 6:5.6.0-9.el9_7
-    sourcerpm: podman-5.6.0-9.el9_7.src.rpm
+    evr: 6:5.6.0-11.el9_7
+    sourcerpm: podman-5.6.0-11.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/os/Packages/s/skopeo-1.20.0-2.el9_7.s390x.rpm
     repoid: ubi-9-for-s390x-appstream-rpms
     size: 8099399
@@ -1083,12 +1083,12 @@ arches:
     checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
     name: perl-podlators
     evr: 1:4.14-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/podman-5.6.0-9.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/p/podman-5.6.0-11.el9_7.src.rpm
     repoid: ubi-9-for-s390x-appstream-source-rpms
-    size: 23009670
-    checksum: sha256:3394760ff7c7e882200fffc2e3422477f5a8ebc36c4dab2a8ef9c6b1f2887471
+    size: 23013197
+    checksum: sha256:d0b1c777f5a703c072d5d973d858955a8cdb259946250e5cf2ffd2dc15470335
     name: podman
-    evr: 6:5.6.0-9.el9_7
+    evr: 6:5.6.0-11.el9_7
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/appstream/source/SRPMS/Packages/s/skopeo-1.20.0-2.el9_7.src.rpm
     repoid: ubi-9-for-s390x-appstream-source-rpms
     size: 10334884
@@ -1827,13 +1827,13 @@ arches:
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/podman-5.6.0-9.el9_7.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/podman-5.6.0-11.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 16796680
-    checksum: sha256:d5ceaec0f70ede851be7a829b85282c3f7a6ebf5a45dfdc76d2623d0ff392d95
+    size: 16795730
+    checksum: sha256:a709f26a5fba7c21feef808c5a5688fdd4f88efdd941f5af1822d79d73ff856a
     name: podman
-    evr: 6:5.6.0-9.el9_7
-    sourcerpm: podman-5.6.0-9.el9_7.src.rpm
+    evr: 6:5.6.0-11.el9_7
+    sourcerpm: podman-5.6.0-11.el9_7.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/skopeo-1.20.0-2.el9_7.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8597530
@@ -2346,12 +2346,12 @@ arches:
     checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
     name: perl-podlators
     evr: 1:4.14-460.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/podman-5.6.0-9.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/p/podman-5.6.0-11.el9_7.src.rpm
     repoid: ubi-9-for-x86_64-appstream-source-rpms
-    size: 23009670
-    checksum: sha256:3394760ff7c7e882200fffc2e3422477f5a8ebc36c4dab2a8ef9c6b1f2887471
+    size: 23013197
+    checksum: sha256:d0b1c777f5a703c072d5d973d858955a8cdb259946250e5cf2ffd2dc15470335
     name: podman
-    evr: 6:5.6.0-9.el9_7
+    evr: 6:5.6.0-11.el9_7
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/s/skopeo-1.20.0-2.el9_7.src.rpm
     repoid: ubi-9-for-x86_64-appstream-source-rpms
     size: 10334884


### PR DESCRIPTION
This is bringing podman v5.6.0-11.el9_7.
See https://errata.engineering.redhat.com/advisory/157250

Fixes: [KATA-4542](https://issues.redhat.com//browse/KATA-4542)