### PR TITLE
tests/osc-test-fbc-integration: do not run the pipeline on push

### DIFF
--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -10,8 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel" &&
       ( "fbc/test-fbc/***".pathChanged() ||
         "fbc/render.sh".pathChanged() ||
-        ".tekton/osc-test-fbc-push.yaml".pathChanged() ||
-        "tests/osc-test-fbc-integration.yaml".pathChanged()
+        ".tekton/osc-test-fbc-push.yaml".pathChanged()
       )
   creationTimestamp:
   labels:


### PR DESCRIPTION
Avoid triggering the prowjobs when the pipeline definition (tests/osc-test-fbc-integration.yaml) only changed and was pushed because it is waste of resources.

The .tekton/osc-test-fbc-pull-request.yaml is still configured to trigger osc-test-fbc-integration pipeline when its own definition changed, but rather on pull_request. This way we still can test changes on the osc-test-fbc-integration pipeline at pull_request time.

To make it clear: any changes on the catalog (test-fbc) that are pushed will still be triggering the osc-test-fbc-integration pipeline.