### PR TITLE
make-tests: Set CPU and memory resources

### DIFF
--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -22,6 +22,13 @@ spec:
           description: Test output
         steps:
         - image: registry.redhat.io/openshift4/ose-cli:latest
+          resources:
+            requests:
+              cpu: "2"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
           env:
           - name: SNAPSHOT
             value: $(params.SNAPSHOT)
@@ -39,7 +46,7 @@ spec:
             git clone ${srcURL} sources
             cd sources
             git checkout ${srcREV}
-            make test
+            GOMAXPROCS=2 make test
 
             # After the tests finish, record the overall result in the RESULT variable
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
Konflux workers have 32 CPU, the task has no CPU limit and requests 100m. The go compiler ends up thinking it has a lot more CPU than what it gets in practice. It spawns 32 compile threads that quickly saturate both CPU and memory available to the task. This causes `go vet` to run for more than 2 hours and the task times out.

Set limits and requests in the task spec and tell go about the maximum number of CPU it can use.

