### PR TITLE
prowjob-analyzer: enhance the analysis when most/all tests fail

### DIFF
--- a/.claude/commands/prowjob-analyze.md
+++ b/.claude/commands/prowjob-analyze.md
@@ -29,9 +29,12 @@ python3 scripts/prowjob-analyzer/analyze.py --no-wait "$@"
 **Case A: Tests failed** (Failed Step is `openshift-extended-test` AND Failed Tests are listed)
 - This means the job ran through infrastructure setup and failed during test execution
 - **IMPORTANT**: Check the failure count:
-  - If **>90% of tests failed** (e.g., 10+ tests failed): Run analysis on **ONLY the FIRST test**
+  - If **>90% of tests failed** (e.g., 10+ tests failed):
+    - Each test in the "Failed Tests" section shows metadata including "Execution Order: N"
+    - Find the test with "Execution Order: 1" - this is the FIRST test that executed
+    - Use ONLY that test name for detailed analysis:
     ```bash
-    python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> <FIRST_TEST_NAME>
+    python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> "<TEST_NAME_WITH_EXECUTION_ORDER_1>"
     ```
     This is because when all/most tests fail, it indicates a setup failure. The first test contains the root cause, and subsequent tests show cascading errors.
 

--- a/.claude/commands/prowjob-analyze.md
+++ b/.claude/commands/prowjob-analyze.md
@@ -28,11 +28,18 @@ python3 scripts/prowjob-analyzer/analyze.py --no-wait "$@"
 
 **Case A: Tests failed** (Failed Step is `openshift-extended-test` AND Failed Tests are listed)
 - This means the job ran through infrastructure setup and failed during test execution
-- Run detailed test analysis:
-```bash
-python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> <TEST_NAME_1> <TEST_NAME_2> ...
-```
-Use the exact test names from the "Failed Tests" section.
+- **IMPORTANT**: Check the failure count:
+  - If **>90% of tests failed** (e.g., 10+ tests failed): Run analysis on **ONLY the FIRST test**
+    ```bash
+    python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> <FIRST_TEST_NAME>
+    ```
+    This is because when all/most tests fail, it indicates a setup failure. The first test contains the root cause, and subsequent tests show cascading errors.
+
+  - If **only a few tests failed** (e.g., <10 tests): Run analysis on all failing tests
+    ```bash
+    python3 scripts/prowjob-analyzer/failed_tests_report.py <PROW_JOB_URL> <TEST_NAME_1> <TEST_NAME_2> ...
+    ```
+    Use the exact test names from the "Failed Tests" section.
 
 **Case B: Infrastructure/setup step failed** (Failed Step is NOT `openshift-extended-test`)
 - Examples: `ipi-install-install`, `sandboxed-containers-operator-peerpods-param-cm`, etc.
@@ -134,6 +141,37 @@ OSC supports three distinct workload types, controlled by configuration:
   - Extremely long job execution times
   - Job timeouts (tests trying setup instead of running actual test logic)
 - This explains why infrastructure failures can cause the entire job to timeout
+
+**CRITICAL: Root Cause Analysis Strategy**:
+When ALL or MOST tests fail (>90%), this indicates a common root cause in the environment setup:
+
+1. **Focus on the FIRST test's logs ONLY**:
+   - The first test that runs will encounter the initial/real error during setup
+   - Subsequent tests will show cascading/secondary errors because setup already failed
+   - The FIRST test's logs contain the true root cause
+
+2. **RPM Installation Failures - Common Pattern**:
+   - **Real error** (appears in FIRST test): `error: Failed dependencies` - This is the ROOT CAUSE
+   - **Cascading error** (appears in MANY subsequent tests): `error: Deployment is already in unlocked state: hotfix`
+   - The cascading error appears frequently because every subsequent test tries to install the RPM and fails since the system is in a bad state
+   - DO NOT be misled by error frequency - the FIRST occurrence is what matters
+
+3. **Analysis Approach**:
+   - If 90%+ of tests failed, immediately look at the FIRST test's logs
+   - Identify what failed during setup (RPM install, KataConfig creation, operator installation, etc.)
+   - Ignore errors that appear in most/all tests - these are cascading failures
+   - The error that appears EARLIEST (in the first test) is the root cause
+
+4. **Example Scenario**:
+   ```
+   Test 1: Fails with "error: Failed dependencies: packageX is needed by kata"
+   Test 2: Fails with "error: Deployment is already in unlocked state: hotfix"
+   Test 3: Fails with "error: Deployment is already in unlocked state: hotfix"
+   ... (all remaining tests show the same "unlocked state" error)
+
+   ROOT CAUSE: Failed dependencies in Test 1
+   CASCADING ERRORS: "Deployment is already in unlocked state" in all subsequent tests
+   ```
 
 **Test Execution**:
 - Tests run sequentially due to `[Serial]` tag (shared cluster state)

