### PR TITLE
Add --csv output to prowjob analyzer script

### DIFF
--- a/scripts/prowjob-analyzer/analyze.py
+++ b/scripts/prowjob-analyzer/analyze.py
@@ -28,7 +28,7 @@ from lib.parser import (
 )
 from lib.metadata_extractor import extract_metadata
 from lib.failure_analyzer import analyze_failure
-from lib.report_generator import generate_human_report, generate_json_report
+from lib.report_generator import generate_human_report, generate_json_report, generate_csv_report
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -138,6 +138,9 @@ Examples:
 
   %(prog)s --json <URL> > report.json
 
+  %(prog)s --csv <URL> >> jobs.csv
+  %(prog)s --csv --no-header <URL>
+
   %(prog)s --verbose --no-wait <URL>
         '''
     )
@@ -151,6 +154,18 @@ Examples:
         '--json',
         action='store_true',
         help='Output machine-readable JSON format'
+    )
+
+    parser.add_argument(
+        '--csv',
+        action='store_true',
+        help='Output CSV format (one row: start_time, catalog_full_tag, catalog_build_date, provider, ocp_version, prowjob url, workload_type, kata_rpm_version, status, trigger, root_cause)'
+    )
+
+    parser.add_argument(
+        '--no-header',
+        action='store_true',
+        help='Omit CSV header row (only applies with --csv)'
     )
 
     parser.add_argument(
@@ -199,6 +214,17 @@ Examples:
             results['failure_analysis'],
             results['base_url']
         )
+    elif args.csv:
+        logger.info("Generating CSV report...")
+        report = generate_csv_report(
+            results['prowjob_data'],
+            results['metadata'],
+            results['status'],
+            results['test_results'],
+            results['failure_analysis'],
+            results['base_url'],
+            header=not args.no_header,
+        )
     else:
         logger.info("Generating human-readable report...")
         report = generate_human_report(
@@ -211,7 +237,8 @@ Examples:
         )
 
     # Output report
-    print("\n" + "="*80 + "\n")
+    if not args.csv:
+        print("\n" + "="*80 + "\n")
     print(report)
 
     # Exit code based on job status

--- a/scripts/prowjob-analyzer/analyze.py
+++ b/scripts/prowjob-analyzer/analyze.py
@@ -28,7 +28,12 @@ from lib.parser import (
 )
 from lib.metadata_extractor import extract_metadata
 from lib.failure_analyzer import analyze_failure
-from lib.report_generator import generate_human_report, generate_json_report, generate_csv_report
+from lib.report_generator import (
+    build_report_data,
+    generate_human_report,
+    generate_json_report,
+    generate_csv_report,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -159,7 +164,7 @@ Examples:
     parser.add_argument(
         '--csv',
         action='store_true',
-        help='Output CSV format (one row: start_time, catalog_full_tag, catalog_build_date, provider, ocp_version, prowjob url, workload_type, kata_rpm_version, status, trigger, root_cause)'
+        help='Output CSV format (one row: trigger, start_time, catalog_full_tag, catalog_build_date, provider, ocp_version, prowjob url, workload_type, kata_rpm_version, status, failed_steps, primary_pattern, Confidence, root_cause)'
     )
 
     parser.add_argument(
@@ -203,38 +208,25 @@ Examples:
         logger.error("Analysis failed")
         sys.exit(2)
 
-    # Generate report
+    # Build canonical report data once (single source of truth; JSON has everything)
+    report_data = build_report_data(
+        results['prowjob_data'],
+        results['metadata'],
+        results['status'],
+        results['test_results'],
+        results['failure_analysis'],
+        results['base_url'],
+    )
+
     if args.json:
         logger.info("Generating JSON report...")
-        report = generate_json_report(
-            results['prowjob_data'],
-            results['metadata'],
-            results['status'],
-            results['test_results'],
-            results['failure_analysis'],
-            results['base_url']
-        )
+        report = generate_json_report(report_data)
     elif args.csv:
         logger.info("Generating CSV report...")
-        report = generate_csv_report(
-            results['prowjob_data'],
-            results['metadata'],
-            results['status'],
-            results['test_results'],
-            results['failure_analysis'],
-            results['base_url'],
-            header=not args.no_header,
-        )
+        report = generate_csv_report(report_data, header=not args.no_header)
     else:
         logger.info("Generating human-readable report...")
-        report = generate_human_report(
-            results['prowjob_data'],
-            results['metadata'],
-            results['status'],
-            results['test_results'],
-            results['failure_analysis'],
-            results['base_url']
-        )
+        report = generate_human_report(report_data)
 
     # Output report
     if not args.csv:

--- a/scripts/prowjob-analyzer/lib/metadata_extractor.py
+++ b/scripts/prowjob-analyzer/lib/metadata_extractor.py
@@ -7,7 +7,11 @@ Extracts job metadata from prowjob.json and related artifacts.
 import re
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Dict, Optional
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
 from .fetcher import fetch_artifact, extract_variant_from_job_name
 
 logger = logging.getLogger(__name__)
@@ -147,6 +151,75 @@ def extract_ocp_version(prowjob_data: Dict, base_url: str = None) -> str:
     return 'unknown'
 
 
+def fetch_build_date_from_quay(catalog_image: str) -> Optional[str]:
+    """
+    Fetch image build date from Quay.io API for digest references (@sha256:...).
+
+    Uses the same approach as record-metadata: query
+    https://quay.io/api/v1/repository/{namespace}/{repository}/tag/
+    and find the tag whose manifest_digest matches, then return last_modified
+    formatted as '%Y-%m-%d %H:%M:%S UTC'.
+
+    Args:
+        catalog_image: Full image string (e.g. quay.io/openshift/osc-test-fbc@sha256:abc123...)
+
+    Returns:
+        Build date string in UTC, or None if not found or on error
+    """
+    if not catalog_image or '@sha256:' not in catalog_image:
+        return None
+
+    try:
+        # Parse quay.io/namespace/repo@sha256:hex
+        if not catalog_image.startswith('quay.io/'):
+            return None
+        rest = catalog_image[8:]  # after 'quay.io/'
+        if '@' not in rest:
+            return None
+        image_path, digest_part = rest.split('@', 1)
+        if not digest_part.startswith('sha256:'):
+            return None
+        manifest_digest = digest_part  # keep full "sha256:hex"
+
+        # Paginate through tag list (same as record-metadata script)
+        for page in range(1, 6):
+            url = (
+                f"https://quay.io/api/v1/repository/{image_path}/tag/"
+                f"?limit=100&page={page}"
+            )
+            req = Request(url, headers={'Accept': 'application/json'})
+            with urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read().decode('utf-8'))
+
+            tags = data.get('tags') or data.get('tag') or []
+            if isinstance(tags, dict):
+                tags = list(tags.values())
+
+            for tag_obj in tags:
+                if tag_obj.get('manifest_digest') == manifest_digest:
+                    raw = tag_obj.get('last_modified')
+                    if not raw:
+                        return None
+                    # Parse "Mon, 19 Jan 2026 13:19:23 -0000" -> UTC string
+                    try:
+                        dt = datetime.strptime(
+                            raw.strip(),
+                            '%a, %d %b %Y %H:%M:%S %z'
+                        )
+                        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+                    except ValueError:
+                        logger.debug(f"Could not parse last_modified: {raw!r}")
+                        return None
+
+            if not data.get('has_additional', True):
+                break
+
+        return None
+    except (HTTPError, URLError, json.JSONDecodeError, OSError) as e:
+        logger.debug(f"Quay API lookup for build date failed: {e}")
+        return None
+
+
 def parse_catalog_tag(catalog_image: str) -> Dict:
     """
     Parse catalog image tag to extract version and timestamp.
@@ -165,8 +238,6 @@ def parse_catalog_tag(catalog_image: str) -> Dict:
     Returns:
         Dictionary with parsed catalog information
     """
-    from datetime import datetime, timezone
-
     catalog_info = {
         'full_tag': '',
         'base_version': '',
@@ -190,7 +261,12 @@ def parse_catalog_tag(catalog_image: str) -> Dict:
         else:
             catalog_info['base_version'] = tag
 
-        catalog_info['build_date'] = 'unknown'
+        # Try Quay API for build date when using sha256 digest (same as record-metadata)
+        if '@sha256:' in catalog_image:
+            quay_build_date = fetch_build_date_from_quay(catalog_image)
+            catalog_info['build_date'] = quay_build_date if quay_build_date else 'unknown'
+        else:
+            catalog_info['build_date'] = 'unknown'
         return catalog_info
 
     # Check if using tag format (with :)

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -1,9 +1,11 @@
 """
 Report Generator Module
 
-Generates human-readable markdown and machine-parsable JSON reports.
+Generates human-readable markdown, machine-parsable JSON, and CSV reports.
 """
 
+import csv
+import io
 import json
 import logging
 from typing import Dict, List, Optional
@@ -395,3 +397,81 @@ def generate_json_report(
         report['artifacts']['must_gather'] = get_artifact_url(base_url, f'artifacts/{variant}/sandboxed-containers-operator-gather-must-gather/artifacts/')
 
     return json.dumps(report, indent=2)
+
+
+def _get_root_cause_for_csv(status: str, failure_analysis: Optional[Dict]) -> str:
+    """Get root cause string for CSV: likely_cause if determined, else 'unknown' (or '' for success)."""
+    if status == 'success':
+        return ''
+    if not failure_analysis:
+        return 'unknown'
+    root_cause = failure_analysis.get('root_cause') or {}
+    likely = root_cause.get('likely_cause', '').strip()
+    return likely if likely else 'unknown'
+
+
+def generate_csv_report(
+    prowjob_data: Dict,
+    metadata: Dict,
+    status: str,
+    test_results: Optional[Dict],
+    failure_analysis: Optional[Dict],
+    base_url: str,
+    header: bool = True,
+) -> str:
+    """
+    Generate a single-row CSV report.
+
+    Column order: start_time, catalog_full_tag, catalog_build_date, provider,
+    ocp_version, prowjob url, workload_type, kata_rpm_version, prowjob status,
+    trigger, root_cause.
+
+    Args:
+        prowjob_data: Parsed prowjob data
+        metadata: Extracted metadata
+        status: Overall job status
+        test_results: Test results (if available)
+        failure_analysis: Failure analysis (if failed)
+        base_url: Base URL of Prow job
+        header: If True, include a header row with column names
+
+    Returns:
+        CSV formatted string (one data row, optionally preceded by header)
+    """
+    build_date = metadata.get('build_date', '') or 'unknown'
+    if build_date == 'invalid-timestamp':
+        build_date = 'unknown'
+
+    prowjob_status = status.upper() if status else ''
+    row = [
+        prowjob_data.get('start_time', ''),
+        metadata.get('full_tag', ''),
+        build_date,
+        metadata.get('provider', ''),
+        metadata.get('ocp_version', ''),
+        base_url,
+        metadata.get('workload_type', ''),
+        metadata.get('kata_rpm_version', 'unknown'),
+        prowjob_status,
+        metadata.get('trigger_source', ''),
+        _get_root_cause_for_csv(status, failure_analysis),
+    ]
+    columns = [
+        'start_time',
+        'catalog_full_tag',
+        'catalog_build_date',
+        'provider',
+        'ocp_version',
+        'prowjob_url',
+        'workload_type',
+        'kata_rpm_version',
+        'prowjob_status',
+        'trigger',
+        'root_cause',
+    ]
+    buf = io.StringIO()
+    writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+    if header:
+        writer.writerow(columns)
+    writer.writerow(row)
+    return buf.getvalue().rstrip('\n')

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -175,55 +175,44 @@ def generate_artifacts_section(base_url: str, variant: str, test_results_availab
     return section
 
 
-def generate_human_report(
-    prowjob_data: Dict,
-    metadata: Dict,
-    status: str,
-    test_results: Optional[Dict],
-    failure_analysis: Optional[Dict],
-    base_url: str
-) -> str:
+def generate_human_report(report_data: Dict) -> str:
     """
-    Generate human-readable markdown report.
-
-    Args:
-        prowjob_data: Parsed prowjob data
-        metadata: Extracted metadata
-        status: Overall job status
-        test_results: Test results (if available)
-        failure_analysis: Failure analysis (if failed)
-        base_url: Base URL of Prow job
-
-    Returns:
-        Markdown formatted report
+    Generate human-readable markdown report from the canonical report_data
+    (subset of build_report_data() output).
     """
+    prowjob = report_data['prowjob']
+    metadata = report_data['metadata']
+    status = prowjob['status']
+    base_url = prowjob['url']
+    variant = metadata['variant']
+    test_results = report_data.get('test_results')
+    failure_analysis = report_data.get('failure_analysis')
+
     report = "# Prow Job Analysis Report\n\n"
 
-    # Status
     status_emoji = format_status_emoji(status)
     report += f"## Status: {status_emoji} {status.upper()}\n\n"
 
-    # Job Overview
     report += "## Job Overview\n\n"
-    report += f"- **Job Name**: `{metadata['job_name']}`\n"
-    report += f"- **Snowflake ID**: `{metadata['build_id']}`\n"
-    report += f"- **Trigger**: {metadata['trigger_source']}\n"
+    report += f"- **Job Name**: `{prowjob['name']}`\n"
+    report += f"- **Snowflake ID**: `{prowjob['build_id']}`\n"
+    report += f"- **Trigger**: {prowjob['trigger']}\n"
 
-    # Show release stage if available
     if metadata.get('release_stage'):
         report += f"- **Release Stage**: {metadata['release_stage']}\n"
 
-    duration = prowjob_data.get('duration_seconds', 0)
+    duration = prowjob.get('duration_seconds', 0)
     if duration > 0:
         report += f"- **Duration**: {format_duration(duration)}\n"
 
-    start_time = prowjob_data.get('start_time', '')
-    if start_time:
-        report += f"- **Started**: {start_time}\n"
+    if prowjob.get('start_time'):
+        report += f"- **Started**: {prowjob['start_time']}\n"
 
     report += f"- **URL**: {base_url}\n"
 
-    # Environment
+    if report_data.get('root_cause'):
+        report += f"- **Root cause**: {report_data['root_cause']}\n"
+
     report += "\n## Environment\n\n"
     report += f"- **Provider**: {metadata['provider']}\n"
     report += f"- **OCP Version**: {metadata['ocp_version']}\n"
@@ -241,29 +230,19 @@ def generate_human_report(
 
     if metadata.get('catalog_source_image'):
         catalog = metadata['catalog_source_image']
-
-        # For digest format (@sha256:...), show only the image name without digest
         if '@' in catalog:
             catalog_display = catalog.split('@')[0]
         else:
             catalog_display = catalog
-
-        # Shorten long catalog images
         if len(catalog_display) > 80:
             catalog_display = "..." + catalog_display[-77:]
-
         report += f"- **Catalog Image**: `{catalog_display}`\n"
 
-        # Display full tag if available
-        if metadata.get('full_tag'):
-            report += f"- **Catalog Tag**: `{metadata['full_tag']}`\n"
-
-            # Display base version if available
-            if metadata.get('base_version'):
-                report += f"- **Catalog Version**: {metadata['base_version']}\n"
-
-            # Always display build date
-            build_date = metadata.get('build_date', 'unknown')
+        if metadata.get('catalog_full_tag'):
+            report += f"- **Catalog Tag**: `{metadata['catalog_full_tag']}`\n"
+            if metadata.get('catalog_version'):
+                report += f"- **Catalog Version**: {metadata['catalog_version']}\n"
+            build_date = metadata.get('catalog_build_date', 'unknown')
             if build_date == 'invalid-timestamp':
                 build_date = 'unknown'
             if build_date == 'unknown':
@@ -271,38 +250,32 @@ def generate_human_report(
             else:
                 report += f"- **Catalog Build Date**: {build_date}\n"
 
-    # Always show expected operator version, even if empty
     expected_ver = metadata.get('expected_operator_version', '')
-    if expected_ver:
-        report += f"- **Expected Operator Version**: {expected_ver}\n"
-    else:
-        report += f"- **Expected Operator Version**: (not set)\n"
+    report += f"- **Expected Operator Version**: {expected_ver or '(not set)'}\n"
 
-    # Test Results
     if test_results:
         report += generate_test_results_section(test_results, failure_analysis or {})
 
-    # Failure Analysis (if failed)
     if status != 'success' and failure_analysis:
-        report += generate_failure_analysis_section(failure_analysis, base_url, metadata.get('variant', ''))
+        report += generate_failure_analysis_section(failure_analysis, base_url, variant)
 
-    # Artifacts
     analyzed_files = failure_analysis.get('analyzed_files', []) if failure_analysis else []
-    report += generate_artifacts_section(base_url, metadata.get('variant', ''), test_results is not None, analyzed_files)
+    report += generate_artifacts_section(base_url, variant, test_results is not None, analyzed_files)
 
     return report
 
 
-def generate_json_report(
+def build_report_data(
     prowjob_data: Dict,
     metadata: Dict,
     status: str,
     test_results: Optional[Dict],
     failure_analysis: Optional[Dict],
-    base_url: str
-) -> str:
+    base_url: str,
+) -> Dict:
     """
-    Generate machine-parsable JSON report.
+    Build the canonical report data structure. JSON contains this in full;
+    human and CSV outputs are subsets of this data.
 
     Args:
         prowjob_data: Parsed prowjob data
@@ -313,11 +286,15 @@ def generate_json_report(
         base_url: Base URL of Prow job
 
     Returns:
-        JSON formatted report
+        Full report dict (single source of truth for all report formats)
     """
+    variant = metadata.get('variant', '')
+    root_cause_summary = get_root_cause_summary(status, failure_analysis)
+
     report = {
         'version': '1.0',
         'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'root_cause': root_cause_summary,
         'prowjob': {
             'url': base_url,
             'name': metadata['job_name'],
@@ -346,28 +323,22 @@ def generate_json_report(
         },
     }
 
-    # Test results summary
     if test_results:
-        # Handle different test results formats
         total = test_results.get('total', 0)
         if total == 0:
-            # Fallback to 'tests' field or count of test list
             total = test_results.get('tests', 0) if isinstance(test_results.get('tests'), int) else len(test_results.get('tests', []))
         failures = test_results.get('failures', 0)
-
         report['test_results'] = {
             'total': total,
             'passed': total - failures,
-            'failed': failures,
+            'failures': failures,
             'skipped': test_results.get('skipped', 0),
         }
 
-    # Failure analysis
     if failure_analysis:
         failing_tests = failure_analysis.get('failing_tests', [])
-
         report['failure_analysis'] = {
-            'failed_steps': failure_analysis.get('failure_location', 'unknown'),
+            'failure_location': failure_analysis.get('failure_location', 'unknown'),
             'failing_tests': [
                 {
                     'name': test.get('name', ''),
@@ -379,28 +350,34 @@ def generate_json_report(
                 }
                 for test in failing_tests
             ],
+            'failing_tests_by_category': failure_analysis.get('failing_tests_by_category', {}),
             'detected_patterns': failure_analysis.get('detected_patterns', []),
             'analyzed_files': failure_analysis.get('analyzed_files', []),
             'root_cause': failure_analysis.get('root_cause', {}),
         }
 
-    # Artifacts
-    variant = metadata.get('variant', '')
     report['artifacts'] = {
         'prowjob_json': get_artifact_url(base_url, 'prowjob.json'),
         'finished_json': get_artifact_url(base_url, 'finished.json'),
     }
-
     if variant and variant != 'unknown':
         report['artifacts']['test_results'] = get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml')
         report['artifacts']['extended_log'] = get_artifact_url(base_url, f'artifacts/{variant}/openshift-extended-test/artifacts/extended.log')
         report['artifacts']['must_gather'] = get_artifact_url(base_url, f'artifacts/{variant}/sandboxed-containers-operator-gather-must-gather/artifacts/')
 
-    return json.dumps(report, indent=2)
+    return report
 
 
-def _get_root_cause_for_csv(status: str, failure_analysis: Optional[Dict]) -> str:
-    """Get root cause string for CSV: likely_cause if determined, else 'unknown' (or '' for success)."""
+def generate_json_report(report_data: Dict) -> str:
+    """
+    Emit the full report data as JSON. report_data is the canonical structure
+    from build_report_data().
+    """
+    return json.dumps(report_data, indent=2)
+
+
+def get_root_cause_summary(status: str, failure_analysis: Optional[Dict]) -> str:
+    """Get root cause one-line summary: likely_cause if determined, else 'unknown' (or '' for success). Used by human, JSON, and CSV outputs."""
     if status == 'success':
         return ''
     if not failure_analysis:
@@ -410,53 +387,51 @@ def _get_root_cause_for_csv(status: str, failure_analysis: Optional[Dict]) -> st
     return likely if likely else 'unknown'
 
 
-def generate_csv_report(
-    prowjob_data: Dict,
-    metadata: Dict,
-    status: str,
-    test_results: Optional[Dict],
-    failure_analysis: Optional[Dict],
-    base_url: str,
-    header: bool = True,
-) -> str:
+def generate_csv_report(report_data: Dict, header: bool = True) -> str:
     """
-    Generate a single-row CSV report.
+    Generate a single-row CSV report from the canonical report_data
+    (subset of build_report_data() output).
 
-    Column order: start_time, catalog_full_tag, catalog_build_date, provider,
-    ocp_version, prowjob url, workload_type, kata_rpm_version, prowjob status,
-    trigger, root_cause.
-
-    Args:
-        prowjob_data: Parsed prowjob data
-        metadata: Extracted metadata
-        status: Overall job status
-        test_results: Test results (if available)
-        failure_analysis: Failure analysis (if failed)
-        base_url: Base URL of Prow job
-        header: If True, include a header row with column names
-
-    Returns:
-        CSV formatted string (one data row, optionally preceded by header)
+    Column order: trigger, start_time, catalog_full_tag, catalog_build_date,
+    provider, ocp_version, prowjob url, workload_type, kata_rpm_version,
+    prowjob status, failed_steps, primary_pattern, Confidence, root_cause.
     """
-    build_date = metadata.get('build_date', '') or 'unknown'
+    prowjob = report_data['prowjob']
+    metadata = report_data['metadata']
+    failure_analysis = report_data.get('failure_analysis') or {}
+    root_cause_obj = failure_analysis.get('root_cause') or {}
+
+    build_date = metadata.get('catalog_build_date', '') or 'unknown'
     if build_date == 'invalid-timestamp':
         build_date = 'unknown'
 
-    prowjob_status = status.upper() if status else ''
+    prowjob_status = (prowjob.get('status') or '').upper()
+    failed_steps = failure_analysis.get('failure_location', '') or ''
+    primary_pattern = root_cause_obj.get('primary_pattern', '') or ''
+    confidence = root_cause_obj.get('confidence', '') or ''
+
+    catalog_full_tag = metadata.get('catalog_full_tag', '') or ''
+    if catalog_full_tag.startswith('sha256:'):
+        catalog_full_tag = catalog_full_tag[7:]
+
     row = [
-        prowjob_data.get('start_time', ''),
-        metadata.get('full_tag', ''),
+        prowjob.get('trigger', ''),
+        prowjob.get('start_time', ''),
+        catalog_full_tag,
         build_date,
         metadata.get('provider', ''),
         metadata.get('ocp_version', ''),
-        base_url,
+        prowjob.get('url', ''),
         metadata.get('workload_type', ''),
         metadata.get('kata_rpm_version', 'unknown'),
         prowjob_status,
-        metadata.get('trigger_source', ''),
-        _get_root_cause_for_csv(status, failure_analysis),
+        failed_steps,
+        primary_pattern,
+        confidence,
+        report_data.get('root_cause', ''),
     ]
     columns = [
+        'trigger',
         'start_time',
         'catalog_full_tag',
         'catalog_build_date',
@@ -466,7 +441,9 @@ def generate_csv_report(
         'workload_type',
         'kata_rpm_version',
         'prowjob_status',
-        'trigger',
+        'failed_steps',
+        'primary_pattern',
+        'Confidence',
         'root_cause',
     ]
     buf = io.StringIO()


### PR DESCRIPTION
[KATA-4656](https://issues.redhat.com/browse/KATA-4656) Add option to prowjob analyzer script save results to a spreadsheet

Add --csv output to script for import into a spreadsheet

- Consolidate complete output data into json
  - Human and csv are subsets
- Change csv output to be closer to record-metadata in prow
- A sha256 catalog will now get its build time from quay to match  record-metadata
- Adding an initial RCA

To add a Konflux run, download all task logs to `task.log`
```
 for i in $(grep https://prow task.log)
do
  scripts/prowjob-analyzer/analyze.py --csv --no-header $i
done > import.csv
```

In your spreadsheet, go to the line where you want the data and import.
Replace the data at that line and choose comma deliminated


