### PR TITLE
daemonset deployment: Remove deprecated steps

### DIFF
--- a/scripts/kata-install/Dockerfile
+++ b/scripts/kata-install/Dockerfile
@@ -1,9 +1,5 @@
 FROM registry.access.redhat.com/ubi9/skopeo:9.7-1771375769
 
-RUN mkdir -p /files
-
-ADD 50-kata-remote configuration-remote.toml /files/
-
 RUN mkdir -p /scripts
 
 ADD osc-kata-install.sh osc-log-level.sh lib.sh osc-kata-addons-install.sh /scripts/


### PR DESCRIPTION
Following the bump of OSC to 1.12 across the repo, I had to fix the Dockerfile in order to create a new osc-daemonset image.