--- a/scripts/prowjob-analyzer/failed_tests_report.py
+++ b/scripts/prowjob-analyzer/failed_tests_report.py
@@ -32,6 +32,7 @@ from lib.parser import (
     extract_failing_tests,
     parse_test_case_info,
     categorize_test_by_name,
+    extract_test_execution_order,
 )
 
 # Configure logging
@@ -221,10 +222,28 @@ def analyze_failed_tests(
             'priority': test_info['priority'],
             'failure_summary': test_logs['failure_summary'],
             'full_logs': test_logs['full_logs'],
+            'execution_order': None,  # Will be set below
         }
-        
+
         results.append(result)
-    
+
+    # Add execution order to each test and sort by it
+    # This is critical for root cause analysis - the first test often contains the real error
+    execution_order = extract_test_execution_order(build_log_text)
+    if execution_order:
+        # Create a mapping of test name to execution order number (1-based)
+        order_map = {test_name: idx + 1 for idx, test_name in enumerate(execution_order)}
+
+        # Add execution order to each result
+        for result in results:
+            result['execution_order'] = order_map.get(result['test_name'])
+
+        # Sort results based on execution order
+        results.sort(key=lambda r: r['execution_order'] if r['execution_order'] else float('inf'))
+        logger.info("Added execution order and sorted test results")
+    else:
+        logger.warning("Could not extract execution order, tests shown in original order")
+
     return results
 
 
@@ -250,6 +269,8 @@ def generate_markdown_report(test_results: List[Dict], base_url: str) -> str:
         # Metadata
         if test['test_case_number']:
             report += f"- **Test Case ID**: {test['test_case_number']}\n"
+        if test.get('execution_order'):
+            report += f"- **Execution Order**: {test['execution_order']}\n"
         report += f"- **Elapsed Time**: {test['elapsed_time']}\n"
         report += f"- **Category**: {test['category']}\n"
         if test['author']:

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -67,6 +67,16 @@ FAILURE_PATTERNS = {
         r'qemu.*failed',
         r'failed to create sandbox',
     ],
+    'rpm_install': [
+        r'error:.*Failed dependencies',
+        r'error:.*package.*is needed by kata',
+        r'rpm.*installation failed',
+        r'error:.*nothing provides.*needed by kata',
+    ],
+    'rpm_cascading': [
+        r'error:.*Deployment is already in unlocked state',
+        r'error:.*ostree.*unlocked state',
+    ],
 }
 
 
@@ -295,6 +305,22 @@ def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict
             'Consider distributing test load across multiple time periods',
             'Monitor for recurring quota exhaustion patterns',
         ]
+    elif 'rpm_install' in pattern_names:
+        root_cause['primary_pattern'] = 'rpm_install'
+        root_cause['pattern_source'] = find_pattern_source('rpm_install')
+        root_cause['likely_cause'] = 'RPM installation failed due to missing dependencies'
+        root_cause['confidence'] = 'high'
+        root_cause['suggested_actions'] = [
+            'Check the first test logs for the specific missing dependency',
+            'Verify the Kata RPM package dependencies are available in the repository',
+            'Check if the RPM repository is accessible and configured correctly',
+            'Verify the RPM version compatibility with the target OS',
+        ]
+
+        # If rpm_cascading is also present, note it's a secondary error
+        if 'rpm_cascading' in pattern_names:
+            root_cause['cascading_errors'] = ['rpm_cascading']
+            root_cause['note'] = 'Multiple "Deployment is already in unlocked state" errors are cascading failures from the initial RPM dependency error'
 
     # Check for version mismatch (OSC-specific)
     if any('version' in test['name'].lower() for test in failing_tests):
@@ -306,9 +332,11 @@ def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict
 
     # If many tests failed, might be infrastructure
     if len(failing_tests) > 10:
