### PR TITLE
claude: add osc-user-guide skill for OSC documentation access

### DIFF
--- a/.claude/skills/osc-user-guide/.gitignore
+++ b/.claude/skills/osc-user-guide/.gitignore
@@ -1,0 +1,3 @@
+# Downloaded documentation (stored in per-version subdirectories, e.g. 1.12/*.pdf)
+*.pdf
+[0-9]*/

--- a/.claude/skills/osc-user-guide/SKILL.md
+++ b/.claude/skills/osc-user-guide/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: osc-user-guide
+description: Provides comprehensive guidance on OpenShift Sandboxed Containers (OSC) by reading official Red Hat documentation. Use when questions involve OSC installation, KataConfig configuration, node setup, bare-metal or cloud deployments, PeerPods, confidential containers, TEE, Trustee, attestation, or troubleshooting.
+---
+
+# OSC User Guide Reader
+
+When this skill is triggered, follow these steps to answer the user's question using the official OSC documentation:
+
+## Instructions for Claude
+
+1. **Determine the OSC version** to use:
+
+   - If the user mentions a specific version (e.g., "with OSC 1.11"), use that version.
+   - Otherwise, determine the latest version using the WebFetch tool:
+   ```text
+   WebFetch(url='https://docs.redhat.com/en/documentation/openshift_sandboxed_containers',
+            prompt='What is the latest version of OpenShift Sandboxed Containers documentation? Return only the version number (e.g., 1.12)')
+   ```
+
+2. **Download PDFs** using the Bash tool with the version:
+   ```bash
+   bash .claude/skills/osc-user-guide/download-pdfs.sh <version>
+   ```
+
+   For example, if the version is 1.12:
+   ```bash
+   bash .claude/skills/osc-user-guide/download-pdfs.sh 1.12
+   ```
+
+   This script will:
+   - Dynamically discover all available guides from the Red Hat docs site
+   - Download PDFs into a per-version subdirectory (e.g., `.claude/skills/osc-user-guide/1.12/`)
+   - Skip already-cached files
+   - Works with any version — no hardcoded guide lists
+   - No dependencies required (just curl or wget)
+
+3. **Read the relevant PDF(s)** using Claude's built-in Read tool:
+
+   The download script output will show the directory where PDFs are stored.
+   Use the Read tool to access the documentation.
+
+   **How to read PDFs:**
+   - Use the Read tool with the `pages` parameter
+   - Maximum 20 pages per Read call
+   - Example: `Read(file_path='.claude/skills/osc-user-guide/1.12/<filename>.pdf', pages='1-20')`
+
+   **Reading strategy:**
+   - First, read the table of contents (typically pages 1-5) to understand the PDF structure
+   - Then read only the specific pages relevant to the user's question
+   - This is more efficient than reading the entire PDF
+   - If needed, read additional PDFs using the same TOC-first approach
+
+   **Guide selection — choose based on the user's question:**
+
+   The download script discovers all available guides automatically. PDF filenames
+   indicate their topic, e.g. `...-Deploying_confidential_containers_on_bare-metal_servers-en-US.pdf`.
+
+   Guides fall into three categories:
+   - **Deploying OpenShift Sandboxed Containers** — Operator install, KataConfig, kata runtime, peer pods
+   - **Deploying Confidential Containers** — CoCo, TEE, kata-cc/kata-remote, initdata, attestation
+   - **Deploying Red Hat Build of Trustee** — Trustee/KBS, attestation tokens, secrets
+
+   Each category may have per-platform variants (bare-metal, Azure, AWS, IBM Z, etc.).
+   Pick the guide matching the user's platform. If the user doesn't specify a platform, default to bare-metal.
+   If unsure which guide, read the most relevant one first — it's usually enough.
+
+4. **Answer the question comprehensively:**
+   - Provide a direct answer to the user's question
+   - Include step-by-step instructions when applicable
+   - Show code examples and YAML configurations
+   - List prerequisites and requirements
+   - Cite which guide(s) and page numbers the information comes from
+   - Mention related topics the user should know about
+
+## How This Skill Works
+
+This skill is **automatically triggered** by Claude when you ask questions about OpenShift Sandboxed Containers. You don't need to explicitly invoke it - just ask your question naturally.
+
+When triggered, the skill:
+1. Determines the OSC version (from user's question or latest available)
+2. Dynamically discovers and downloads PDFs for that version (first run only, cached afterward)
+3. Claude reads the table of contents first, then the relevant pages
+4. Claude provides a comprehensive answer with examples and citations
+
+Multiple versions can coexist — each version's PDFs are stored in their own subdirectory.
+
+## Example Questions That Trigger This Skill
+
+Ask questions naturally - the skill will activate automatically:
+
+**General deployment:**
+- "How do I install the OSC operator?"
+- "Show me KataConfig configuration options"
+- "How do I deploy OSC on a subset of worker nodes?"
+- "What are the node eligibility requirements?"
+
+**Confidential containers:**
+- "How do I deploy confidential containers?"
+- "What hardware is required for TEE?"
+- "How does attestation work in confidential containers?"
+
+**Version-specific questions:**
+- "Why is my KataConfig failing with OSC 1.11?"
+- "What changed in OSC 1.12 for peer pods?"
+
+**Trustee:**
+- "How do I configure Red Hat build of Trustee?"
+- "How do I create attestation tokens?"
+- "What is the key broker service?"
+
+**Troubleshooting:**
+- "Why is my KataConfig failing?"
+- "How do I verify Kata runtime installation?"
+
+## Requirements
+
+- `curl` or `wget` for downloading PDFs
+- Internet connection (for initial download only)
+- Read access to .claude/skills directory
+
+## Setup for Team Members
+
+**No manual setup required!**
+
+The first time you run this skill:
+1. Detects the OSC documentation version (from user's question or latest available)
+2. Discovers and downloads all available PDF guides for that version from the Red Hat docs site
+
+On subsequent runs, it uses the cached PDFs. Different versions can be cached simultaneously.

--- a/.claude/skills/osc-user-guide/download-pdfs.sh
+++ b/.claude/skills/osc-user-guide/download-pdfs.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Download OSC User Guide PDFs by dynamically discovering them from the docs site.
+# Works with any version (1.11, 1.12+, future versions) without hardcoded guide lists.
+# PDFs are stored in per-version subdirectories (e.g. osc-user-guide/1.12/*.pdf).
+set -e
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+version="$1"
+if [ -z "${version}" ]; then
+	echo -e "ERROR: Missing version argument\nUse $0 <version>"
+	exit 1
+fi
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: Invalid version '${version}'. Expected format: X.Y (e.g., 1.12)"
+    exit 1
+fi
+
+version_dir="${skill_dir}/${version}"
+mkdir -p "${version_dir}"
+
+docs_base="https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/${version}"
+
+fetch_url() {
+    local url="$1"
+    if command -v curl &> /dev/null; then
+        curl --fail -sL "$url"
+    elif command -v wget &> /dev/null; then
+        wget -q -O- "$url"
+    else
+        echo "ERROR: Neither curl nor wget found." >&2
+        exit 1
+    fi
+}
+
+file_size_kb() {
+    local file="$1"
+    echo $(( $(stat -f%z "$file" 2>/dev/null || stat -c%s "$file") / 1024 ))
+}
+
+is_valid_pdf() {
+    local file="$1"
+    [ -f "$file" ] && [ "$(file_size_kb "$file")" -gt 1 ] && head -c 4 "$file" | grep -q '%PDF'
+}
+
+download_pdf() {
+    local pdf_url="$1"
+    local filename
+    filename=$(basename "$pdf_url")
+    local pdf_file="${version_dir}/${filename}"
+
+    # Check cache
+    if is_valid_pdf "$pdf_file"; then
+        echo "  [cached] ${filename} ($(file_size_kb "$pdf_file")KB)"
+        return 0
+    fi
+    rm -f "$pdf_file"
+
+    echo "  [downloading] ${filename}..."
+
+    if command -v curl &> /dev/null; then
+        curl --fail -sL "$pdf_url" -o "$pdf_file" || { echo "  [FAILED] ${filename} - download error"; rm -f "$pdf_file"; return 1; }
+    elif command -v wget &> /dev/null; then
+        wget -q "$pdf_url" -O "$pdf_file" || { echo "  [FAILED] ${filename} - download error"; rm -f "$pdf_file"; return 1; }
+    fi
+
+    if is_valid_pdf "$pdf_file"; then
+        echo "  [ok] ${filename} ($(file_size_kb "$pdf_file")KB)"
+    else
+        echo "  [FAILED] ${filename} - not a valid PDF, removing"
+        rm -f "$pdf_file"
+        return 1
+    fi
+}
+
+echo "OSC ${version} User Guide PDFs"
+echo "========================"
+echo
+
+# Step 1: Discover guide slugs from the version landing page
+echo "Discovering guides for version ${version}..."
+landing_page=$(fetch_url "${docs_base}") || {
+    echo "ERROR: Could not fetch docs landing page for version ${version}."
+    echo "Check that the version exists at: ${docs_base}"
+    exit 1
+}
+
+slugs=$(echo "$landing_page" | \
+    grep -oE "/en/documentation/openshift_sandboxed_containers/${version}/html/[^\"]+" | \
+    sed 's|.*/html/||' | sort -u)
+
+if [ -z "$slugs" ]; then
+    echo "ERROR: No guides found for version ${version}."
+    exit 1
+fi
+
+guide_count=$(echo "$slugs" | wc -l | tr -d ' ')
+echo "Found ${guide_count} guides."
+echo
+
+# Step 2: For each slug, discover the PDF URL from the guide's HTML page and download it
+for slug in $slugs; do
+    slug_page=$(fetch_url "${docs_base}/html/${slug}" 2>/dev/null) || {
+        echo "  [SKIP] ${slug} - could not fetch guide page"
+        continue
+    }
+    pdf_path=$(echo "$slug_page" | \
+        grep -oE "/en/documentation/openshift_sandboxed_containers/${version}/pdf/[^\"]+\.pdf" | \
+        head -1)
+
+    if [ -z "$pdf_path" ]; then
+        echo "  [SKIP] ${slug} - could not find PDF link"
+        continue
+    fi
+
+    download_pdf "https://docs.redhat.com${pdf_path}" || true
+done
+
+echo
+echo "Download complete. PDFs are in: ${version_dir}"


### PR DESCRIPTION
Supersedes: #1798 

**- Description of the problem which is fixed/What is the use case**

While developing or reviewing a PR, sometimes I need to get some information from the user guide of OSC.

For example, recently I was reviewing a PR about adding automation to tests. I wanted to check if the code was implementing the setup that was describe in our user guide; then I used the Claude skill I am proposing here to automatically and easily fetch the information needed to compare.

Claude would be capable of getting the OSC guide without this still, but maybe it would get an older version. Or maybe it would spend some cycles figuring out how to get and parse the content. This skill automates the process so that you don't need to teach claude over and over how to get the information.

**- What I did**

Adds a comprehensive Claude Code skill that provides access to all three OpenShift Sandboxed Containers documentation guides:
- Deploying Red Hat OpenShift Sandboxed Containers
- Deploying Confidential Containers
- Deploying Red Hat Build of Trustee

How it works:
1. Downloads PDF guides using a simple bash script (curl/wget)
2. Reads entire PDFs using built-in PDF reading capability
3. Provides a comprehensive answer with examples and citations

The skill automatically triggers when users ask questions about OSC installation, configuration, deployment, troubleshooting, PeerPods, confidential containers, TEE, or Trustee.

Assisted-by: Claude

**- How to verify it**

You can test that PR by:

*  pull & checkout it
*  launch claude
* Ask something like "What is the runtimeclass that I should use for Confidential Containers? Use the user guide" (you don't necessarily need to mention the user guide as it can infer -- look at the skill prompt that there are some conditions when the skill is triggered)

Example of output:

```
❯ What is the runtimeclass that I should use for Confidential Containers? Use the user guide. 

● I'll use the OSC user guide to find information about the runtimeclass for Confidential Containers.

❯ Tool loaded. 

● Skill(osc-user-guide)
  ⎿  Successfully loaded skill

● I'll help you find the runtimeclass for Confidential Containers by consulting the official OSC documentation.

❯ Tool loaded. 

● Fetch(https://docs.redhat.com/en/documentation/openshift_sandboxed_containers)
  ⎿  Received 289.8KB (200 OK)
                     
❯ Tool loaded.                 
                                                                                                                                                  
● Bash(bash .claude/skills/osc-user-guide/download-pdfs.sh 1.11)                                                                                  
  ⎿  OSC 1.11 User Guide PDFs                                                                                                                     
     ========================                                                                                                                     
     … +11 lines (ctrl+o to expand)                                                                                                               
                                                                                                                                                  
❯ Tool loaded.                                                                                                                                    
                                                           
● Read 1 file (ctrl+o to expand)                                                                                                                  
                                                                                                                  
● Based on the OSC 1.11 Confidential Containers deployment guide, the runtimeclass depends on your deployment type:                               
                                                                                                                                                  
  RuntimeClass for Confidential Containers                                                                                                        
                                                                                                                                                  
  For Bare Metal deployments:                                                                                                                     
  - kata-cc                                                                                                                                       
                                                                                                                                                  
  For Peer Pods (cloud) deployments:                                                                                                              
  - kata-remote

  Key Details

  From the documentation (pages 17-18, 35):

  1. kata-cc is installed as a runtime class when you create the KataConfig CR for bare metal confidential containers deployments (Intel TDX, AMD
  SEV-SNP, IBM SE)
  2. kata-remote is installed as a runtime class when you create the KataConfig CR for peer pods deployments on cloud platforms (Azure, IBM Z, IBM
   LinuxONE)

  Both are installed as secondary, optional runtimes on the cluster, not as the primary runtime.

  Example Pod Manifest

  To use confidential containers, specify the runtimeClassName in your pod spec:

  apiVersion: v1
  kind: Pod
  metadata:
    name: ocp-cc-pod
  spec:
    runtimeClassName: kata-cc  # or kata-remote for peer pods
    containers:
      - name: <container_name>
        image: registry.access.redhat.com/ubi9/ubi:latest

  Source: Deploying Confidential Containers guide, pages 17-18 (bare metal), page 35 (Azure peer pods)

✻ Cogitated for 3m 39s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Claude skill that fetches and caches official OpenShift Sandboxed Containers guides to provide step-by-step answers with examples, YAML snippets, prerequisites, and page-cited references.

* **Documentation**
  * Added skill documentation describing selection rules, caching behavior, runtime requirements, and response expectations.

* **Chores**
  * Added tooling to download/cache PDF guides and updated .gitignore to avoid tracking downloaded PDFs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->