### PR TITLE
fix: Removing backup kata-se/config file

### DIFF
--- a/scripts/kata-install/osc-kata-addons-install.sh
+++ b/scripts/kata-install/osc-kata-addons-install.sh
@@ -28,11 +28,6 @@ update_config() {
         return 1
     fi
     
-    echo "Updating configuration: $config_file"
-    
-    # Backup config
-    chroot /host cp "$config_file" "${config_file}.backup-$(date +%s)"
-    
     # Update kernel if provided
 	chroot /host sed -i "s|^\(kernel[[:space:]]*=[[:space:]]*\)\".*\"|\1\"$kernel_path\"|g" "$config_file"
 	echo "  Updated kernel: $kernel_path"
@@ -110,11 +105,6 @@ uninstall_addons() {
     local kernel_src="${ADDON_KERNEL_PATH:?}"
     # Remove installed artifacts
     chroot /host rm -f "$install_dir/$(basename "$kernel_src")"
-     
-    # Restore config backup
-    local config_file="/etc/kata-containers/kata-se/configuration.toml"
-    local backup=$(ls -t "${config_file}.backup-"* 2>/dev/null | head -1)
-    [ -n "$backup" ] && [ -f "$backup" ] && chroot /host cp "$backup" "$config_file"
     
     echo "Addon artifacts uninstalled"
     return 0


### PR DESCRIPTION
For clean rpm uninstall to happen. i.e, removal of kata-se folder while uninstalling
Fixes: [KATA-4605](https://issues.redhat.com/browse/KATA-4605)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

``` Once the cleanup job `osc-rpm-uninstall-xxxx` is triggered, we see that in worker node `kata-se` directory is not getting removed automatically ```

**- What I did**

``` In the demonset flow there is a block of code which do the backup of `kata-se/configuration.toml` as `kata-se/configuration.toml.backup-1767604472` because of this while unistalling this directory is not getting cleanup. Hence I removed backing up of `kata-se/configuration.toml` since `kata-se/configuration.toml` can be directly used just like other runtimeclass configuration.toml.```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
