### PR TITLE
cache: Only cache required objects to prevent OOM

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,6 +36,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -105,6 +106,24 @@ func main() {
 		},
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "290f4947.kataconfiguration.openshift.io",
+		// The controller runtime can end up caching all objects in the cluster and cause OOM.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					// Restrict caching to namespaces where we access secrets
+					Namespaces: map[string]cache.Config{
+						controllers.OperatorNamespace: {},
+						"openshift-config":            {}, // for global pull-secrets
+					},
+				},
+				&corev1.ConfigMap{}: {
+					// Same for config maps
+					Namespaces: map[string]cache.Config{
+						controllers.OperatorNamespace: {},
+					},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/controllers/ppwebhook.go
+++ b/controllers/ppwebhook.go
@@ -270,7 +270,7 @@ func (r *KataConfigOpenShiftReconciler) createMutatingWebhookConfig() error {
 	// Add list of namespaces to exclude
 	namespacesToExclude := []string{
 		"peer-pods-webhook-system",
-		"openshift-sandboxed-containers-operator",
+		OperatorNamespace,
 		"openshift",
 		"openshift-apiserver",
 		"openshift-apiserver-operator",

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -35,6 +35,6 @@ func GetScc() *secv1.SecurityContextConstraints {
 			Type: secv1.SELinuxStrategyRunAsAny,
 		},
 		Volumes: []secv1.FSType{secv1.FSTypeAll},
-		Users:   []string{"system:serviceaccount:openshift-sandboxed-containers-operator:monitor"},
+		Users:   []string{"system:serviceaccount:" + OperatorNamespace + ":monitor"},
 	}
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -156,7 +156,7 @@ func getPeerPodsSecret(c client.Client) (*corev1.Secret, error) {
 
 	err := c.Get(context.TODO(), types.NamespacedName{
 		Name:      peerPodsSecretName,
-		Namespace: "openshift-sandboxed-containers-operator",
+		Namespace: OperatorNamespace,
 	}, peerPodsSecret)
 
 	if err != nil {


### PR DESCRIPTION
The operator accesses a variety of object types. The controller runtime
caches all objects of all types in RAM by default. Some types may have
too many instances, causing the cache to inflate until OOM. The way to
go is to fine tune the cache so that it only keeps objects that the
operator actually needs.

Good first candidates for that are secrets and config maps. Let's
scope the cache to namespaces where we access any of these.

A full review of the operator code is needed if we want to find
other candidates.

First commit is just because I spotted the literal string when looking for secrets in the code.

OOM Reproducer :

- run the following script

```
#!/bin/bash

#
# Create 1000 secrets with a 100KB payload. Controller will need ~400MB to
# 600MB of heap to cache them all.
#
SECRET_COUNT=1000
PREFIX="dummy-secret"

# Create a 100KB payload string
PAYLOAD=$(head -c 102400 /dev/urandom | base64 | head -c 102400)

echo "Deploying $SECRET_COUNT secrets (100KB each)..."

for i in $(seq 1 $SECRET_COUNT); do
  kubectl create secret generic "$PREFIX-$i" \
    --from-literal=payload="$PAYLOAD" \
    --namespace=default \
    --dry-run=client -o yaml | kubectl apply -f -

  if [ $((i % 100)) -eq 0 ]; then
    echo "Sent $i/1000 secrets..."
  fi
done
```

- install latest OSC

Assisted by gemini to find the root cause and to come up with a reproducer script.