### PR TITLE
osc-podvm-builder: fix cpe string for 1.11

### DIFF
--- a/config/peerpods/podvm/Dockerfile.podvm-builder
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder
@@ -53,7 +53,7 @@ ADD podvm-builder.sh /podvm-builder.sh
 
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-podvm-builder-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.11::el9" \
 version="1.11" \
 com.redhat.component="osc-podvm-builder-container" \
 summary="Container image containing artefacts that is required for creating Pod VM images" \


### PR DESCRIPTION
We missed the bump in the cpe string for 1.11
