### PR TITLE
tests/osc-test-fbc-integration: optimize the execution of prowjobs

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -14,6 +14,13 @@ spec:
       name: SNAPSHOT
       default: '{"components": [{"name":"osc-test-fbc", "containerImage": "quay.io/redhat-user-workloads/ose-osc-tenant/osc-test-fbc:latest"}]}'
       type: string
+    - name: RUN_PROWJOBS
+      type: string
+      description: >-
+        Which prowjobs to run. Options: "sanity" (default, runs only sanity checks),
+        "all" (runs all prowjobs), or specific job names like "ocp419 ocp420"
+        (runs only those OCP version jobs, space-separated). Available job names: ocp418, ocp419, ocp420
+      default: "sanity"
   tasks:
     - name: get-catalog-image
       params:
@@ -39,13 +46,91 @@ spec:
               catalogImage=$(jq -r '.components[] | select(.name=="osc-test-fbc") | .containerImage' <<< "${SNAPSHOT}")
               echo "Catalog image: ${catalogImage}"
               echo -n "${catalogImage}" > $(results.CATALOG_IMAGE.path)
+    - name: determine-prowjobs
+      params:
+        - name: RUN_PROWJOBS
+          value: $(params.RUN_PROWJOBS)
+      taskSpec:
+        params:
+          - name: RUN_PROWJOBS
+            type: string
+        results:
+          - name: run_sanity
+            description: "Whether to run sanity check prowjobs"
+          - name: run_ocp418
+            description: "Whether to run OCP 4.18 prowjobs"
+          - name: run_ocp419
+            description: "Whether to run OCP 4.19 prowjobs"
+          - name: run_ocp420
+            description: "Whether to run OCP 4.20 prowjobs"
+        steps:
+          - name: determine
+            image: registry.redhat.io/ubi9/ubi-minimal:latest
+            env:
+              - name: RUN_PROWJOBS
+                value: $(params.RUN_PROWJOBS)
+            script: |
+              #!/bin/bash
+              set -e
+
+              # Supported OCP versions
+              OCP_VERSIONS="418 419 420"
+
+              # Function to check if a value is in the space-separated list
+              contains() {
+                local search="$1"
+                local list="$2"
+                for item in $list; do
+                  if [ "$item" = "$search" ]; then
+                    return 0
+                  fi
+                done
+                return 1
+              }
+
+              # Determine which jobs should run
+              if contains "all" "${RUN_PROWJOBS}"; then
+                # Run all jobs
+                echo -n "true" > $(results.run_sanity.path)
+                for version in ${OCP_VERSIONS}; do
+                  echo -n "true" > /tekton/results/run_ocp${version}
+                done
+              else
+                # Check sanity
+                if contains "sanity" "${RUN_PROWJOBS}"; then
+                  echo -n "true" > $(results.run_sanity.path)
+                else
+                  echo -n "false" > $(results.run_sanity.path)
+                fi
+
+                # Check each version individually
+                for version in ${OCP_VERSIONS}; do
+                  if contains "ocp${version}" "${RUN_PROWJOBS}"; then
+                    echo -n "true" > /tekton/results/run_ocp${version}
+                  else
+                    echo -n "false" > /tekton/results/run_ocp${version}
+                  fi
+                done
+              fi
+
+              # Print results for debugging
+              echo "RUN_PROWJOBS: ${RUN_PROWJOBS}"
+              echo "run_sanity: $$(cat $(results.run_sanity.path))"
+              for version in ${OCP_VERSIONS}; do
+                echo "run_ocp${version}: $$(cat /tekton/results/run_ocp${version})"
+              done
     # Run a sanity check job first.
     # Choose the kata workload test and newest supported OCP version.
     - name: prowjob-sanity
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
+      when:
+        - input: "$(tasks.determine-prowjobs.results.run_sanity)"
+          operator: in
+          values: ["true"]
       runAfter:
         - get-catalog-image
+        - determine-prowjobs
       taskRef:
         resolver: git
         params:
@@ -71,6 +156,10 @@ spec:
     - name: prowjob-ocp418
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
+      when:
+        - input: "$(tasks.determine-prowjobs.results.run_ocp418)"
+          operator: in
+          values: ["true"]
       runAfter:
         - prowjob-ocp420
         - prowjob-ocp419
@@ -105,6 +194,10 @@ spec:
     - name: prowjob-ocp419
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
+      when:
+        - input: "$(tasks.determine-prowjobs.results.run_ocp419)"
+          operator: in
+          values: ["true"]
       runAfter:
         - prowjob-sanity
       taskRef:
@@ -137,6 +230,10 @@ spec:
     - name: prowjob-ocp420
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
+      when:
+        - input: "$(tasks.determine-prowjobs.results.run_ocp420)"
+          operator: in
+          values: ["true"]
       runAfter:
         - prowjob-sanity
       taskRef:

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -72,7 +72,8 @@ spec:
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
       runAfter:
-        - prowjob-sanity
+        - prowjob-ocp420
+        - prowjob-ocp419
       taskRef:
         resolver: git
         params:

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -39,11 +39,40 @@ spec:
               catalogImage=$(jq -r '.components[] | select(.name=="osc-test-fbc") | .containerImage' <<< "${SNAPSHOT}")
               echo "Catalog image: ${catalogImage}"
               echo -n "${catalogImage}" > $(results.CATALOG_IMAGE.path)
-    - name: prowjob-ocp418
+    # Run a sanity check job first.
+    # Choose the kata workload test and newest supported OCP version.
+    - name: prowjob-sanity
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
       runAfter:
         - get-catalog-image
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/openshift/konflux-tasks
+        - name: revision
+          value: 4826f365057d22d0189fa0db00d953c151f90c77
+        - name: pathInRepo
+          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: VARIANT
+          value: downstream-candidate420
+        - name: ENVS
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.12.0,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.20.el9"
+      matrix:
+        params:
+          - name: PROWJOB_NAME
+            value:
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-kata
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-aws-ipi-peerpods
+    - name: prowjob-ocp418
+      displayName: "Running prow job $(params.PROWJOB_NAME)"
+      timeout: "4h"
+      runAfter:
+        - prowjob-sanity
       taskRef:
         resolver: git
         params:
@@ -76,7 +105,7 @@ spec:
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
       runAfter:
-        - get-catalog-image
+        - prowjob-sanity
       taskRef:
         resolver: git
         params:
@@ -108,7 +137,7 @@ spec:
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"
       runAfter:
-        - get-catalog-image
+        - prowjob-sanity
       taskRef:
         resolver: git
         params:
@@ -133,6 +162,4 @@ spec:
         params:
           - name: PROWJOB_NAME
             value:
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-kata
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-peerpods
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-aws-ipi-peerpods


### PR DESCRIPTION
Currently we are running all the prowjobs in a single phase.

In order to save resources as well as avoid the azure quota limit problem, I refactor the pipeline to run the jobs in phases and in groups.