### PR TITLE
fbc: update ADDITIONAL_TAGS with the current OSC release value

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -257,7 +257,7 @@ spec:
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
-      value: ["latest", "1.10.3-$(tasks.clone-repository.results.commit-timestamp)"]
+      value: ["latest", "1.11.1-$(tasks.clone-repository.results.commit-timestamp)"]
     runAfter:
     - build-image-index
     taskRef:


### PR DESCRIPTION
This value will be displayed in quay.io for the FBC images.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>