### PR TITLE
mintmaker: change schedule config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "schedule": ["* * * * 0,6"],
     "extends": [
         "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
     ],


### PR DESCRIPTION
We don't need to have Mintmaker run every 4 hours.
This commit changes the schedule to run it only once per week, on weekends.

See:
- https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#scheduling
- https://docs.renovatebot.com/key-concepts/scheduling/
