### PR TITLE
RFC: runtime class: Unified kata-cc runtime class support

### DIFF
--- a/api/v1/kataconfig_types.go
+++ b/api/v1/kataconfig_types.go
@@ -44,6 +44,14 @@ type KataConfigSpec struct {
 	// +optional
 	// +kubebuilder:default:=false
 	EnablePeerPods bool `json:"enablePeerPods"`
+
+	// UnifiedKataCCHandler enables a single kata-cc handler that maps to TDX, SNP, or IBM SE
+	// per node. When true, the operator creates per-TEE MachineConfigs (CRI-O drop-ins) and
+	// MachineConfigPools, allowing the same kata-cc RuntimeClass to work across heterogeneous
+	// TEE hardware. Requires NFD to label nodes with TEE capabilities.
+	// +optional
+	// +kubebuilder:default:=false
+	UnifiedKataCCHandler bool `json:"unifiedKataCCHandler"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig

--- a/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/config/crd/bases/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -124,6 +124,14 @@ spec:
                 description: Sets log level on kata-equipped nodes.  Valid values
                   are the same as for `crio --log-level`.
                 type: string
+              unifiedKataCCHandler:
+                default: false
+                description: |-
+                  UnifiedKataCCHandler enables a single kata-cc handler that maps to TDX, SNP, or IBM SE
+                  per node. When true, the operator creates per-TEE MachineConfigs (CRI-O drop-ins) and
+                  MachineConfigPools, allowing the same kata-cc RuntimeClass to work across heterogeneous
+                  TEE hardware. Requires NFD to label nodes with TEE capabilities.
+                type: boolean
             required:
             - checkNodeEligibility
             type: object

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -6,7 +6,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 )
 
 const (
@@ -20,10 +23,13 @@ const (
 	amdSNPNodeLabel   = "amd.feature.node.kubernetes.io/snp"
 	ibmSENodeLabel    = "ibm.feature.node.kubernetes.io/se"
 
-	// RuntimeClass handlers for TEE
+	// RuntimeClass handlers for TEE (legacy single-TEE mode)
 	kataCCIntelHandler = "kata-tdx"
 	kataCCAmdHandler   = "kata-snp"
 	kataCCIbmHandler   = "kata-se"
+
+	// Unified handler for heterogeneous TEE clusters
+	kataCCUnifiedHandler = "kata-cc"
 
 	// Extended resources for TEE
 	intelTDXExtendedResource = "tdx.intel.com/keys"
@@ -123,6 +129,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 
 // handleConfidentialBaremetal configures confidential computing for baremetal deployments.
 // It manages kata-cc runtime classes with TEE-specific handlers (Intel TDX, AMD SNP or IBM SE).
+// When UnifiedKataCCHandler is true, a single kata-cc handler maps to per-node CRI-O configs.
 func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state FeatureGateState) error {
 	if state == Enabled {
 		if !r.kataConfig.Spec.EnablePeerPods {
@@ -143,35 +150,28 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 
 		r.Log.Info("Creating " + kataCCRuntimeClassName + " runtime class for confidential containers")
 
-		handler, nodeLabel, err := r.computeTEEHandlerAndLabel()
-		if err != nil {
-			// If peer pods is enabled, just warn and skip baremetal coco
-			if r.kataConfig.Spec.EnablePeerPods {
-				r.Log.Info("WARNING: No TEE hardware detected, skipping baremetal confidential containers (peer pods CVM will handle confidential workloads)", "err", err)
-				return nil
+		if r.kataConfig.Spec.UnifiedKataCCHandler {
+			// Unified mode: single kata-cc handler, per-TEE CRI-O configs and MCPs
+			if err := r.handleConfidentialBaremetalUnified(); err != nil {
+				return err
 			}
-			// If peer pods disabled, this is an error - user wants baremetal coco but no hardware
-			r.Log.Info("failed to detect TEE platform", "err", err)
-			return err
-		}
-
-		// Determine extended resource based on TEE type
-		var kataCCRuntimeClassExtResOverhead string
-		if handler == kataCCIntelHandler {
-			kataCCRuntimeClassExtResOverhead = intelTDXExtendedResource
-		} else if handler == kataCCAmdHandler {
-			kataCCRuntimeClassExtResOverhead = amdSNPExtendedResource
-		}
-
-		// Create kata-cc runtime class restricted to the detected TEE subset
-		err = r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, nodeLabel)
-		if err != nil {
-			r.Log.Info("Error creating "+kataCCRuntimeClassName+" runtime class", "err", err)
-			return fmt.Errorf("Error creating "+kataCCRuntimeClassName+" runtime class: %w", err)
+		} else {
+			// Legacy mode: single TEE type, TEE-specific handler
+			if err := r.handleConfidentialBaremetalLegacy(); err != nil {
+				return err
+			}
 		}
 
 	} else {
 		r.Log.Info("Deleting " + kataCCRuntimeClassName + " runtime class for confidential containers")
+
+		// Clean up TEE-specific MCs and MCPs (idempotent)
+		for _, tee := range []string{"tdx", "snp", "se"} {
+			if err := r.deleteTEEPoolAndMC(tee); err != nil {
+				r.Log.Info("Error cleaning up TEE resources", "tee", tee, "err", err)
+				// Continue with other TEEs
+			}
+		}
 
 		// Delete kata-cc runtime class
 		err := r.deleteRuntimeClass(kataCCRuntimeClassName)
@@ -182,6 +182,114 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 	}
 
 	return nil
+}
+
+// handleConfidentialBaremetalUnified implements unified kata-cc: single handler, per-TEE CRI-O configs.
+func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetalUnified() error {
+	teeTypes, err := r.getPresentTEETypes()
+	if err != nil {
+		if r.kataConfig.Spec.EnablePeerPods {
+			r.Log.Info("WARNING: No TEE hardware detected, skipping baremetal confidential containers", "err", err)
+			return nil
+		}
+		return err
+	}
+	if len(teeTypes) == 0 {
+		if r.kataConfig.Spec.EnablePeerPods {
+			r.Log.Info("WARNING: No TEE hardware detected, skipping baremetal confidential containers")
+			return nil
+		}
+		return fmt.Errorf("no TEE platform labels found (expected %s, %s or %s)", intelTDXNodeLabel, amdSNPNodeLabel, ibmSENodeLabel)
+	}
+
+	// TEE type -> (node label, kata config path)
+	teeConfig := map[string]struct{ label, configPath string }{
+		"tdx": {intelTDXNodeLabel, "/etc/kata-containers/kata-tdx/configuration.toml"},
+		"snp": {amdSNPNodeLabel, "/etc/kata-containers/kata-snp/configuration.toml"},
+		"se":  {ibmSENodeLabel, "/etc/kata-containers/kata-se/configuration.toml"},
+	}
+
+	for _, tee := range teeTypes {
+		cfg, ok := teeConfig[tee]
+		if !ok {
+			continue
+		}
+		mcRole := kataCCTEEMCPPrefix + tee
+		mc, err := r.createKataCCCRIODropInMC(tee, cfg.configPath, mcRole)
+		if err != nil {
+			return fmt.Errorf("failed to create kata-cc CRI-O MachineConfig for %s: %w", tee, err)
+		}
+		found := &mcfgv1.MachineConfig{}
+		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, found); err != nil {
+			if k8serrors.IsNotFound(err) {
+				if err := r.Client.Create(context.TODO(), mc); err != nil {
+					return fmt.Errorf("failed to create MachineConfig %s: %w", mc.Name, err)
+				}
+				r.Log.Info("Created kata-cc CRI-O MachineConfig", "tee", tee, "mc", mc.Name)
+			} else {
+				return err
+			}
+		}
+		if err := r.createOrUpdateTEEPool(tee, cfg.label); err != nil {
+			return fmt.Errorf("failed to create/update TEE pool for %s: %w", tee, err)
+		}
+	}
+
+	// Create RuntimeClass with unified handler, no TEE-specific node selector, no extended resources
+	return r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, "", kataCCUnifiedHandler, "")
+}
+
+// handleConfidentialBaremetalLegacy implements legacy single-TEE mode.
+func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetalLegacy() error {
+	handler, nodeLabel, err := r.computeTEEHandlerAndLabel()
+	if err != nil {
+		if r.kataConfig.Spec.EnablePeerPods {
+			r.Log.Info("WARNING: No TEE hardware detected, skipping baremetal confidential containers (peer pods CVM will handle confidential workloads)", "err", err)
+			return nil
+		}
+		r.Log.Info("failed to detect TEE platform", "err", err)
+		return err
+	}
+
+	var kataCCRuntimeClassExtResOverhead string
+	if handler == kataCCIntelHandler {
+		kataCCRuntimeClassExtResOverhead = intelTDXExtendedResource
+	} else if handler == kataCCAmdHandler {
+		kataCCRuntimeClassExtResOverhead = amdSNPExtendedResource
+	}
+
+	return r.createRuntimeClass(kataCCRuntimeClassName, kataCCRuntimeClassCpuOverhead, kataCCRuntimeClassMemOverhead, kataCCRuntimeClassExtResOverhead, handler, nodeLabel)
+}
+
+// getPresentTEETypes returns the list of TEE types present on nodes matching KataConfigPoolSelector.
+func (r *KataConfigOpenShiftReconciler) getPresentTEETypes() ([]string, error) {
+	selector, err := r.getKataConfigNodeSelectorAsSelector()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build node selector: %w", err)
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := r.Client.List(context.TODO(), nodes, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var tees []string
+	seen := map[string]bool{}
+	for _, n := range nodes.Items {
+		if v, ok := n.Labels[intelTDXNodeLabel]; ok && v == "true" && !seen["tdx"] {
+			tees = append(tees, "tdx")
+			seen["tdx"] = true
+		}
+		if v, ok := n.Labels[amdSNPNodeLabel]; ok && v == "true" && !seen["snp"] {
+			tees = append(tees, "snp")
+			seen["snp"] = true
+		}
+		if v, ok := n.Labels[ibmSENodeLabel]; ok && v == "true" && !seen["se"] {
+			tees = append(tees, "se")
+			seen["se"] = true
+		}
+	}
+	return tees, nil
 }
 
 func (r *KataConfigOpenShiftReconciler) computeTEEHandlerAndLabel() (string, string, error) {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -544,6 +544,171 @@ func (r *KataConfigOpenShiftReconciler) newMCPforCR() *mcfgv1.MachineConfigPool 
 	return mcp
 }
 
+// kata-cc CRI-O drop-in MachineConfig names and paths for unified handler mode
+const (
+	kataCCCRIODropInPath = "/etc/crio/crio.conf.d/99-kata-cc.conf"
+	kataCCCRIOMCPrefix   = "99-kata-cc-"
+	kataCCTEEMCPPrefix   = "kata-oc-"
+)
+
+// createKataCCCRIODropInMC creates a MachineConfig that adds the kata-cc CRI-O handler
+// with the given Kata config path, targeted to the specified MCP role.
+func (r *KataConfigOpenShiftReconciler) createKataCCCRIODropInMC(tee, kataConfigPath, mcRole string) (*mcfgv1.MachineConfig, error) {
+	crioConfig := fmt.Sprintf(`[crio.runtime.runtimes.kata-cc]
+runtime_path = "/usr/bin/kata-runtime"
+runtime_type = "vm"
+runtime_args = ["--kata-config=%s"]
+`, kataConfigPath)
+
+	encodedContent := base64.StdEncoding.EncodeToString([]byte(crioConfig))
+
+	ic := ignTypes.Config{
+		Ignition: ignTypes.Ignition{
+			Version: "3.2.0",
+		},
+		Storage: ignTypes.Storage{
+			Files: []ignTypes.File{
+				{
+					Node: ignTypes.Node{
+						Path:      kataCCCRIODropInPath,
+						Overwrite: ptrToBool(true),
+					},
+					FileEmbedded1: ignTypes.FileEmbedded1{
+						Contents: ignTypes.Resource{
+							Source: ptrToString("data:text/plain;charset=utf-8;base64," + encodedContent),
+						},
+						Mode: ptrToInt(0644),
+					},
+				},
+			},
+		},
+	}
+
+	icb, err := json.Marshal(ic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ignition config: %w", err)
+	}
+
+	mcName := kataCCCRIOMCPrefix + tee
+	mc := &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcName,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": mcRole,
+				"app":                                    r.kataConfig.Name,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: runtime.RawExtension{Raw: icb},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.kataConfig, mc, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return mc, nil
+}
+
+func ptrToBool(b bool) *bool       { return &b }
+func ptrToInt(i int) *int          { return &i }
+func ptrToString(s string) *string { return &s }
+
+// createOrUpdateTEEPool creates or updates a MachineConfigPool for the given TEE type.
+// The MCP selects nodes that match KataConfigPoolSelector AND have the TEE label.
+func (r *KataConfigOpenShiftReconciler) createOrUpdateTEEPool(tee, teeNodeLabel string) error {
+	mcpName := kataCCTEEMCPPrefix + tee
+	mcRole := kataCCTEEMCPPrefix + tee
+
+	nodeSelector := r.getKataConfigNodeSelectorAsLabelSelector().DeepCopy()
+	nodeSelector = metav1.AddLabelToSelector(nodeSelector, teeNodeLabel, "true")
+
+	lsr := metav1.LabelSelectorRequirement{
+		Key:      "machineconfiguration.openshift.io/role",
+		Operator: metav1.LabelSelectorOpIn,
+		Values:   []string{"worker", "kata-oc", mcRole},
+	}
+
+	mcp := &mcfgv1.MachineConfigPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfigPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcpName,
+			Labels: map[string]string{
+				"pools.operator.machineconfiguration.openshift.io/" + mcpName: "",
+			},
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{lsr},
+			},
+			NodeSelector: nodeSelector,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.kataConfig, mcp, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &mcfgv1.MachineConfigPool{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, found)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("Creating TEE MachineConfigPool", "mcp", mcpName, "tee", tee)
+			return r.Client.Create(context.TODO(), mcp)
+		}
+		return err
+	}
+
+	if reflect.DeepEqual(found.Spec, mcp.Spec) {
+		return nil
+	}
+
+	found.Spec = mcp.Spec
+	r.Log.Info("Updating TEE MachineConfigPool", "mcp", mcpName, "tee", tee)
+	return r.Client.Update(context.TODO(), found)
+}
+
+// deleteTEEPoolAndMC deletes the MachineConfigPool and MachineConfig for the given TEE type.
+func (r *KataConfigOpenShiftReconciler) deleteTEEPoolAndMC(tee string) error {
+	mcpName := kataCCTEEMCPPrefix + tee
+	mcName := kataCCCRIOMCPrefix + tee
+
+	mcp := &mcfgv1.MachineConfigPool{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		if err := r.Client.Delete(context.TODO(), mcp); err != nil && !k8serrors.IsNotFound(err) {
+			r.Log.Info("Error deleting TEE MachineConfigPool", "mcp", mcpName, "err", err)
+			return err
+		}
+		r.Log.Info("Deleted TEE MachineConfigPool", "mcp", mcpName)
+	}
+
+	mc := &mcfgv1.MachineConfig{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcName}, mc); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		if err := r.Client.Delete(context.TODO(), mc); err != nil && !k8serrors.IsNotFound(err) {
+			r.Log.Info("Error deleting kata-cc CRI-O MachineConfig", "mc", mcName, "err", err)
+			return err
+		}
+		r.Log.Info("Deleted kata-cc CRI-O MachineConfig", "mc", mcName)
+	}
+
+	return nil
+}
+
 func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 	// RHCOS uses "sandboxed-containers" as thats resolved/translated in the machine-config-operator to "kata-containers"
 	// FCOS/SCOS however does not get any translation in the machine-config-operator so we need to


### PR DESCRIPTION
Raw implementation of a unified Kata CC handler that dispatches
differently for Intel TDX, AMD SEV-SNP and IBM SE runtime classes.

Here is the AI-generated description of the solution:

It is possible to achieve this in OpenShift by leveraging Kubernetes
RuntimeClass along with per-node CRI-O configurations. The key is to
use a single cluster-wide RuntimeClass (e.g., named "kata-cc") that
references a consistent handler name (e.g., "kata-cc"). Then,
customize the CRI-O runtime definition for that handler on different
node pools based on their labels/hardware types (TDX, SEV-SNP, IBM
SE).

Step-by-Step Approach
=====================

1. **Define a Single RuntimeClass**:
   - Create a RuntimeClass resource with the handler set to
     "kata-cc". This is a cluster-wide object, so all pods referencing
     this class will use the same handler name.
   - Include pod overhead to account for virtualization costs (adjust
     based on your setup).
   - Optionally, add scheduling constraints like node selectors or
     tolerations if needed, but for flexibility across node types, keep
     it general.
   - Example YAML:
     ```
     apiVersion: node.k8s.io/v1
     kind: RuntimeClass
     metadata:
       name: kata-cc
     handler: kata-cc
     overhead:
       podFixed:
         cpu: "250m"
         memory: "160Mi"
     ```

2. **Configure CRI-O Per Node Pool**:
   - In OpenShift, CRI-O configurations are managed via MachineConfig
     resources, which can be applied selectively to
     MachineConfigPools (MCPs) based on node labels.
   - For each node type (e.g., TDX, SEV-SNP, IBM SE), create a separate
     MachineConfig that defines the "kata-cc" runtime handler in CRI-O's drop-in
     config (e.g., `/etc/crio/crio.conf.d/99-kata-cc.conf`).
   - Use the same handler name ("kata-cc") but point it to Kata's runtime binary
     (`kata-runtime`) with a hardware-specific configuration file via
     `runtime_args`. Kata supports multiple config files (e.g.,
     `/usr/share/defaults/kata-containers/configuration-tdx.toml`) to enable
     features like TDX, SEV-SNP, or IBM SE.
   - Ensure the appropriate Kata configuration files are deployed to the nodes
     (this can also be done via MachineConfig).
   - Example MachineConfig for TDX nodes (label: `hardware=tdx`):
     ```
     apiVersion: machineconfiguration.openshift.io/v1
     kind: MachineConfig
     metadata:
       labels:
         machineconfiguration.openshift.io/role: worker-tdx  # Targets MCP for TDX nodes
       name: 99-worker-tdx-kata-cc
     spec:
       config:
         ignition:
           version: 3.2.0
         storage:
           files:
             - contents:
                 source: data:text/plain;charset=utf-8;base64,<base64-encoded CRI-O config>
               mode: 0644
               path: /etc/crio/crio.conf.d/99-kata-cc.conf
               overwrite: true
     ```
   - Encoded CRI-O config content for TDX (adjust paths as needed):
     ```
     [crio.runtime.runtimes.kata-cc]
     runtime_path = "/usr/bin/kata-runtime"
     runtime_type = "vm"
     runtime_args = ["--kata-config=/usr/share/defaults/kata-containers/configuration-tdx.toml"]
     ```
   - For SEV-SNP nodes (label: `hardware=sev-snp`):
     Use a similar MachineConfig but with `configuration-snp.toml` in
     `runtime_args`.
   - For IBM SE nodes (label: `hardware=ibm-se`):
     Use `configuration-se.toml` in `runtime_args`.

3. **Create MachineConfigPools for Node Types**:
   - Define MCPs to group nodes by labels and apply the corresponding
     MachineConfigs.
   - Example for TDX:
     ```
     apiVersion: machineconfiguration.openshift.io/v1
     kind: MachineConfigPool
     metadata:
       name: worker-tdx
     spec:
       machineConfigSelector:
         matchLabels:
           machineconfiguration.openshift.io/role: worker-tdx
       nodeSelector:
         matchLabels:
           hardware: tdx  # Your node label
     ```
   - Repeat for other node types. Applying these will trigger node reboots to
     update CRI-O configs.

4. **Schedule Pods to Appropriate Nodes**:
   - In your pod or deployment specs, reference the RuntimeClass:
     `spec.runtimeClassName: kata-cc`.
   - Use node affinity or selectors to ensure pods land on the correct hardware
     nodes (e.g., via `nodeAffinity` in the pod spec matching `hardware=tdx`).
   - Example pod snippet:
     ```
     spec:
       runtimeClassName: kata-cc
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: hardware
                     operator: In
                     values:
                       - tdx
     ```
   - If you need automatic distribution, consider using a custom scheduler or
     operator to handle affinity based on workload requirements.

- **Homogeneous vs. Heterogeneous Clusters**: This works best in heterogeneous
  clusters where nodes are labeled by hardware type. The OpenShift sandboxed
  containers Operator (for Kata) typically assumes homogeneous setups and
  creates hardware-specific RuntimeClasses/handlers (e.g., "kata-tdx",
  "kata-snp"). For a single RuntimeClass across mixed nodes, you'll need manual
  CRI-O tweaks as described, bypassing some Operator automation.
- **Kata Configuration Files**: Ensure hardware-specific Kata configs are
  present on nodes (e.g., via MachineConfig or the Operator). These enable
  TDX/SEV-SNP/SE features in the VM hypervisor (e.g., QEMU with TDX support).
- **Reboots and Downtime**: MachineConfigs cause node drains and reboots. Plan
  for this in production.
- **Testing**: Verify with `oc get runtimeclass` and `oc describe node` to check
  labels. Run test pods and inspect CRI-O logs (`oc debug node/<node> -- chroot
  /host journalctl -u crio`) to confirm the correct config is used.
- **Limitations**: If hardware requires fundamentally different runtime binaries
  (not just configs), this won't work—fall back to multiple
  RuntimeClasses. Based on Kata docs, config files handle most TEE differences.

This setup allows the same "kata-cc" RuntimeClass to effectively "map"
to different behaviors via per-node CRI-O customizations.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
