### PR TITLE
tests/osc-test-fbc-integration: kata RPM to 3.21.0-5

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -59,7 +59,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.21.0-5.rhaos4.19.el9"
       matrix:
         params:
           - name: PROWJOB_NAME


### PR DESCRIPTION
The release candidate of kata-containers RPM for 1.11.2 is 3.21.0-5, let's use that version on the tests.