### PR TITLE
feat(runtimeclass): add NVIDIA GPU support for kata runtime classes

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -31,6 +31,7 @@ type KataConfigSpec struct {
 
 	// CheckNodeEligibility is used to detect the node(s) eligibility to run Kata containers.
 	// This is currently done through the use of the Node Feature Discovery Operator (NFD).
+	// In addition this option will also enforce runtime class creation if only if node(s) support them.
 	// For more information on how the check works, please refer to the sandboxed containers documentation - https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.6/html-single/user_guide/index#about-node-eligibility-checks_about-osc
 	// +kubebuilder:default:=false
 	CheckNodeEligibility bool `json:"checkNodeEligibility"`

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -62,6 +62,7 @@ spec:
                 description: |-
                   CheckNodeEligibility is used to detect the node(s) eligibility to run Kata containers.
                   This is currently done through the use of the Node Feature Discovery Operator (NFD).
+                  In addition this option will also enforce runtime class creation if only if node(s) support them.
                   For more information on how the check works, please refer to the sandboxed containers documentation - https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.6/html-single/user_guide/index#about-node-eligibility-checks_about-osc
                 type: boolean
               enablePeerPods:

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -164,7 +164,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 		}
 
 		// Create kata-cc runtime class restricted to the detected TEE subset
