### PR TITLE
Update KATA_RPM_VERSION to version 3.25.0-2

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -59,7 +59,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate417
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-1.rhaos4.17.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.17.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -92,7 +92,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate418
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-1.rhaos4.18.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.18.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -125,7 +125,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate419
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-1.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.19.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -157,7 +157,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate420
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-1.rhaos4.20.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.11.2,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.20.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES


### PR DESCRIPTION
Kata-containers version 3.25.0-2 RPMs have been built.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>