### PR TITLE
tests/osc-test-fbc-integration: remove OCP 4.17 jobs

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -39,39 +39,6 @@ spec:
               catalogImage=$(jq -r '.components[] | select(.name=="osc-test-fbc") | .containerImage' <<< "${SNAPSHOT}")
               echo "Catalog image: ${catalogImage}"
               echo -n "${catalogImage}" > $(results.CATALOG_IMAGE.path)
-    - name: prowjob-ocp417
-      displayName: "Running prow job $(params.PROWJOB_NAME)"
-      timeout: "4h"
-      runAfter:
-        - get-catalog-image
-      taskRef:
-        resolver: git
-        params:
-        - name: url
-          value: https://github.com/openshift/konflux-tasks
-        - name: revision
-          value: 4826f365057d22d0189fa0db00d953c151f90c77
-        - name: pathInRepo
-          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
-        - name: VARIANT
-          value: downstream-candidate417
-        - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),EXPECTED_OPERATOR_VERSION=1.12.0,FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.17.el9"
-        - name: RETRY_DELAY
-          value: "60"
-        - name: MAX_RETRIES
-          value: "5"
-      matrix:
-        params:
-          - name: PROWJOB_NAME
-            value:
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-azure-ipi-kata
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-azure-ipi-peerpods
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-aro-ipi-peerpods
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate417-aws-ipi-peerpods
     - name: prowjob-ocp418
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       timeout: "4h"


### PR DESCRIPTION
For the upcoming OSC 1.12 release the support for OCP 4.17 is dropped so that we don't need to test on that version.