-		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, nodeLabel)
+		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, map[string]string{nodeLabel: "true"})
 		if err != nil {
 			r.Log.Info("Error creating "+kataCCRuntimeClassName+" runtime class", "err", err)
 			return fmt.Errorf("Error creating "+kataCCRuntimeClassName+" runtime class: %w", err)

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -10,6 +11,9 @@ import (
 )
 
 const (
+
+	// CPU
+
 	// kata-cc runtime class for CoCo BM
 	kataCCRuntimeClassName        = "kata-cc"
 	kataCCRuntimeClassCpuOverhead = "0.25"
@@ -29,10 +33,40 @@ const (
 	intelTDXExtendedResource = "tdx.intel.com/keys"
 	amdSNPExtendedResource   = "sev-snp.amd.com/esids"
 
+	// GPU
+
+	// kata-cc-nvidia-gpu runtime class for CoCo BM GPU
+	kataNvidiaGPUCCRuntimeClassName        = "kata-cc-nvidia-gpu"
+	kataNvidiaGPUCCRuntimeClassCpuOverhead = "0.25"
+	kataNvidiaGPUCCRuntimeClassMemOverhead = "350Mi"
+
+	// RuntimeClass handlers for TEE
+	kataNvidiaGPUCCIntelHandler = "kata-tdx-nvidia-gpu"
+	kataNvidiaGPUCCAmdHandler   = "kata-snp-nvidia-gpu"
+
 	// INITDATA value for non-confidential peer pods, this is required in order
 	// to override the default restrictive CoCo agent policy
 	// created from sourced plaintxt: cat config/peerpods/default-non-cc-initdata.toml | gzip | base64 -w0
 	defaultNonCCInitdata = "H4sIAAAAAAAAA42UwW7bMAyG734KwT3ktKDDehgG9NAl2VZgWQw7bQ7DMDAWYxOVRU+i03pPP7lGhx0muwddyE8U+ZPUhdrX5BVZEg0C6kQG1SN4VToEQa2OvZIaFfvyDbfoQNglYCp2JHWjrlXqa3j3/ipNzug8sR1Ml8u3y8s0Sb4PIX8kKcBSuDFp8C0Wi2Q4SdqyobJfOqz4xdFC+QAVqnCs/ByBJNF4gs6IutH6Js++IVX1kZ3P8VeHXtSHayWuw3+x4hHamHtl2GMhmmyU4Lb/FGSI+p+VWbEVIItuGivA6iM/xaB1MDruZ6jNE5aZ4xJ9tOrPKFsUR+UUsdttN+cgbRQZrGsMdZlomK/k5dYKuhOEfKaonDuJE1tsvrC0pqs+9qG2Y1TunTVB5lV2F27EmAw6P9+RrDPmtgnDFQNyBF1I6Fv0oRwbPs+/NGKFgMF7ckJ88kUNDrfcWYlKkqNH1HmYBW7WeJ7AumY+hwJl7GeYwj010aIDlz1vWhSgyoKZmb9Qq5P5nAZq76AkW00w4l8RiduZQHvpD8OWe/odLf6u1a/Z5RHbtDU24Qs0020c4b87Mo1NL8kBSGaEP4SPGP8/tMOX+geD8J3Z4AUAAA=="
+)
+
+var (
+	// TEE node labels for NVIDIA GPUs
+	nvidiaGPUCCNodeLabels = map[string]string{
+		"nvidia.com/cc.mode.state":  "on",
+		"nvidia.com/cc.ready.state": "true",
+	}
+
+	// TEE node labels for CPUs
+	intelTDXNodeLabels = map[string]string{
+		intelTDXNodeLabel: "true",
+	}
+	amdSNPNodeLabels = map[string]string{
+		amdSNPNodeLabel: "true",
+	}
+	imbSENodeLabels = map[string]string{
+		ibmSENodeLabel: "true",
+	}
 )
 
 // When the feature is enabled, handleFeatureConfidential configures confidential computing support.
@@ -124,6 +158,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 // handleConfidentialBaremetal configures confidential computing for baremetal deployments.
 // It manages kata-cc runtime classes with TEE-specific handlers (Intel TDX, AMD SNP or IBM SE).
 func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state FeatureGateState) error {
+	// if confidential feature gate enabled
 	if state == Enabled {
 		if !r.kataConfig.Spec.EnablePeerPods {
 			isLess, version, err := r.isOCPVersionLessThan("4.20.6")
@@ -143,7 +178,8 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 
 		r.Log.Info("Creating " + kataCCRuntimeClassName + " runtime class for confidential containers")
 
-		handler, nodeLabel, err := r.computeTEEHandlerAndLabel()
+		// compute TEE
+		hasIntelTDX, hasAmdSNP, hasIbmSE, err := r.computeTEE()
 		if err != nil {
 			// If peer pods is enabled, just warn and skip baremetal coco
 			if r.kataConfig.Spec.EnablePeerPods {
@@ -155,19 +191,64 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 			return err
 		}
 
-		// Determine extended resource based on TEE type
-		var kataCCRuntimeClassExtResOverhead string
-		if handler == kataCCIntelHandler {
+		// Determine handler and extended resource based on TEE type
+		var handler, kataCCRuntimeClassExtResOverhead string
+		additionalLabels := map[string]string{}
+		if hasIntelTDX {
 			kataCCRuntimeClassExtResOverhead = intelTDXExtendedResource
-		} else if handler == kataCCAmdHandler {
+			handler = kataCCIntelHandler
+			maps.Copy(additionalLabels, intelTDXNodeLabels)
+		} else if hasAmdSNP {
 			kataCCRuntimeClassExtResOverhead = amdSNPExtendedResource
+			handler = kataCCAmdHandler
+			maps.Copy(additionalLabels, amdSNPNodeLabels)
+		} else if hasIbmSE {
+			handler = kataCCIbmHandler
+			maps.Copy(additionalLabels, imbSENodeLabels)
 		}
 
 		// Create kata-cc runtime class restricted to the detected TEE subset
-		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, map[string]string{nodeLabel: "true"})
+		err = r.createRuntimeClass(
+			kataCCRuntimeClassName,
+			kataCCRuntimeClassCpuOverhead,
+			kataCCRuntimeClassMemOverhead,
+			kataCCRuntimeClassExtResOverhead,
+			handler,
+			additionalLabels)
 		if err != nil {
-			r.Log.Info("Error creating "+kataCCRuntimeClassName+" runtime class", "err", err)
-			return fmt.Errorf("Error creating "+kataCCRuntimeClassName+" runtime class: %w", err)
+			r.Log.Error(err, "aborting, failed to create runtimeclass")
+			return err
+		}
+
+		additionalLabels = map[string]string{}
+		// for kata-cc-nvidia-gpu
+		if hasIntelTDX {
+			kataCCRuntimeClassExtResOverhead = intelTDXExtendedResource
+			handler = kataNvidiaGPUCCIntelHandler
+			maps.Copy(additionalLabels, nvidiaGPUNodeLabels)
+			// nvidiaGPUCCNodeLabels overrides values of base gpu labels
+			maps.Copy(additionalLabels, nvidiaGPUCCNodeLabels)
+			maps.Copy(additionalLabels, intelTDXNodeLabels)
+		} else if hasAmdSNP {
+			kataCCRuntimeClassExtResOverhead = amdSNPExtendedResource
+			handler = kataNvidiaGPUCCAmdHandler
+			maps.Copy(additionalLabels, nvidiaGPUNodeLabels)
+			// nvidiaGPUCCNodeLabels overrides values of base gpu labels
+			maps.Copy(additionalLabels, nvidiaGPUCCNodeLabels)
+			maps.Copy(additionalLabels, amdSNPNodeLabels)
+		}
+
+		// Create kata-cc-nvidia-gpu runtime class restricted to the detected GPU TEE subset
+		err = r.createRuntimeClass(
+			kataNvidiaGPUCCRuntimeClassName,
+			kataNvidiaGPUCCRuntimeClassCpuOverhead,
+			kataNvidiaGPUCCRuntimeClassMemOverhead,
+			kataCCRuntimeClassExtResOverhead,
+			handler,
+			additionalLabels)
+		if err != nil {
+			r.Log.Error(err, "aborting, failed to create runtimeclass")
+			return err
 		}
 
 	} else {
@@ -179,26 +260,35 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 			r.Log.Info("Error deleting "+kataCCRuntimeClassName+" runtime class", "err", err)
 			return fmt.Errorf("Error deleting "+kataCCRuntimeClassName+" runtime class: %w", err)
 		}
+
+		r.Log.Info("Deleting " + kataNvidiaGPUCCRuntimeClassName + " runtime class for confidential containers")
+
+		// Delete kata-cc runtime class
+		err = r.deleteRuntimeClass(kataNvidiaGPUCCRuntimeClassName)
+		if err != nil {
+			r.Log.Info("Error deleting "+kataNvidiaGPUCCRuntimeClassName+" runtime class", "err", err)
+			return fmt.Errorf("Error deleting "+kataNvidiaGPUCCRuntimeClassName+" runtime class: %w", err)
+		}
 	}
 
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) computeTEEHandlerAndLabel() (string, string, error) {
+func (r *KataConfigOpenShiftReconciler) computeTEE() (hasIntelTDX, hasAmdSNP, hasIbmSE bool, err error) {
 	selector, err := r.getKataConfigNodeSelectorAsSelector()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to build node selector: %w", err)
+		err = fmt.Errorf("failed to build node selector: %w", err)
+		return
 	}
 
 	nodes := &corev1.NodeList{}
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: selector},
 	}
-	if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
-		return "", "", fmt.Errorf("failed to list nodes: %w", err)
+	if err = r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+		err = fmt.Errorf("failed to list nodes: %w", err)
+		return
 	}