-        root_cause['likely_cause'] = 'Widespread test failures suggest infrastructure or configuration issue'
-        root_cause['confidence'] = 'medium'
+        if not root_cause['likely_cause']:  # Only set if no other cause was found
+            root_cause['likely_cause'] = 'Widespread test failures suggest infrastructure or configuration issue'
+            root_cause['confidence'] = 'medium'
         root_cause['suggested_actions'].append('Review cluster health and OSC installation logs')
+        root_cause['suggested_actions'].append('IMPORTANT: When most/all tests fail, examine the FIRST test\'s logs for the root cause - subsequent test errors are often cascading failures')
 
     return root_cause
 

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -8,7 +8,7 @@ import re
 import logging
 from typing import Dict, List, Optional
 from collections import defaultdict
-from .parser import categorize_test_by_name, extract_failing_tests
+from .parser import categorize_test_by_name, extract_failing_tests, add_execution_order_to_tests
 from .fetcher import fetch_artifact, get_failed_steps
 
 logger = logging.getLogger(__name__)
@@ -202,6 +202,25 @@ def categorize_failing_tests(test_results: Dict) -> Dict[str, List[Dict]]:
     return dict(categorized)
 
 
+def categorize_test_list(failing_tests: List[Dict]) -> Dict[str, List[Dict]]:
+    """
+    Group a list of failing tests by category.
+
+    Args:
+        failing_tests: List of failing test dictionaries
+
+    Returns:
+        Dictionary mapping category to list of failing tests
+    """
+    categorized = defaultdict(list)
+
+    for test in failing_tests:
+        category = categorize_test_by_name(test['name'])
+        categorized[category].append(test)
+
+    return dict(categorized)
+
+
 def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict], metadata: Dict, build_log_text: Optional[str] = None) -> Dict:
     """
     Attempt to determine root cause of failure.
@@ -385,14 +404,16 @@ def analyze_failure(
     # Fetch and analyze logs for patterns
     detected_patterns = []
     build_log_text = None
+    build_log_text_full = None  # Keep full log for execution order extraction
     analyzed_files = []
 
     # First check the main build log for infrastructure-level failures (e.g., Azure quota)
     build_log_content = fetch_artifact(base_url, "build-log.txt")
     if build_log_content:
         try:
-            build_log_text = build_log_content.decode('utf-8', errors='ignore')
-            # Limit to last 100KB to avoid processing huge logs
+            build_log_text_full = build_log_content.decode('utf-8', errors='ignore')
+            # Use truncated version for pattern matching (performance)
+            build_log_text = build_log_text_full
             if len(build_log_text) > 100000:
                 build_log_text = build_log_text[-100000:]
             patterns_from_build_log = check_log_for_patterns(build_log_text, "build-log.txt")
@@ -433,6 +454,15 @@ def analyze_failure(
     # Store detected patterns with sources and analyzed files info
     analysis['detected_patterns'] = detected_patterns
     analysis['analyzed_files'] = analyzed_files
+
+    # Add execution order to failing tests
+    if analysis['failing_tests'] and build_log_text_full:
+        analysis['failing_tests'] = add_execution_order_to_tests(
+            analysis['failing_tests'],
+            build_log_text_full
+        )
+        # Re-categorize with execution order included
+        analysis['failing_tests_by_category'] = categorize_test_list(analysis['failing_tests'])
 
     # Determine root cause
     analysis['root_cause'] = determine_root_cause(

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -294,6 +294,83 @@ def categorize_test_by_name(test_name: str) -> str:
         return 'other'
 
 
+def extract_test_execution_order(log_content: str) -> List[str]:
+    """
+    Extract test execution order from build-log.txt or extended.log.
+
+    Tests are logged in execution order with pattern:
+    started: (x/y/z) "test name"
+    where x=failures so far, y=execution order (1-based), z=total tests
+
+    Example: started: (0/1/36) "[sig-kata] Kata Author:abhbaner-High-C00147..."
+
+    Args:
+        log_content: Content of build-log.txt or extended.log
+
+    Returns:
+        List of test names in execution order
+    """
+    import re
+
+    # Store tuples of (execution_order, test_name)
+    test_order_tuples = []
+
+    # Pattern to match: started: (x/y/z) "test_name"
+    # Capture groups: y (execution order) and test_name
+    pattern = r'started:\s*\(\d+/(\d+)/\d+\)\s*"(.+?)"'
+
+    for match in re.finditer(pattern, log_content):
+        execution_order = int(match.group(1))
+        test_name = match.group(2)
+        test_order_tuples.append((execution_order, test_name))
+        logger.debug(f"Found test #{execution_order}: {test_name}")
+
+    # Sort by execution order and return just the test names
+    test_order_tuples.sort(key=lambda x: x[0])
+    test_names = [test_name for _, test_name in test_order_tuples]
+
+    logger.info(f"Extracted execution order for {len(test_names)} tests")
+    return test_names
+
+
+def add_execution_order_to_tests(failing_tests: List[Dict], log_content: str) -> List[Dict]:
+    """
+    Add execution order number to each failing test.
+
+    Args:
+        failing_tests: List of failing test dictionaries from extract_failing_tests()
+        log_content: Content of build-log.txt or extended.log
+
+    Returns:
+        Updated list of failing tests with execution_order field added
+    """
+    if not failing_tests:
+        return failing_tests
+
+    # Get execution order from logs
+    execution_order = extract_test_execution_order(log_content)
+
+    if not execution_order:
+        logger.warning("Could not extract test execution order from logs")
+        # Return tests with execution_order = None
+        for test in failing_tests:
+            test['execution_order'] = None
+        return failing_tests
+
+    # Create mapping of test name to execution order
+    order_map = {test_name: idx + 1 for idx, test_name in enumerate(execution_order)}
+
+    # Add execution order to each failing test
+    for test in failing_tests:
+        test_name = test['name']
+        test['execution_order'] = order_map.get(test_name)
+        if test['execution_order']:
+            logger.debug(f"Test '{test_name}' execution order: {test['execution_order']}")
+
+    logger.info(f"Added execution order to {len(failing_tests)} failing tests")
+    return failing_tests
+
+
 def format_duration(seconds: int) -> str:
     """
     Format duration in seconds to human-readable format.

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -59,11 +59,14 @@ def generate_test_results_section(test_results: Dict, failure_analysis: Dict) ->
                     test_case_num = test.get('test_case_number', '')
                     description = test.get('description', '')
                     test_name = test.get('name', 'Unknown')
