### PR TITLE
Upgrade golangci-lint from v1 to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+version: "2"
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.17.2 # this is overriden by our Dockerfile for container builds
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.0.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -251,7 +251,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
## Summary
- Update golangci-lint from v1.59.1 to v2.0.2
- Update module path to use `/v2/` prefix
- Add `.golangci.yml` with v2 version declaration

## Changes Made
- **Makefile**: Updated version variable and module path
- **.golangci.yml**: Created with v2 version declaration

## Test plan
- [ ] CI linting passes with golangci-lint v2
- [ ] No new linting errors introduced

Tracking: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/49