### PR TITLE
go: fix golangci-lint errors

### DIFF
--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,0 +1,43 @@
+# Run static checkers on the Go sources of the project.
+---
+name: go-check
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yml'
+      - '.github/workflows/go-checks.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: true
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: 'go.sum'
+          cache: true
+      - name: Generate code
+        run: make generate
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.3
+

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.17.2 # this is overriden by our Dockerfile for container builds
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.0.2
+GOLANGCI_LINT_VERSION ?= v2.11.3
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: generate golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/api/v1/kataconfig_webhook.go
+++ b/api/v1/kataconfig_webhook.go
@@ -66,11 +66,11 @@ func (r *KataConfig) ValidateCreate(ctx context.Context, obj runtime.Object) (ad
 		client.InNamespace(corev1.NamespaceAll),
 	}
 	if err := clientInst.List(ctx, kataConfigList, listOpts...); err != nil {
-		return nil, fmt.Errorf("Failed to list KataConfig custom resources: %v", err)
+		return nil, fmt.Errorf("failed to list KataConfig custom resources: %v", err)
 	}
 
 	if len(kataConfigList.Items) == 1 {
-		return nil, fmt.Errorf("A KataConfig instance already exists, refusing to create a duplicate")
+		return nil, fmt.Errorf("a KataConfig instance already exists, refusing to create a duplicate")
 	}
 
 	return nil, nil

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -244,12 +244,12 @@ func labelNamespace(ctx context.Context, mgr manager.Manager) error {
 	}
 
 	setupLog.Info("Labelling Namespace")
-	setupLog.Info("Labels: ", "Labels", ns.ObjectMeta.Labels)
+	setupLog.Info("Labels: ", "Labels", ns.Labels)
 	// Add namespace label to align with newly introduced Pod Security Admission controller
-	ns.ObjectMeta.Labels["openshift.io/cluster-monitoring"] = "true"
-	ns.ObjectMeta.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
-	ns.ObjectMeta.Labels["pod-security.kubernetes.io/audit"] = "privileged"
-	ns.ObjectMeta.Labels["pod-security.kubernetes.io/warn"] = "privileged"
+	ns.Labels["openshift.io/cluster-monitoring"] = "true"
+	ns.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+	ns.Labels["pod-security.kubernetes.io/audit"] = "privileged"
+	ns.Labels["pod-security.kubernetes.io/warn"] = "privileged"
 
 	return mgr.GetClient().Update(ctx, ns)
 }

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -179,7 +179,7 @@ func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
 	if currentVersion == "" {
 		// FIXME: Look into having a single util function to return the ClusterVersion
 		clusterVersion := &configv1.ClusterVersion{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+		err := r.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 		if err != nil {
 			return false, err
 		}
@@ -367,7 +367,7 @@ func (r *KataConfigOpenShiftReconciler) computeTEE() (hasIntelTDX, hasAmdSNP, ha
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: selector},
 	}
-	if err = r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+	if err = r.List(context.TODO(), nodes, listOpts...); err != nil {
 		err = fmt.Errorf("failed to list nodes: %w", err)
 		return
 	}

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -340,7 +340,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 		err := r.deleteRuntimeClass(kataCCRuntimeClassName)
 		if err != nil {
 			r.Log.Info("Error deleting "+kataCCRuntimeClassName+" runtime class", "err", err)
-			return fmt.Errorf("Error deleting "+kataCCRuntimeClassName+" runtime class: %w", err)
+			return fmt.Errorf("error deleting "+kataCCRuntimeClassName+" runtime class: %w", err)
 		}
 
 		r.Log.Info("Deleting " + kataNvidiaGPUCCRuntimeClassName + " runtime class for confidential containers")
@@ -349,7 +349,7 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 		err = r.deleteRuntimeClass(kataNvidiaGPUCCRuntimeClassName)
 		if err != nil {
 			r.Log.Info("Error deleting "+kataNvidiaGPUCCRuntimeClassName+" runtime class", "err", err)
-			return fmt.Errorf("Error deleting "+kataNvidiaGPUCCRuntimeClassName+" runtime class: %w", err)
+			return fmt.Errorf("error deleting "+kataNvidiaGPUCCRuntimeClassName+" runtime class: %w", err)
 		}
 	}
 