-
-	var hasIntelTDX, hasAmdSNP, hasIbmSE bool
 
 	for _, n := range nodes.Items {
 		if v, ok := n.Labels[intelTDXNodeLabel]; ok && v == "true" {
@@ -223,19 +313,14 @@ func (r *KataConfigOpenShiftReconciler) computeTEEHandlerAndLabel() (string, str
 		count++
 	}
 
+	if count == 0 {
+		err = fmt.Errorf("no TEE platform labels found (expected %s, %s or %s)", intelTDXNodeLabel, amdSNPNodeLabel, ibmSENodeLabel)
+		return
+	}
 	if count >= 2 {
-		return "", "", fmt.Errorf("multiple TEE platforms detected; only one per cluster supported")
+		err = fmt.Errorf("multiple TEE platforms detected; only one per cluster supported")
+		return
 	}
 
-	if hasIntelTDX {
-		return kataCCIntelHandler, intelTDXNodeLabel, nil
-	}
-	if hasAmdSNP {
-		return kataCCAmdHandler, amdSNPNodeLabel, nil
-	}
-	if hasIbmSE {
-		return kataCCIbmHandler, ibmSENodeLabel, nil
-	}
-
-	return "", "", fmt.Errorf("no TEE platform labels found (expected %s, %s or %s)", intelTDXNodeLabel, amdSNPNodeLabel, ibmSENodeLabel)
+	return
 }

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -978,7 +978,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 			NodeSelector: nodeSelector,
 		}
 
-		r.Log.Info("RuntimeClass NodeSelector:", "nodeSelector", nodeSelector)
+		r.Log.Info("RuntimeClass", "name", runtimeClassName, "nodeSelector", nodeSelector)
 
 		return rc
 	}()
