### PR TITLE
Add 'openshift-kube-proxy' to the list

### DIFF
--- a/controllers/ppwebhook.go
+++ b/controllers/ppwebhook.go
@@ -309,6 +309,7 @@ func (r *KataConfigOpenShiftReconciler) createMutatingWebhookConfig() error {
 		"openshift-kube-apiserver",
 		"openshift-kube-apiserver-operator",
 		"openshift-kube-controller-manager",
+		"openshift-kube-proxy",
 		"openshift-kube-scheduler",
 		"openshift-kube-scheduler-operator",
 		"openshift-kube-storage-version-migrator",


### PR DESCRIPTION
It's a long story how we found this. IBM Cloud uses calico CNI. Even after configuring calico exclusions the OSC peer pod webhook was causing problems because openshift-kube-proxy wasn't excluded.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
The peer pod webhook can cause havoc in alternate CNIs causing them to not start correctly if the underlying app isn't responding. Even after adding exclusions to the webhook for the obvious namespaces our CNI used, this one eluded us. 

**- What I did**
added an exclusion for an additional openshift namespace commonly used on startup resources

**- How to verify it**
Create a CNI that depends on notifying the peer pod webhook to start up but there is no peer pod app to respond to it thereby hanging the CNI from starting. 

**- Description for the changelog**
Add openshift-kube-proxy to exclude peer pod webhook namespaces