--- a/controllers/confidential_handler_test.go
+++ b/controllers/confidential_handler_test.go
@@ -47,9 +47,9 @@ var _ = Describe("validateOCPVersion", func() {
 	AfterEach(func() {
 		// Restore original environment variable
 		if origEnv != "" {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", origEnv)
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", origEnv)).To(Succeed())
 		} else {
-			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+			Expect(os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")).To(Succeed())
 		}
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("validateOCPVersion", func() {
 		// Test cases for versions below minimum requirements
 		DescribeTable("should return false for versions below minimum",
 			func(version string) {
-				os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)
+				Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)).To(Succeed())
 				valid, err := reconciler.validateOCPVersion()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeFalse())
@@ -74,7 +74,7 @@ var _ = Describe("validateOCPVersion", func() {
 		// Test cases for versions at or above minimum requirements
 		DescribeTable("should return true for versions at or above minimum",
 			func(version string) {
-				os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)
+				Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)).To(Succeed())
 				valid, err := reconciler.validateOCPVersion()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(valid).To(BeTrue())
@@ -95,7 +95,7 @@ var _ = Describe("validateOCPVersion", func() {
 
 		// Test cases for invalid version formats
 		It("should return error for invalid version format", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "invalid-version")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "invalid-version")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).To(HaveOccurred())
 			Expect(valid).To(BeFalse())
@@ -103,14 +103,14 @@ var _ = Describe("validateOCPVersion", func() {
 		})
 
 		It("should return error for malformed version", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "not-a-version")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "not-a-version")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).To(HaveOccurred())
 			Expect(valid).To(BeFalse())
 		})
 
 		It("should handle version with pre-release suffix", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.9-rc1")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.9-rc1")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).ToNot(HaveOccurred())
 			// Pre-release versions (4.21.9-rc1) are considered LESS than their base (4.21.9) by semver
@@ -121,7 +121,7 @@ var _ = Describe("validateOCPVersion", func() {
 
 	Context("when BM_COCO_OVERRIDE_OCP_VERSION is not set", func() {
 		It("should attempt to fetch from cluster", func() {
-			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+			Expect(os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")).To(Succeed())
 
 			// In unit test environment, this will use the test k8s client from suite_test.go
 			// The cluster won't have the version CRD populated, so it should return an error
@@ -133,14 +133,14 @@ var _ = Describe("validateOCPVersion", func() {
 
 	Context("edge cases", func() {
 		It("should handle version 4.19.27 correctly (just below threshold)", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.27")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.27")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(valid).To(BeFalse())
 		})
 
 		It("should handle version 4.19.28 correctly (exactly at threshold)", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.28")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.28")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(valid).To(BeTrue())
@@ -149,7 +149,7 @@ var _ = Describe("validateOCPVersion", func() {
 		It("should handle versions between supported minors", func() {
 			// 4.19.28+ is supported, 4.20.18+ is supported
 			// But 4.20.0 to 4.20.17 should not be supported
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.20.10")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.20.10")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(valid).To(BeFalse())
@@ -171,11 +171,11 @@ var _ = Describe("validateOCPVersion integration", func() {
 
 	Context("with environment override", func() {
 		AfterEach(func() {
-			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+			Expect(os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")).To(Succeed())
 		})
 
 		It("should use environment variable when set", func() {
-			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.9")
+			Expect(os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.9")).To(Succeed())
 			valid, err := reconciler.validateOCPVersion()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(valid).To(BeTrue())

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -76,7 +76,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.Log.Info("reconciling Secret for OpenShift Sandboxed Containers", "secret", req.Name)
 
 	ccoSecret := &corev1.Secret{}
-	if err := r.Client.Get(context.TODO(), req.NamespacedName, ccoSecret); err != nil {
+	if err := r.Get(context.TODO(), req.NamespacedName, ccoSecret); err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("no cco-secret has been found")
 			return ctrl.Result{}, nil
@@ -328,7 +328,7 @@ func (kh *KataConfigHandler) teardownPeerPodsCredentials(ctx context.Context) (b
 	// 2. Handle STS flow secrets (they don't have owner references and need manual cleanup)
 	if peerPodsSecret != nil && isSTSFlowSecret(peerPodsSecret) {
 		kh.reconciler.Log.Info("Deleting STS flow peer-pods-secret")
-		if err := kh.reconciler.Client.Delete(ctx, peerPodsSecret); err != nil {
+		if err := kh.reconciler.Delete(ctx, peerPodsSecret); err != nil {
 			if !k8serrors.IsNotFound(err) && !k8serrors.IsGone(err) {
 				kh.reconciler.Log.Error(err, "Failed to delete STS flow peer-pods-secret")
 				return false, err
@@ -405,7 +405,7 @@ func (kh *KataConfigHandler) createCredentialsRequests() error {
 		return nil
 	}
 
-	if err := kh.reconciler.Client.Create(context.TODO(), credentialsRequest); err != nil {
+	if err := kh.reconciler.Create(context.TODO(), credentialsRequest); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			kh.reconciler.Log.Info("CredentialsRequest already exists", "name", credentialsRequest.Name)
 			return nil
@@ -428,7 +428,7 @@ func (kh *KataConfigHandler) deleteCredentialsRequests() error {
 		return nil // skip silently
 	}
 
-	if err := kh.reconciler.Client.Delete(context.TODO(), credentialsRequest); err != nil {
+	if err := kh.reconciler.Delete(context.TODO(), credentialsRequest); err != nil {
 		if k8serrors.IsNotFound(err) || k8serrors.IsGone(err) {
 			return nil
 		} else {

--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -71,7 +71,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 		r.Log.Error(err, "Failed getting DaemonSet for Kata installation")
 		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
 	}
-	err = r.Client.Delete(context.TODO(), kataInstallDaemonSet)
+	err = r.Delete(context.TODO(), kataInstallDaemonSet)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("kata install daemonset was already deleted")
@@ -96,11 +96,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 	}
 
 	foundKataDaemonSet := &appsv1.DaemonSet{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: kataUninstallDaemonSet.Name, Namespace: kataUninstallDaemonSet.Namespace}, foundKataDaemonSet)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: kataUninstallDaemonSet.Name, Namespace: kataUninstallDaemonSet.Namespace}, foundKataDaemonSet)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("Creating a new kata uninstallation daemonset", "kataUninstallDaemonSet.Namespace", kataUninstallDaemonSet.Namespace, "kataUninstallDaemonSet.Name", kataUninstallDaemonSet.Name)
-			err = r.Client.Create(context.TODO(), kataUninstallDaemonSet)
+			err = r.Create(context.TODO(), kataUninstallDaemonSet)
 			if err != nil {
 				r.Log.Error(err, "Error when creating kata uninstallation daemonset")
 				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
@@ -248,11 +248,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 	}
 
 	foundKataDaemonSet := &appsv1.DaemonSet{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: kataInstallDaemonSet.Name, Namespace: kataInstallDaemonSet.Namespace}, foundKataDaemonSet)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: kataInstallDaemonSet.Name, Namespace: kataInstallDaemonSet.Namespace}, foundKataDaemonSet)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("Creating a new kata installation daemonset", "kataInstallDaemonSet.Namespace", kataInstallDaemonSet.Namespace, "kataInstallDaemonSet.Name", kataInstallDaemonSet.Name)
-			err = r.Client.Create(context.TODO(), kataInstallDaemonSet)
+			err = r.Create(context.TODO(), kataInstallDaemonSet)
 			if err != nil {
 				r.Log.Error(err, "Error when creating kata installation daemonset")
 				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
@@ -275,7 +275,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 		}
 	} else {
 		r.Log.Info("Updating kata installation daemonset", "kataInstallDaemonSet.Namespace", kataInstallDaemonSet.Namespace, "kataInstallDaemonSet.Name", kataInstallDaemonSet.Name)
-		err = r.Client.Update(context.TODO(), kataInstallDaemonSet)
+		err = r.Update(context.TODO(), kataInstallDaemonSet)
 		if err != nil {
 			r.Log.Error(err, "error when updating kata installation daemonset")
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
@@ -460,7 +460,7 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForKataInstall(action KataDaemo
 // getAddonEnvVars retrieves addon configuration from ConfigMap and returns environment variables
 func (r *KataConfigOpenShiftReconciler) getAddonEnvVars() []corev1.EnvVar {
 	var cm corev1.ConfigMap
-	if err := r.Client.Get(context.Background(),
+	if err := r.Get(context.Background(),
 		types.NamespacedName{Name: "kata-addon-artifacts", Namespace: OperatorNamespace},
 		&cm,
 	); err != nil {
@@ -750,7 +750,7 @@ func (r *KataConfigOpenShiftReconciler) unlabelNodesDaemonSet(nodeSelector label
 		client.MatchingLabelsSelector{Selector: nodeSelector},
 	}
 
-	if err := r.Client.List(context.TODO(), nodeList, listOpts...); err != nil {
+	if err := r.List(context.TODO(), nodeList, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes failed")
 		return err
 	}
@@ -759,7 +759,7 @@ func (r *KataConfigOpenShiftReconciler) unlabelNodesDaemonSet(nodeSelector label
 		if _, ok := node.Labels["node-role.kubernetes.io/kata-oc"]; ok {
 			delete(node.Labels, "node-role.kubernetes.io/kata-oc")
 			delete(node.Labels, kataInstallationDaemonSetLabel)
-			err := r.Client.Update(context.TODO(), &node)
+			err := r.Update(context.TODO(), &node)
 			if err != nil {
 				r.Log.Error(err, "Error when removing labels from node", "node", node)
 				return err

--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -7,7 +7,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -465,7 +464,7 @@ func (r *KataConfigOpenShiftReconciler) getAddonEnvVars() []corev1.EnvVar {
 		types.NamespacedName{Name: "kata-addon-artifacts", Namespace: OperatorNamespace},
 		&cm,
 	); err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			r.Log.Error(err, "Failed to get addon ConfigMap")
 		}
 		return nil

--- a/controllers/deployment_mode_handler.go
+++ b/controllers/deployment_mode_handler.go
@@ -106,7 +106,7 @@ func (r *KataConfigOpenShiftReconciler) isMachineConfigAvailable() (bool, error)
 
 	// Attempt to GET any MachineConfig to verify if the GVK is known.
 	// If the CRD isn’t installed, it will return a NoMatchError.
-	err := r.Client.Get(context.Background(), client.ObjectKey{Name: "dummy-machine-config"}, machineConfig)
+	err := r.Get(context.Background(), client.ObjectKey{Name: "dummy-machine-config"}, machineConfig)
 	if err == nil || k8serrors.IsNotFound(err) {
 		r.Log.Info("MachineConfig CRD is present")
 		return true, nil

--- a/controllers/fg_handler.go
+++ b/controllers/fg_handler.go
@@ -51,7 +51,7 @@ func (r *KataConfigOpenShiftReconciler) NewFeatureGateStatus() (*FeatureGateStat
 	}
 
 	cfgMap := &corev1.ConfigMap{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: FgConfigMapName,
+	err := r.Get(context.TODO(), types.NamespacedName{Name: FgConfigMapName,
 		Namespace: OperatorNamespace}, cfgMap)
 	if err == nil {
 		if value, ok := cfgMap.Data[ConfidentialFeatureGate]; ok {

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -647,7 +647,7 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 
 	case "azure":
 		// Check if azure Secret Keys are present in the peerPodsSecret
-		if !(checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretKeys) || checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretFederatedKeys)) {
+		if !checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretKeys) && !checkKeysPresentAndNotEmpty(peerPodsSecret.Data, azureSecretFederatedKeys) {
 			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-secret Secret")
 		}
 

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -307,8 +307,8 @@ func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, er
 
 		// If provider is Azure set IMAGE_ID, if provider is AWS set AMI_ID
 		// Also for Azure, update the command to add a "-g" option to delete the gallery
-		if r.provider == AzureProvider {
-
+		switch r.provider {
+		case AzureProvider:
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  "IMAGE_ID",
 				Value: imageId,
@@ -319,17 +319,17 @@ func (r *ImageGenerator) createJobFromFile(jobFileName string) (*batchv1.Job, er
 			// Updated command: ["/podvm-builder.sh", "delete", "-f", "-g"]
 			job.Spec.Template.Spec.Containers[0].Command = append(job.Spec.Template.Spec.Containers[0].Command, "-g")
 
-		} else if r.provider == AWSProvider {
+		case AWSProvider:
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  "AMI_ID",
 				Value: imageId,
 			})
-		} else if r.provider == GCPProvider {
+		case GCPProvider:
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  "IMAGE_NAME",
 				Value: imageId,
 			})
-		} else if r.provider == LibvirtProvider {
+		case LibvirtProvider:
 			job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  "LIBVIRT_IMAGE_ID",
 				Value: imageId,

--- a/controllers/layered_image_handler.go
+++ b/controllers/layered_image_handler.go
@@ -52,7 +52,7 @@ func (r *KataConfigOpenShiftReconciler) handleLayeredImageDeploymentFeature(stat
 		r.Log.Info("LayeredImageDeployment feature is enabled")
 
 		cm := &corev1.ConfigMap{}
-		err := r.Client.Get(context.Background(), types.NamespacedName{
+		err := r.Get(context.Background(), types.NamespacedName{
 			Name:      LayeredImageDeployCm,
 			Namespace: OperatorNamespace,
 		}, cm)
@@ -85,7 +85,7 @@ func (r *KataConfigOpenShiftReconciler) getExistingMachineConfig() (*mcfgv1.Mach
 	// Check for label "app":r.kataConfig.Name
 	// and name "50-enable-sandboxed-containers-extension" or name "50-enable-sandboxed-containers-image"
 	mcList := &mcfgv1.MachineConfigList{}
-	err := r.Client.List(context.Background(), mcList)
+	err := r.List(context.Background(), mcList)
 	if err != nil {
 		r.Log.Info("Error in listing MachineConfigs", "err", err)
 		return nil, err

--- a/controllers/migrate.go
+++ b/controllers/migrate.go
@@ -31,7 +31,7 @@ func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 	peerPodConfig.SetAPIVersion("confidentialcontainers.org/v1alpha1")
 	peerPodConfig.SetKind("PeerPodConfig")
 
-	err := r.Client.Get(context.TODO(), client.ObjectKey{
+	err := r.Get(context.TODO(), client.ObjectKey{
 		Name:      "peerpodconfig-openshift",
 		Namespace: OperatorNamespace,
 	}, peerPodConfig)
@@ -52,11 +52,11 @@ func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 	if !found {
 		r.Log.Info("spec.limit not found, skipping migration, in favor of default value.")
 		r.Log.Info("Removing deprecated PeerPodConfig...")
-		return r.Client.Delete(context.TODO(), peerPodConfig)
+		return r.Delete(context.TODO(), peerPodConfig)
 	}
 
 	configMap := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), client.ObjectKey{
+	err = r.Get(context.TODO(), client.ObjectKey{
 		Name:      "peer-pods-cm",
 		Namespace: OperatorNamespace,
 	}, configMap)
@@ -65,18 +65,18 @@ func (r *KataConfigOpenShiftReconciler) migratePeerPodsLimit() error {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("No peer-pods-cm found, skipping migration")
 			r.Log.Info("Removing deprecated PeerPodConfig...")
-			return r.Client.Delete(context.TODO(), peerPodConfig)
+			return r.Delete(context.TODO(), peerPodConfig)
 		}
 		return err
 	}
 
 	configMap.Data["PEERPODS_LIMIT_PER_NODE"] = limitValue
-	err = r.Client.Update(context.TODO(), configMap)
+	err = r.Update(context.TODO(), configMap)
 	if err != nil {
 		return err
 	}
 
-	err = r.Client.Delete(context.TODO(), peerPodConfig)
+	err = r.Delete(context.TODO(), peerPodConfig)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (r *KataConfigOpenShiftReconciler) ensureRuntimeClassFinalizers() error {
 
 	for _, name := range runtimeClasses {
 		rc := &nodeapi.RuntimeClass{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name}, rc)
+		err := r.Get(context.TODO(), types.NamespacedName{Name: name}, rc)
 		if k8serrors.IsNotFound(err) {
 			continue
 		}
@@ -106,7 +106,7 @@ func (r *KataConfigOpenShiftReconciler) ensureRuntimeClassFinalizers() error {
 		if !controllerutil.ContainsFinalizer(rc, runtimeClassFinalizerName) {
 			r.Log.Info("Adding finalizer to existing runtime class", "runtimeClass", name)
 			controllerutil.AddFinalizer(rc, runtimeClassFinalizerName)
-			if err := r.Client.Update(context.TODO(), rc); err != nil {
+			if err := r.Update(context.TODO(), rc); err != nil {
 				return err
 			}
 		}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -132,7 +132,7 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// Fetch the KataConfig instance
 	r.kataConfig = &kataconfigurationv1.KataConfig{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, r.kataConfig)
+	err := r.Get(context.TODO(), req.NamespacedName, r.kataConfig)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after ctrl request.
@@ -196,7 +196,7 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 				err = fmt.Errorf("unknown deployment mode: %d", r.DeploymentMode)
 			}
 
-			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+			updateErr := r.Status().Update(context.TODO(), r.kataConfig)
 			// The finalizer test is to get rid of the
 			// "Operation cannot be fulfilled [...] Precondition failed"
 			// error which happens when returning from a reconciliation that
@@ -228,7 +228,7 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 
 		if r.IsKataConfigStatusChanged(oldObjStatus, &r.kataConfig.Status) {
 			r.Log.Info("KataConfig's status changed, updating...")
-			updateErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+			updateErr := r.Status().Update(context.TODO(), r.kataConfig)
 			if updateErr != nil {
 				return ctrl.Result{}, updateErr
 			}
@@ -240,11 +240,11 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.
 			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, nil
 		}
 		foundCm := &corev1.ConfigMap{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cMap.Name, Namespace: cMap.Namespace}, foundCm)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: cMap.Name, Namespace: cMap.Namespace}, foundCm)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				r.Log.Info("Installing metrics dashboard")
-				err = r.Client.Create(context.TODO(), cMap)
+				err = r.Create(context.TODO(), cMap)
 				if err != nil {
 					r.Log.Error(err, "Error when creating the dashboard configmap")
 					res = ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}
@@ -309,7 +309,7 @@ func (r *KataConfigOpenShiftReconciler) processLogLevel(desiredLogLevel string) 
 	}
 
 	ctrRuntimeCfg := &mcfgv1.ContainerRuntimeConfig{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: container_runtime_config_name}, ctrRuntimeCfg)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: container_runtime_config_name}, ctrRuntimeCfg)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			r.Log.Error(err, "could not get ContainerRuntimeConfig, try again")
@@ -340,7 +340,7 @@ func (r *KataConfigOpenShiftReconciler) processLogLevel(desiredLogLevel string) 
 		ctrRuntimeCfg = makeContainerRuntimeConfig(desiredLogLevel, machineConfigPoolSelector)
 
 		r.Log.Info("creating ContainerRuntimeConfig")
-		err = r.Client.Create(context.TODO(), ctrRuntimeCfg)
+		err = r.Create(context.TODO(), ctrRuntimeCfg)
 		if err != nil {
 			r.Log.Error(err, "error creating ContainerRuntimeConfig")
 			return err
@@ -360,7 +360,7 @@ func (r *KataConfigOpenShiftReconciler) processLogLevel(desiredLogLevel string) 
 		ctrRuntimeCfg.Spec.ContainerRuntimeConfig.LogLevel = desiredLogLevel
 
 		r.Log.Info("updating ContainerRuntimeConfig")
-		err = r.Client.Update(context.TODO(), ctrRuntimeCfg)
+		err = r.Update(context.TODO(), ctrRuntimeCfg)
 		if err != nil {
 			r.Log.Error(err, "error updating ContainerRuntimeConfig")
 			return err
@@ -376,7 +376,7 @@ func (r *KataConfigOpenShiftReconciler) removeLogLevel() error {
 	r.Log.Info("removing logLevel ContainerRuntimeConfig")
 
 	ctrRuntimeCfg := &mcfgv1.ContainerRuntimeConfig{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: container_runtime_config_name}, ctrRuntimeCfg)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: container_runtime_config_name}, ctrRuntimeCfg)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("no logLevel ContainerRuntimeConfig found, nothing to do")
@@ -387,7 +387,7 @@ func (r *KataConfigOpenShiftReconciler) removeLogLevel() error {
 		}
 	}
 
-	err = r.Client.Delete(context.TODO(), ctrRuntimeCfg)
+	err = r.Delete(context.TODO(), ctrRuntimeCfg)
 	if err != nil {
 		r.Log.Info("error deleting ContainerRuntimeConfig", "err", err)
 		return err
@@ -505,7 +505,7 @@ func (r *KataConfigOpenShiftReconciler) processDashboardConfigMap() *corev1.Conf
 
 	// retrieve content of the dashboard from our own namespace
 	foundCm := &corev1.ConfigMap{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: dashboardConfigMapName, Namespace: OperatorNamespace}, foundCm)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: dashboardConfigMapName, Namespace: OperatorNamespace}, foundCm)
 	if err != nil {
 		r.Log.Error(err, "could not get dashboard data")
 		return nil
@@ -573,7 +573,7 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 
 	// FIXME: Look into having a single util function to return the ClusterVersion
 	clusterVersion := &configv1.ClusterVersion{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 	if err != nil {
 		return "", err
 	}
@@ -600,7 +600,7 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 // NOTE: This logic is applicable only for kata-se / IBM Secure Execution (s390x).
 func (r *KataConfigOpenShiftReconciler) getCustomKernelConfig(ctx context.Context) (*customKernelConfig, error) {
 	cm := &corev1.ConfigMap{}
-	err := r.Client.Get(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Name:      KataAddonConfigMapName,
 		Namespace: OperatorNamespace,
 	}, cm)
@@ -707,7 +707,7 @@ func (r *KataConfigOpenShiftReconciler) addFinalizer() error {
 	controllerutil.AddFinalizer(r.kataConfig, kataConfigFinalizer)
 
 	// Update CR
-	err := r.Client.Update(context.TODO(), r.kataConfig)
+	err := r.Update(context.TODO(), r.kataConfig)
 	if err != nil {
 		r.Log.Error(err, "Failed to update KataConfig with finalizer")
 		return err
@@ -719,7 +719,7 @@ func (r *KataConfigOpenShiftReconciler) removeFinalizer() error {
 	r.Log.Info("Removing finalizer from the KataConfig")
 	controllerutil.RemoveFinalizer(r.kataConfig, kataConfigFinalizer)
 
-	err := r.Client.Update(context.TODO(), r.kataConfig)
+	err := r.Update(context.TODO(), r.kataConfig)
 	if err != nil {
 		r.Log.Error(err, "Unable to update KataConfig")
 		return err
@@ -732,7 +732,7 @@ func (r *KataConfigOpenShiftReconciler) listKataPods() error {
 	listOpts := []client.ListOption{
 		client.InNamespace(corev1.NamespaceAll),
 	}
-	if err := r.Client.List(context.TODO(), podList, listOpts...); err != nil {
+	if err := r.List(context.TODO(), podList, listOpts...); err != nil {
 		return fmt.Errorf("failed to list kata pods: %v", err)
 	}
 	for _, pod := range podList.Items {
@@ -748,7 +748,7 @@ func (r *KataConfigOpenShiftReconciler) listKataPods() error {
 //lint:ignore U1000 This method is unused, but let's keep it for now
 func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 	kataOcMcp := &mcfgv1.MachineConfigPool{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "kata-oc"}, kataOcMcp)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: "kata-oc"}, kataOcMcp)
 	if err != nil && k8serrors.IsNotFound(err) {
 		r.Log.Info("kata-oc MachineConfigPool not found")
 		return false, nil
@@ -765,7 +765,7 @@ func (r *KataConfigOpenShiftReconciler) checkConvergedCluster() (bool, error) {
 	//Worker machinecount should be 0
 	listOpts := []client.ListOption{}
 	mcpList := &mcfgv1.MachineConfigPoolList{}
-	err := r.Client.List(context.TODO(), mcpList, listOpts...)
+	err := r.List(context.TODO(), mcpList, listOpts...)
 	if err != nil {
 		r.Log.Error(err, "Unable to get the list of MCPs")
 		return false, err
@@ -829,14 +829,14 @@ func (r *KataConfigOpenShiftReconciler) createScc() error {
 	}
 
 	foundScc := &secv1.SecurityContextConstraints{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: scc.Name}, foundScc)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: scc.Name}, foundScc)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
 		r.Log.Info("Creating a new Scc", "scc.Name", scc.Name)
-		err = r.Client.Create(context.TODO(), scc)
+		err = r.Create(context.TODO(), scc)
 		if err != nil {
 			return err
 		}
@@ -855,11 +855,11 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 	r.Log.Info("controller reference set for the monitor daemonset")
 
 	foundDS := &appsv1.DaemonSet{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, foundDS)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, foundDS)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("Creating a new installation monitor daemonset", "ds.Namespace", ds.Namespace, "ds.Name", ds.Name)
-			err = r.Client.Create(context.TODO(), ds)
+			err = r.Create(context.TODO(), ds)
 			if err != nil {
 				r.Log.Error(err, "error when creating monitor daemonset")
 				return err
@@ -870,7 +870,7 @@ func (r *KataConfigOpenShiftReconciler) createDaemonsetForMonitor() error {
 		}
 	} else {
 		r.Log.Info("Updating monitor daemonset", "ds.Namespace", ds.Namespace, "ds.Name", ds.Name)
-		err = r.Client.Update(context.TODO(), ds)
+		err = r.Update(context.TODO(), ds)
 		if err != nil {
 			r.Log.Error(err, "error when updating monitor daemonset")
 			return err
@@ -904,7 +904,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 			client.MatchingLabelsSelector{Selector: selector},
 			client.MatchingLabels(additionalNodeLabels),
 		}
-		if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+		if err := r.List(context.TODO(), nodes, listOpts...); err != nil {
 			return fmt.Errorf("failed to list nodes: %w", err)
 		}
 
@@ -962,14 +962,14 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 	}
 
 	foundRc := &nodeapi.RuntimeClass{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: rc.Name}, foundRc)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: rc.Name}, foundRc)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
 		r.Log.Info("Creating a new RuntimeClass", "rc.Name", rc.Name)
-		err = r.Client.Create(context.TODO(), rc)
+		err = r.Create(context.TODO(), rc)
 		if err != nil {
 			return fmt.Errorf("error creating %s runtime class: %w", rc.Name, err)
 		}
@@ -985,7 +985,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 func (r *KataConfigOpenShiftReconciler) deleteRuntimeClass(runtimeClassName string) error {
 
 	foundRc := &nodeapi.RuntimeClass{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: runtimeClassName}, foundRc)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: runtimeClassName}, foundRc)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -993,7 +993,7 @@ func (r *KataConfigOpenShiftReconciler) deleteRuntimeClass(runtimeClassName stri
 		return err
 	}
 
-	if err := r.Client.Delete(context.TODO(), foundRc); err != nil {
+	if err := r.Delete(context.TODO(), foundRc); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
@@ -1064,7 +1064,7 @@ func (r *KataConfigOpenShiftReconciler) getNodeSelectorAsLabelSelector() *metav1
 
 func (r *KataConfigOpenShiftReconciler) isMcpUpdating(mcpName string) bool {
 	mcp := &mcfgv1.MachineConfigPool{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
 	if err != nil {
 		r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcpName, "err", err)
 		return false
@@ -1109,7 +1109,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 
 	var isMcDeleted bool
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, mc)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, mc)
 	if err != nil && k8serrors.IsNotFound(err) {
 		isMcDeleted = true
 		// Reset ImgMc
@@ -1119,7 +1119,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	}
 
 	if !isMcDeleted {
-		err = r.Client.Delete(context.TODO(), mc)
+		err = r.Delete(context.TODO(), mc)
 		if err != nil {
 			// error during removing mc, don't block the uninstall. Just log the error and move on.
 			r.Log.Error(err, "Error found deleting machine config. If the machine config exists after installation it can be safely deleted manually.",
@@ -1180,10 +1180,10 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequest() (ctrl.R
 	if !isConvergedCluster {
 		r.Log.Info("Get()'ing MachineConfigPool to delete it", "machinePool", "kata-oc")
 		kataOcMcp := &mcfgv1.MachineConfigPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "kata-oc"}, kataOcMcp)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "kata-oc"}, kataOcMcp)
 		if err == nil {
 			r.Log.Info("Deleting MachineConfigPool ", "machinePool", "kata-oc")
-			err = r.Client.Delete(context.TODO(), kataOcMcp)
+			err = r.Delete(context.TODO(), kataOcMcp)
 			if err != nil {
 				r.Log.Error(err, "Unable to delete kata-oc MachineConfigPool")
 				return ctrl.Result{}, err
@@ -1294,11 +1294,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequest() (ctrl.
 
 		// Create kata-oc only if it doesn't exist
 		mcp := &mcfgv1.MachineConfigPool{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: machinePool}, mcp)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: machinePool}, mcp)
 		if err != nil && k8serrors.IsNotFound(err) {
 			r.Log.Info("Creating a new MachineConfigPool ", "machinePool", machinePool)
 			mcp = r.newMCPforCR()
-			err = r.Client.Create(context.TODO(), mcp)
+			err = r.Create(context.TODO(), mcp)
 			if err != nil {
 				r.Log.Error(err, "Error in creating new MachineConfigPool ", "machinePool", machinePool)
 				return ctrl.Result{}, err
@@ -1392,10 +1392,10 @@ func (r *KataConfigOpenShiftReconciler) createMc(machinePool string, customKerne
 	}
 
 	existingMc := &mcfgv1.MachineConfig{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, existingMc)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: mc.Name}, existingMc)
 	if err != nil && (k8serrors.IsNotFound(err) || k8serrors.IsGone(err)) {
 
-		err = r.Client.Create(context.TODO(), mc)
+		err = r.Create(context.TODO(), mc)
 		if err != nil {
 			r.Log.Error(err, "Failed to create a new MachineConfig ", "mc.Name", mc.Name)
 			return dummy, err
@@ -1408,7 +1408,7 @@ func (r *KataConfigOpenShiftReconciler) createMc(machinePool string, customKerne
 	} else if !reflect.DeepEqual(existingMc.Spec, mc.Spec) {
 		r.Log.Info("MachineConfig spec changed, updating", "mc.Name", mc.Name)
 		existingMc.Spec = mc.Spec
-		if err := r.Client.Update(context.TODO(), existingMc); err != nil {
+		if err := r.Update(context.TODO(), existingMc); err != nil {
 			r.Log.Error(err, "Failed to update MachineConfig", "mc.Name", mc.Name)
 			return dummy, err
 		}
@@ -1757,7 +1757,7 @@ func (r *KataConfigOpenShiftReconciler) getNodes() (*corev1.NodeList, error) {
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	}
 
-	if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+	if err := r.List(context.TODO(), nodes, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes failed")
 		return &corev1.NodeList{}, err
 	}
@@ -1771,7 +1771,7 @@ func (r *KataConfigOpenShiftReconciler) getNodesWithLabels(nodeLabels map[string
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	}
 
-	if err := r.Client.List(context.TODO(), nodes, listOpts...); err != nil {
+	if err := r.List(context.TODO(), nodes, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes having specified labels failed")
 		return &corev1.NodeList{}, err
 	}
@@ -1785,7 +1785,7 @@ func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (labelingChanged bool
 		client.MatchingLabelsSelector{Selector: workerSelector},
 	}
 
-	if err := r.Client.List(context.TODO(), workerNodeList, listOpts...); err != nil {
+	if err := r.List(context.TODO(), workerNodeList, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes failed")
 		return false, err
 	}
@@ -1814,7 +1814,7 @@ func (r *KataConfigOpenShiftReconciler) updateNodeLabels() (labelingChanged bool
 			delete(worker.Labels, "node-role.kubernetes.io/kata-oc")
 		}
 
-		err = r.Client.Update(context.TODO(), &worker)
+		err = r.Update(context.TODO(), &worker)
 		if err != nil {
 			r.Log.Error(err, "Error when adding labels to node", "node", worker)
 			return labelingChanged, err
@@ -1832,7 +1832,7 @@ func (r *KataConfigOpenShiftReconciler) unlabelNodes(nodeSelector labels.Selecto
 		client.MatchingLabelsSelector{Selector: nodeSelector},
 	}
 
-	if err := r.Client.List(context.TODO(), nodeList, listOpts...); err != nil {
+	if err := r.List(context.TODO(), nodeList, listOpts...); err != nil {
 		r.Log.Error(err, "Getting list of nodes failed")
 		return false, err
 	}
@@ -1840,7 +1840,7 @@ func (r *KataConfigOpenShiftReconciler) unlabelNodes(nodeSelector labels.Selecto
 	for _, node := range nodeList.Items {
 		if _, ok := node.Labels["node-role.kubernetes.io/kata-oc"]; ok {
 			delete(node.Labels, "node-role.kubernetes.io/kata-oc")
-			err = r.Client.Update(context.TODO(), &node)
+			err = r.Update(context.TODO(), &node)
 			if err != nil {
 				r.Log.Error(err, "Error when removing labels from node", "node", node)
 				return labelingChanged, err
@@ -1865,7 +1865,7 @@ func (r *KataConfigOpenShiftReconciler) getConditionReason(conditions []mcfgv1.M
 func (r *KataConfigOpenShiftReconciler) getMcpByName(mcpName string) (*mcfgv1.MachineConfigPool, error) {
 
 	mcp := &mcfgv1.MachineConfigPool{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: mcpName}, mcp)
 	if err != nil {
 		r.Log.Info("Getting MachineConfigPool failed ", "machinePool", mcp, "err", err)
 		return nil, err
@@ -2013,7 +2013,7 @@ func (r *KataConfigOpenShiftReconciler) putNodeOnStatusList(node *corev1.Node) e
 	var isKataEnabledOnNode bool
 	if isConvergedCluster {
 		targetMc := &mcfgv1.MachineConfig{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: targetMcp.Spec.Configuration.Name}, targetMc)
+		err := r.Get(context.TODO(), types.NamespacedName{Name: targetMcp.Spec.Configuration.Name}, targetMc)
 		if err != nil {
 			r.Log.Info("Failed to retrieve MachineConfig", "MC name", targetMcp.Spec.Configuration.Name, targetMc, "MCP name", targetMcpName)
 			return err
@@ -2288,7 +2288,7 @@ func (r *KataConfigOpenShiftReconciler) checkDeletionEligibility() (ctrl.Result,
 		err := r.listKataPods()
 		if err != nil {
 			r.setInProgressConditionToBlockedByExistingKataPods(err.Error())
-			updErr := r.Client.Status().Update(context.TODO(), r.kataConfig)
+			updErr := r.Status().Update(context.TODO(), r.kataConfig)
 			if updErr != nil {
 				return ctrl.Result{}, updErr
 			}
@@ -2301,7 +2301,7 @@ func (r *KataConfigOpenShiftReconciler) checkDeletionEligibility() (ctrl.Result,
 
 func (r *KataConfigOpenShiftReconciler) deleteDaemonsetForMonitor() error {
 	ds := r.processDaemonsetForMonitor()
-	err := r.Client.Delete(context.TODO(), ds)
+	err := r.Delete(context.TODO(), ds)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("monitor daemonset was already deleted")
@@ -2315,7 +2315,7 @@ func (r *KataConfigOpenShiftReconciler) deleteDaemonsetForMonitor() error {
 
 func (r *KataConfigOpenShiftReconciler) deleteScc() error {
 	scc := GetScc()
-	err := r.Client.Delete(context.TODO(), scc)
+	err := r.Delete(context.TODO(), scc)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("SCC was already deleted")

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -295,10 +295,10 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 		return err
 	}
 
-	err := r.Client.Update(context.TODO(), ds)
+	err := r.Update(context.TODO(), ds)
 	if err != nil && k8serrors.IsNotFound(err) {
 		r.Log.Error(err, "cloud-api-adaptor daemonset doesn't exist. Creating")
-		err = r.Client.Create(context.TODO(), ds)
+		err = r.Create(context.TODO(), ds)
 		if err != nil {
 			r.Log.Error(err, "failed to create cloud-api-adaptor daemonset")
 			return err
@@ -337,7 +337,7 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 
 func (r *KataConfigOpenShiftReconciler) disablePeerPodsMiscConfigs() error {
 	ds := r.processDaemonsetForCAA()
-	err := r.Client.Delete(context.TODO(), ds)
+	err := r.Delete(context.TODO(), ds)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			r.Log.Info("cloud-api-adaptor daemonset was already deleted")

--- a/controllers/ppwebhook.go
+++ b/controllers/ppwebhook.go
@@ -83,7 +83,7 @@ func (r *KataConfigOpenShiftReconciler) createMutatingWebhookService() error {
 	}
 
 	// Create webhook service
-	if err := r.Client.Create(context.Background(), webhookService); err != nil {
+	if err := r.Create(context.Background(), webhookService); err != nil {
 		// Check if the webhook service already exists
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -245,7 +245,7 @@ func (r *KataConfigOpenShiftReconciler) createMutatingWebhookDeployment() error 
 	}
 
 	// Create webhook deployment
-	if err := r.Client.Create(context.Background(), webhookDeployment); err != nil {
+	if err := r.Create(context.Background(), webhookDeployment); err != nil {
 		// Check if the webhook deployment already exists
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -398,7 +398,7 @@ func (r *KataConfigOpenShiftReconciler) createMutatingWebhookConfig() error {
 	}
 
 	// Create MutatingWebhookConfiguration object
-	if err := r.Client.Create(context.Background(), mutatingWebhookConfig); err != nil {
+	if err := r.Create(context.Background(), mutatingWebhookConfig); err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
@@ -419,7 +419,7 @@ func (r *KataConfigOpenShiftReconciler) deleteMutatingWebhookDeployment() error 
 		},
 	}
 	// Delete the deployment
-	err := r.Client.Delete(context.Background(), deployment)
+	err := r.Delete(context.Background(), deployment)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -441,7 +441,7 @@ func (r *KataConfigOpenShiftReconciler) deleteMutatingWebhookService() error {
 		},
 	}
 	// Delete the service
-	err := r.Client.Delete(context.Background(), service)
+	err := r.Delete(context.Background(), service)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -459,7 +459,7 @@ func (r *KataConfigOpenShiftReconciler) deleteMutatingWebhookConfig() error {
 		},
 	}
 	// Delete the mutating webhook configuration
-	err := r.Client.Delete(context.Background(), mutatingWebhookConfig)
+	err := r.Delete(context.Background(), mutatingWebhookConfig)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/controllers/runtimeclass_controller.go
+++ b/controllers/runtimeclass_controller.go
@@ -49,7 +49,7 @@ const (
 
 // Reconcile handles RuntimeClass lifecycle, specifically finalizer cleanup
 func (r *RuntimeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("runtimeclass", req.NamespacedName.Name)
+	log := r.Log.WithValues("runtimeclass", req.Name)
 
 	runtimeClass := &nodeapi.RuntimeClass{}
 	err := r.Get(ctx, req.NamespacedName, runtimeClass)

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -11,7 +11,6 @@ import (
 	yaml "github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/oc/pkg/cli/admin/release"
 	batchv1 "k8s.io/api/batch/v1"
@@ -87,15 +86,6 @@ func readYamlFile(yamlFile string) ([]byte, error) {
 		return nil, err
 	}
 	return yamlData, nil
-}
-
-func parseMachineConfigYAML(yamlData []byte) (*mcfgv1.MachineConfig, error) {
-	machineConfig := &mcfgv1.MachineConfig{}
-	err := yaml.Unmarshal(yamlData, machineConfig)
-	if err != nil {
-		return nil, err
-	}
-	return machineConfig, nil
 }
 
 func parseCredentialsRequestYAML(yamlData []byte) (*ccov1.CredentialsRequest, error) {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -325,7 +325,7 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 	var err error
 
 	pullSecret := &corev1.Secret{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "pull-secret", Namespace: "openshift-config"}, pullSecret)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: "pull-secret", Namespace: "openshift-config"}, pullSecret)
 	if err != nil {
 		r.Log.Info("Error fetching pull-secret", "err", err)
 		return err
@@ -342,10 +342,10 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	err = r.Client.Create(context.TODO(), &authJsonSecret)
+	err = r.Create(context.TODO(), &authJsonSecret)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			err = r.Client.Update(context.TODO(), &authJsonSecret)
+			err = r.Update(context.TODO(), &authJsonSecret)
 			if err != nil {
 				r.Log.Info("Error updating auth-json-secret", "err", err)
 				return err


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

Currently we don't run any static analysis tool!

I've a plan to introduce some of those tools in our CI, and I wanted to start with golangci-lint.

**- What I did**

Ran `make lint` and with help of claude I delinted the entire project.

ps: our `.golangci-lint` file is configure to the mininum of mininum, that's why likely just a handful of errors were catch.

**- How to verify it**

`make lint` and it should return 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated Go code quality checks via GitHub Actions workflow.
  * Upgraded code linting tool to latest version for improved standards.
  * Refactored internal Kubernetes API interactions for better maintainability.

* **Bug Fixes**
  * Fixed error message capitalization in validation and deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->