@@ -998,7 +998,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 		r.Log.Info("Creating a new RuntimeClass", "rc.Name", rc.Name)
 		err = r.Client.Create(context.TODO(), rc)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating %s runtime class: %w", rc.Name, err)
 		}
 	}
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -88,6 +88,21 @@ const (
 	kataRuntimeClassCpuOverhead = "0.25"
 	// We need a higher value than upstream (see https://github.com/openshift/sandboxed-containers-operator/pull/84)
 	kataRuntimeClassMemOverhead = "350Mi"
+
+	kataNvidiaGPURuntimeClassName        = "kata-nvidia-gpu"
+	kataNvidiaGPURuntimeClassCpuOverhead = "1"
+	kataNvidiaGPURuntimeClassMemOverhead = "4096Mi"
+)
+
+var (
+	// node labels for NVIDIA GPU
+	nvidiaGPUNodeLabels = map[string]string{
+		"nvidia.com/gpu.present":                      "true",
+		"nvidia.com/gpu.deploy.vfio-manager":          "true",
+		"nvidia.com/gpu.deploy.sandbox-device-plugin": "true",
+		"nvidia.com/cc.mode.state":                    "off",
+		"nvidia.com/cc.ready.state":                   "false",
+	}
 )
 
 // +kubebuilder:rbac:groups=kataconfiguration.openshift.io,resources=kataconfigs;kataconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -891,7 +906,40 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, extResOverhead string, handler string, additionalNodeLabels map[string]string) error {
