### PR TITLE
konflux: update the tekton files for building 1.11 from new branch

### DIFF
--- a/.tekton/osc-must-gather-pull-request.yaml
+++ b/.tekton/osc-must-gather-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       ( "must-gather/***".pathChanged() ||
         ".tekton/osc-must-gather-pull-request.yaml".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-must-gather
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-must-gather-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-must-gather-on-pull-request
+  name: osc-must-gather-v1-11-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -44,7 +44,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-must-gather
+    serviceAccountName: build-pipeline-osc-must-gather-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-must-gather-push.yaml
+++ b/.tekton/osc-must-gather-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       ( "must-gather/***".pathChanged() ||
         ".tekton/osc-must-gather-push.yaml".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-must-gather
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-must-gather-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-must-gather-on-push
+  name: osc-must-gather-v1-11-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-11:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -41,7 +41,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-must-gather
+    serviceAccountName: build-pipeline-osc-must-gather-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "devel" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.11" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator-bundle
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-operator-bundle-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-operator-bundle-on-pull-request
+  name: osc-operator-bundle-v1-11-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -611,7 +611,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator-bundle
+    serviceAccountName: build-pipeline-osc-operator-bundle-v1-11
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.11" && files.all.exists(path, path.matches('bundle*|.tekton/*bundle*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator-bundle
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-operator-bundle-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-operator-bundle-on-push
+  name: osc-operator-bundle-v1-11-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-11:{{revision}}
   - name: dockerfile
     value: bundle.Dockerfile
   pipelineSpec:
@@ -609,7 +609,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator-bundle
+    serviceAccountName: build-pipeline-osc-operator-bundle-v1-11
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -10,17 +10,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-operator-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-operator-on-pull-request
+  name: osc-operator-v1-11-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator
+    serviceAccountName: build-pipeline-osc-operator-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       files.all.exists(path, !path.matches('bundle/.*|.tekton/.*bundle.*yaml$|config/manager/.*')) &&
       files.all.exists(path, !path.matches('must-gather/.*|.tekton/.*must-gather.*yaml$')) &&
       files.all.exists(path, !path.matches('config/peerpods/podvm/.*|.tekton/.*podvm-builder.*yaml$')) &&
       files.all.exists(path, !path.matches('.tekton/.*fbc-.*|fbc/.*'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-operator
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-operator-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-operator-on-push
+  name: osc-operator-v1-11-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-11:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-operator
+    serviceAccountName: build-pipeline-osc-operator-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-builder-pull-request.yaml
+++ b/.tekton/osc-podvm-builder-pull-request.yaml
@@ -9,17 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       ( "config/peerpods/podvm/***".pathChanged() ||
         ".tekton/osc-podvm-builder-pull-request.yaml".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-builder
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-podvm-builder-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-builder-on-pull-request
+  name: osc-podvm-builder-v1-11-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -46,7 +46,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-builder
+    serviceAccountName: build-pipeline-osc-podvm-builder-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-builder-push.yaml
+++ b/.tekton/osc-podvm-builder-push.yaml
@@ -8,17 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       ( "config/peerpods/podvm/***".pathChanged() ||
         ".tekton/osc-podvm-builder-push.yaml".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-builder
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-11
+    appstudio.openshift.io/component: osc-podvm-builder-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-builder-on-push
+  name: osc-podvm-builder-v1-11-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-11:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-builder
+    serviceAccountName: build-pipeline-osc-podvm-builder-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-test-fbc-pull-request.yaml
+++ b/.tekton/osc-test-fbc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "devel" &&
+      target_branch == "osc-release-v1.11" &&
       ( "fbc/test-fbc/***".pathChanged() ||
         "fbc/render.sh".pathChanged() ||
         ".tekton/osc-test-fbc-pull-request.yaml".pathChanged() ||
@@ -17,10 +17,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: osc-test-catalog
-    appstudio.openshift.io/component: osc-test-fbc
+    appstudio.openshift.io/application: osc-test-catalog-v1-11
+    appstudio.openshift.io/component: osc-test-fbc-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-test-fbc-on-pull-request
+  name: osc-test-fbc-v1-11-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc-v1-11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -411,7 +411,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-test-fbc
+    serviceAccountName: build-pipeline-osc-test-fbc-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.11" &&
       ( "fbc/test-fbc/***".pathChanged() ||
         "fbc/render.sh".pathChanged() ||
         ".tekton/osc-test-fbc-push.yaml".pathChanged() ||
@@ -15,10 +15,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: osc-test-catalog
-    appstudio.openshift.io/component: osc-test-fbc
+    appstudio.openshift.io/application: osc-test-catalog-v1-11
+    appstudio.openshift.io/component: osc-test-fbc-v1-11
     pipelines.appstudio.openshift.io/type: build
-  name: osc-test-fbc-on-push
+  name: osc-test-fbc-v1-11-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc-v1-11:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -409,7 +409,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-test-fbc
+    serviceAccountName: build-pipeline-osc-test-fbc-v1-11
   workspaces:
   - name: git-auth
     secret:

--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -33,8 +33,8 @@ spec:
             WARNINGS=0
 
             dnf -y install jq git make go
-            srcURL=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.url' <<< "${SNAPSHOT}")
-            srcREV=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.revision' <<< "${SNAPSHOT}")
+            srcURL=$(jq -r '.components[] | select(.name=="osc-operator-v1-11") | .source.git.url' <<< "${SNAPSHOT}")
+            srcREV=$(jq -r '.components[] | select(.name=="osc-operator-v1-11") | .source.git.revision' <<< "${SNAPSHOT}")
 
             git clone ${srcURL} sources
             cd sources


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.
