### PR TITLE
tests: Pull registry.redhat.io/openshift4/ose-cli with a digest

### DIFF
--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -21,7 +21,7 @@ spec:
         - name: TEST_OUTPUT
           description: Test output
         steps:
-        - image: registry.redhat.io/openshift4/ose-cli:latest
+        - image: registry.redhat.io/openshift4/ose-cli@sha256:4980a846e113a796b7db0ccd86e14064d9d2decca845007d44f0bda4bd139966
           env:
           - name: SNAPSHOT
             value: $(params.SNAPSHOT)

--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -27,18 +27,23 @@ spec:
             value: $(params.SNAPSHOT)
           script: |
             #!/bin/bash
-            set -e
+            set -xe
             SUCCESSES=0
             FAILURES=0
             WARNINGS=0
 
-            dnf -y install jq git make go
+            dnf -y install jq git make go strace
             srcURL=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.url' <<< "${SNAPSHOT}")
             srcREV=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.revision' <<< "${SNAPSHOT}")
 
             git clone ${srcURL} sources
             cd sources
             git checkout ${srcREV}
+
+            export GOMAXPROCS=5
+
+            #go fmt ./...
+            #strace -f go vet ./...
             make test
 
             # After the tests finish, record the overall result in the RESULT variable


### PR DESCRIPTION
Something went wrong in the RH registry and latest tag currently points to an ancient version. Use the current latest digest. Hopefully mintmaker will be able to bump it when a new image is published.
