### PR TITLE
tests/osc-test-fbc-integration: fix VARIANT parameter

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
         - name: VARIANT
-          value: downstream-candidate
+          value: downstream-candidate417
         - name: ENVS
           value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.21.0-5.rhaos4.17.el9"
       matrix:
@@ -86,7 +86,7 @@ spec:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
         - name: VARIANT
-          value: downstream-candidate
+          value: downstream-candidate418
         - name: ENVS
           value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.21.0-5.rhaos4.18.el9"
       matrix:
@@ -115,7 +115,7 @@ spec:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
         - name: VARIANT
-          value: downstream-candidate
+          value: downstream-candidate419
         - name: ENVS
           value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.21.0-5.rhaos4.19.el9"
       matrix:
@@ -143,7 +143,7 @@ spec:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
         - name: VARIANT
-          value: downstream-candidate
+          value: downstream-candidate420
         - name: ENVS
           value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.21.0-5.rhaos4.20.el9"
       matrix:


### PR DESCRIPTION
The VARIANT parameter should match the Prow job's name, otherwise the trigger is going to use downstream-candidate variant that is always OCP 4.19. In other words, this ensure that it uses the correct version of OCP in each job triggered.
