### PR TITLE
daemonset deployment: fix baremetal installation

### DIFF
--- a/scripts/kata-install/osc-kata-install.sh
+++ b/scripts/kata-install/osc-kata-install.sh
@@ -194,7 +194,6 @@ get_cloud_provider() {
 	if ! provider="$(kubectl get configmap/peer-pods-cm \
 		-n openshift-sandboxed-containers-operator \
 		-o jsonpath='{.data.CLOUD_PROVIDER}')"; then
-		error "get_cloud_provider: kubectl failed to query peer-pods-cm"
 		return
 	fi
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

The newly introduced rpm-extensions function, added to resolve installation issues on IBM Cloud, inadvertently broke installation on baremetal. The get_cloud_provider function expected the peer-pods ConfigMap, which is not used on baremetal.

**- What I did**

This update changes the behavior so that get_cloud_provider returns an empty value instead of an error when the peer-pods ConfigMap is not present, restoring correct behavior for baremetal deployments.

**- How to verify it**

Build a new version of the daemonset image and use that on baremetal with DaemonSet mode. 

**- Description for the changelog**
daemonset deployment: fix baremetal installation
