### PR TITLE
Bump OSC to 1.12 in the CSV

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-02-23T16:41:56Z"
+    createdAt: "2026-02-24T18:05:19Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.11.2
+  name: sandboxed-containers-operator.v1.12.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -365,7 +365,7 @@ spec:
   provider:
     name: Red Hat
   replaces: sandboxed-containers-operator.v1.11.1
-  version: 1.11.2
+  version: 1.12.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/scripts/bump-osc-version.sh
+++ b/scripts/bump-osc-version.sh
@@ -19,11 +19,25 @@ EOF
     exit 1
 fi
 
+#
+# Generic case based on OSC_VERSION tag
+#
 sed -Ei "s/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+([^#]+## OSC_VERSION)/${version}\1/g" \
     $(git grep -El '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^#]+## OSC_VERSION')
 
+#
+# Specific cases in the CSV
+#
 sed -Ei \
     "s/(olm.skipRange: '>=1\.1\.0 <)[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'/\1${version}'/g" \
+    config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+
+sed -Ei \
+    "s/^([[:space:]]+version: )[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/\1${version}/g" \
+    config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+
+sed -Ei \
+    "s/^([[:space:]]+name: sandboxed-containers-operator\.v)[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/\1${version}/g" \
     config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
 
 if [[ -n "$replaced" ]]; then
@@ -31,6 +45,9 @@ if [[ -n "$replaced" ]]; then
 	config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
 fi
 
+#
+# Labels
+#
 major_minor()
 {
     local major minor
@@ -44,6 +61,9 @@ sed -Ei "s/(version=)\"[[:digit:]]+\.[[:digit:]]+\"/\1\"$(major_minor "${version
 sed -Ei "s/(cpe:.*confidential_compute_attestation:)[[:digit:]]+\.[[:digit:]]+:/\1$(major_minor "${version}"):/g" \
     $(git grep -El 'cpe:.*confidential_compute_attestation:[[:digit:]]+\.[[:digit:]]+:')
 
+#
+# FBC catalogs
+#
 sed -Ei "s/\"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.*timestamp)/\"${version}\1/g" .tekton/osc-test-fbc-push.yaml .tekton/fbc-pipeline.yaml
 
 #
@@ -53,7 +73,6 @@ readonly files_to_preserve=(
     "bundle.Dockerfile"
     "config/manager/kustomization.yaml"
     "config/metrics/kustomization.yaml"
-    "config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml"
 )
 
 readonly backup_dir=`mktemp --directory -t bump-osc-version-XXXXXX`


### PR DESCRIPTION
This was overlooked by #1729 . Improve the version bump script to do the work and re-run it.