+// createRuntimeClass creates a runtimeclass if it doesn't exist
+// When checkNodeEligibility is set to true, prior to creation
+// it verifies if nodes that support this runtime class exist. This
+// is done by checking if nodes have all labels in additionalNodeLabels.
+func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
+	runtimeClassName string,
+	cpuOverhead string,
+	memoryOverhead string,
+	extResOverhead string,
+	handler string,
+	additionalNodeLabels map[string]string) error {
+
+	if r.kataConfig.Spec.CheckNodeEligibility {
+
+		r.Log.Info("filtering nodes with labels", "labels", additionalNodeLabels)
+		selector, err := r.getKataConfigNodeSelectorAsSelector()
+		if err != nil {
+			return fmt.Errorf("failed to build node selector: %w", err)
+		}
+
+		nodes := &corev1.NodeList{}
+		listOpts := []client.ListOption{
+			client.MatchingLabelsSelector{Selector: selector},
+			client.MatchingLabels(additionalNodeLabels),
+		}
+		if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+			return fmt.Errorf("failed to list nodes: %w", err)
+		}
+
+		if len(nodes.Items) == 0 {
+			r.Log.Info("skipping creating runtimeclass due to missing labels", "runtimeclass", runtimeClassName)
+			return nil
+		}
+	}
 
 	rc := func() *nodeapi.RuntimeClass {
 		podFixed := corev1.ResourceList{
@@ -2356,10 +2404,34 @@ func (r *KataConfigOpenShiftReconciler) deleteScc() error {
 func (r *KataConfigOpenShiftReconciler) postKataInstallation() (*ctrl.Result, error) {
 	r.Log.Info("create runtime class")
 	r.resetInProgressCondition()
-	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, "", kataRuntimeClassName, nil)
+
+	// creating kata runtime class if node labels exist
+	err := r.createRuntimeClass(
+		kataRuntimeClassName,
+		kataRuntimeClassCpuOverhead,
+		kataRuntimeClassMemOverhead,
+		"",                   /* nil extended resource overhead */
+		kataRuntimeClassName, /* reused for handler */
+		map[string]string{
+			"feature.node.kubernetes.io/runtime.kata": "true",
+		})
 	if err != nil {
 		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}
+
+	// creating kata-nvidia-gpu runtime class if node labels exist
+	err = r.createRuntimeClass(
+		kataNvidiaGPURuntimeClassName,
+		kataNvidiaGPURuntimeClassCpuOverhead,
+		kataNvidiaGPURuntimeClassMemOverhead,
+		"",                            /* nil extended resource overhead */
+		kataNvidiaGPURuntimeClassName, /* reused for handler */
+		nvidiaGPUNodeLabels)
+
+	if err != nil {
+		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+	}
+
 	r.Log.Info("create Scc")
 	err = r.createScc()
 	if err != nil {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strings"
@@ -890,7 +891,7 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 	return nil
 }
 
-func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, extResOverhead string, handler string, additionalNodeLabel string) error {
+func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName string, cpuOverhead string, memoryOverhead string, extResOverhead string, handler string, additionalNodeLabels map[string]string) error {
 
 	rc := func() *nodeapi.RuntimeClass {
 		podFixed := corev1.ResourceList{
@@ -921,8 +922,8 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(runtimeClassName stri
 		nodeSelector := r.getNodeSelectorAsMap()
 
 		// Add additional node label if provided
-		if additionalNodeLabel != "" {
-			nodeSelector[additionalNodeLabel] = "true"
+		if additionalNodeLabels != nil {
+			maps.Copy(nodeSelector, additionalNodeLabels)
 		}
 
 		rc.Scheduling = &nodeapi.Scheduling{
@@ -2355,7 +2356,7 @@ func (r *KataConfigOpenShiftReconciler) deleteScc() error {
 func (r *KataConfigOpenShiftReconciler) postKataInstallation() (*ctrl.Result, error) {
 	r.Log.Info("create runtime class")
 	r.resetInProgressCondition()
-	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, "", kataRuntimeClassName, "")
+	err := r.createRuntimeClass(kataRuntimeClassName, kataRuntimeClassCpuOverhead, kataRuntimeClassMemOverhead, "", kataRuntimeClassName, nil)
 	if err != nil {
 		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -2309,53 +2309,6 @@ func (r *KataConfigOpenShiftReconciler) isUpdating() bool {
 	return cond.Status == corev1.ConditionTrue && cond.Reason == "Updating"
 }
 
-// Create the MachineConfigs from file
-// Full path of the file should be provided
-func (r *KataConfigOpenShiftReconciler) createMcFromFile(machineConfigYamlFile string) error {
-	yamlData, err := readYamlFile(machineConfigYamlFile)
-	if err != nil {
-		r.Log.Info("Error in reading MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
-		return err
-	}
-
-	r.Log.Info("machineConfig yaml dump ", "yamlData", yamlData)
-
-	machineConfig, err := parseMachineConfigYAML(yamlData)
-	if err != nil {
-		r.Log.Info("Error in parsing MachineConfigYaml", "mcFile", machineConfigYamlFile, "err", err)
-		return err
-	}
-
-	// Default MCP is kata-oc, however for converged cluster it should be "master"
-	isConvergedCluster, err := r.checkConvergedCluster()
-	if isConvergedCluster && err == nil {
-		machineConfig.Labels["machineconfiguration.openshift.io/role"] = "master"
-	}
-
-	r.Log.Info("machineConfig dump ", "machineConfig", machineConfig)
-
-	if err := r.Client.Create(context.TODO(), machineConfig); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
-			currentMachineConfig := &mcfgv1.MachineConfig{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machineConfig.ObjectMeta.Name}, currentMachineConfig)
-			if err != nil {
-				r.Log.Info("Error getting machineConfig", "mc", machineConfig.Name, "err", err)
-				return err
-			}
-			machineConfig.ObjectMeta.ResourceVersion = currentMachineConfig.ObjectMeta.ResourceVersion
-			err = r.Client.Update(context.TODO(), machineConfig)
-			if err != nil {
-				r.Log.Info("Error updating machineConfig", "mc", machineConfig.Name, "err", err)
-				return err
-			}
-			return nil
-		} else {
-			return err
-		}
-	}
-	return nil
-}
-
 func (r *KataConfigOpenShiftReconciler) checkDeletionEligibility() (ctrl.Result, error) {
 	if contains(r.kataConfig.GetFinalizers(), kataConfigFinalizer) {
 		// Get the list of pods that might be running using kata runtime

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -327,7 +327,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	}
 
 	// Create runtimeClass config for peer-pods
-	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead, "", peerpodsRuntimeClassName, "")
+	err = r.createRuntimeClass(peerpodsRuntimeClassName, peerpodsRuntimeClassCpuOverhead, peerpodsRuntimeClassMemOverhead, "", peerpodsRuntimeClassName, nil)
 	if err != nil {
 		r.Log.Info("Error in creating kata remote runtimeclass", "err", err)
 		return err


### PR DESCRIPTION
Closes: [KATA-4613](https://issues.redhat.com/browse/KATA-4613) and [KATA-4614](https://issues.redhat.com/browse/KATA-4614)

**- Description of the problem which is fixed/What is the use case**
TBD

**- What I did**
Introduce runtime class support for NVIDIA GPUs in both confidential and non-confidential baremetal deployments
 - Add `kata-nvidia-gpu` runtime class for standard GPU workloads
  - Add `kata-cc-nvidia-gpu` runtime class for confidential GPU workloads (Intel TDX and AMD SNP)
  - Refactor TEE handler detection to only guess TEE platform
  - Update createRuntimeClass to accept label maps for node scheduling
  - Update `createRuntimeClass()` for conditional runtime class creation

**- How to verify it**
TBD

**- Description for the changelog**
Introduce runtime class support for NVIDIA GPUs in both confidential and non-confidential baremetal deployment