+                    execution_order = test.get('execution_order')
 
                     # Display test case number and description if available
                     if test_case_num and description:
                         section += f"- **{test_case_num}**: {description}\n"
-                        # Add priority and author if available
+                        # Add execution order, priority and author if available
+                        if execution_order:
+                            section += f"  - Execution Order: {execution_order}\n"
                         if test.get('priority'):
                             section += f"  - Priority: {test['priority']}\n"
                         if test.get('author'):
@@ -73,6 +76,8 @@ def generate_test_results_section(test_results: Dict, failure_analysis: Dict) ->
                         if len(test_name) > 100:
                             test_name = test_name[:97] + "..."
                         section += f"- `{test_name}`\n"
+                        if execution_order:
+                            section += f"  - Execution Order: {execution_order}\n"
                 section += "\n"
 
     return section
@@ -374,6 +379,7 @@ def generate_json_report(
                     'priority': test.get('priority', ''),
                     'author': test.get('author', ''),
                     'duration': test.get('duration', 0),
+                    'execution_order': test.get('execution_order'),
                 }
                 for test in failing_tests
             ],


### PR DESCRIPTION
The commits are self-explanatory but let me try to summarize the changes:

```
    This helps the AI avoid being misled by error frequency and correctly
    identify the root cause in the first test's logs rather than focusing
    on cascading errors that appear more frequently in subsequent tests.
```

We had recently jobs for OCP 4.17 and 4.18 failing because of a bug on the Kata 3.25 rpm, for example https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-azure-ipi-peerpods/2019354177586597888. The prowjob-analyzer was able detect the job failed to install the RPM but could not derive the correct problem cause. This happened because of a characteristic of our test framework (every and each test will try to setup the test environment, unless it was already setup'ed by a previous test) misled the analysis of AI.

In this particular case of rpm install failure, the first test failed to install the rpm due dependency (qemu) not found. Subsequent tests tried to install the rpm likewise, however, they failed to actually make the filesystem read-write because the first did that already! With so many errors, all over the tests, related with filesystem errors, AI thought that was the cause of the problem (and not the lack of a given version of qemu).

Here I'm trying to teach AI how to make the analysis in a similar situation.