### PR TITLE
changelog.sh: simplify the process, trying to get some logs in more situations

### DIFF
--- a/fbc/test-fbc/changelog.sh
+++ b/fbc/test-fbc/changelog.sh
@@ -18,7 +18,7 @@
 # be included in the built image.
 #
 
-#set -x
+set -x
 
 # Takes an image reference with digest, and looks at the quay.io repository
 # for all the tags that point to the same image digest.
@@ -107,24 +107,10 @@ else
     NEW_COMMIT=HEAD
 fi
 
-# Make sure OLD_COMMIT and NEW_COMMIT reference changes to catalog-template.yaml
-# Find the first and last commit that references it in the range OLD_COMMIT..NEW_COMMIT
-# NOTE: we use ~1 to include the OLD_COMMIT itself in the search
-OLD_COMMIT=$(git rev-list "${OLD_COMMIT}~1..${NEW_COMMIT}" -- catalog-template.yaml | tail -n1)
-NEW_COMMIT=$(git rev-list "${OLD_COMMIT}~1..${NEW_COMMIT}" -- catalog-template.yaml | head -n1)
+# Generate the list of commits that changed the bundle manifests between the 2 commits
+COMMIT_LIST=$(git log --oneline "${OLD_COMMIT}..${NEW_COMMIT}" ../../bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml | awk '{print $1}')
 
-# Get the bundle references for old and new commits
-OLD_BUNDLE=$(git show "${OLD_COMMIT}" catalog-template.yaml | grep -E '^\+  - image:'| awk '{print $NF}')
-NEW_BUNDLE=$(git show "${NEW_COMMIT}" catalog-template.yaml | grep -E '^\+  - image:'| awk '{print $NF}')
-
-# Retrieve the commit hashes for old and new bundles
-OLD_BUNDLE_COMMIT=$(get_commit_for_image $OLD_BUNDLE)
-NEW_BUNDLE_COMMIT=$(get_commit_for_image $NEW_BUNDLE)
-
-# Generate the list of commits between the two bundle
-COMMIT_LIST=$(git log --oneline "${OLD_BUNDLE_COMMIT}..${NEW_BUNDLE_COMMIT}" ../../bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml | awk '{print $1}')
-
-echo "Generating changelog between bundle commits $OLD_BUNDLE_COMMIT and $NEW_BUNDLE_COMMIT" | tee CHANGELOG
+echo "Generating changelog between commits $OLD_COMMIT and $NEW_COMMIT" | tee CHANGELOG
 for COMMIT in $COMMIT_LIST; do
     # extract old and new image references, and get their commit hashes
     # Ignore lines with OSC_VERSION: those are just version string updates
@@ -166,6 +152,7 @@ for COMMIT in $COMMIT_LIST; do
     REPO=$(get_repo_for_image $OLD_IMAGE)
     echo "Looking at commits from the repo $REPO" | tee -a CHANGELOG
     echo "between $OLD_IMAGE_COMMIT and $NEW_IMAGE_COMMIT" | tee -a CHANGELOG
+    echo "-----" | tee -a CHANGELOG
 
     PATH_PREFIX=""
     if [ "$REPO" != "https://github.com/openshift/sandboxed-containers-operator" ]; then
@@ -186,5 +173,6 @@ for COMMIT in $COMMIT_LIST; do
         popd
         rm -rf $(basename $REPO)
     fi
+    echo "-----" | tee -a CHANGELOG
     echo "" | tee -a CHANGELOG
 done


### PR DESCRIPTION
Trying to filter out changes that did not impact the bundle proved counter productive: we filtered too much, to the point of getting nothing. Typically: if we get a catalog from a change in the CI test script, this will generate no CHANGELOG, because one of the boundaries of our commit list does not impact the bundle.

This commit removes that filter, looking for changes to the CSV file, without looking for bundle image's commits first.
Since both FBC and bundle are in the same repo, the result *should* be similar, and we will avoid issues. It simplifies the process too, but we will need to monitor the resulting CHANGELOG, to make sure we don't get too many/repetitive entries.
