### PR TITLE
[WIP] ci: add script and integration test to allow pre-merge testing

### DIFF
--- a/tests/build-bundle.sh
+++ b/tests/build-bundle.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# This script builds the project bundle for testing purposes.
+# It takes a list of modified images in an environment variable, and modifies
+# the CSV for the bundle accordingly. Then it builds this bundle, and finally
+# builds a corresponding catalog.
+# Both bundle and catalog are pushed to quay and can then be used for testing.
+#
+# This script needs to be called from the root of the repository.
+set -ex
+
+# List of modified images, separated by newlines.
+MODIFIED_IMAGES=${MODIFIED_IMAGES:-""}
+MODIFIED_IMAGES="quay.io/littlejawa/osc-operator:v1.11.1"
+
+# target image repository: provide the operator's image base. The bundle's image
+# will be derived by adding "-bundle" to it.
+IMAGE_TAG_BASE=${IMAGE_TAG_BASE:-"quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator"}
+IMAGE_TAG_BASE="quay.io/littlejawa/osc-operator"
+
+if [ -z "$MODIFIED_IMAGES" ]; then
+    echo "No modified images specified. Exiting."
+    exit 1
+fi
+
+function get_redhat_url_from_quay_url() {
+    local REDHAT_BASE="registry.redhat.io/openshift-sandboxed-containers"
+    local QUAY_URL="$1"
+    case "$QUAY_URL" in
+        *osc-operator*)
+            echo "$REDHAT_BASE/osc-rhel9-operator"
+            return 0
+            ;;
+        *osc-caa*)
+            echo "$REDHAT_BASE/osc-cloud-api-adaptor-rhel9"
+            return 0
+            ;;
+        *osc-caa-webhook*)
+            echo "$REDHAT_BASE/osc-cloud-api-adaptor-webhook-rhel9"
+            return 0
+            ;;
+        *)
+            local IMAGE_NAME=$(echo "$QUAY_URL" | sed 's|quay.io/redhat-user-workloads/ose-osc-tenant/||' | cut -d'@' -f1)
+            echo "$REDHAT_BASE/${IMAGE_NAME}-rhel9"
+            return 0
+            ;;
+    esac
+}
+
+# Edit the config/manager/manager.yaml file to update the image references.
+MANAGER_YAML="config/manager/manager.yaml"
+for IMAGE in $MODIFIED_IMAGES; do
+    IMAGE_NAME=$(echo "$IMAGE" | cut -d':' -f1)
+    IMAGE_TAG=$(echo "$IMAGE" | cut -d':' -f2)
+
+    # Convert the quay.io image reference to the redhat registry format
+    IMAGE_NAME=$(get_redhat_url_from_quay_url "$IMAGE_NAME")
+
+    sed -i "s|\($IMAGE_NAME:\).*|\1$IMAGE_TAG|g" "$MANAGER_YAML"
+done
+
+# build the bundle with modified references
+TAG=on-pr-$(date +%Y%m%d%H%M%S)
+export BUNDLE_IMG="quay.io/littlejawa/osc-operator-bundle:${TAG}"
+export IMAGE_TAG_BASE
+make bundle       # generate bundle manifests
+make bundle-build # build the bundle image
+make bundle-push  # push the image to the repository
+
+# Now we need to build a catalog that references this new bundle image.
+# We will use the fbc/test-fbc scripts to do that.
+CATALOG_IMAGE="quay.io/redhat-user-workloads/ose-osc-tenant/test-fbc:${TAG}"
+CATALOG_IMAGE="quay.io/littlejawa/test-fbc:${TAG}"
+
+echo "Building catalog for bundle image: $BUNDLE_IMG"
+cd fbc
+# edit the catalog-template.yaml to reference our new bundle image
+CATALOG_TEMPLATE="test-fbc/catalog-template.yaml"
+sed -i "s|\(image: \).*|\1$BUNDLE_IMAGE|g" "$CATALOG_TEMPLATE"
+podman build -f test-fbc/Dockerfile -t "$CATALOG_IMAGE" .
+podman push "$CATALOG_IMAGE"
+echo "Catalog image pushed: $CATALOG_IMAGE"

--- a/tests/build-test-artifacts.yaml
+++ b/tests/build-test-artifacts.yaml
@@ -1,0 +1,95 @@
+kind: Pipelinerun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  name: show-snapshot
+  annotations:
+  build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+spec:
+  params:
+    - description: 'Snapshot of the application'
+      name: SNAPSHOT
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: PULL_NUMBER
+      value: '{{pull_request_number}}'
+  tasks:
+    - name: build-and-push
+      description: Builds a bundle and catalog that references the modified images from the SNAPSHOT
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: PULL_NUMBER
+          value: $(params.PULL_NUMBER)
+      taskSpec:
+        params:
+        - name: SNAPSHOT
+        results:
+        - name: TEST_OUTPUT
+          description: Test output
+        steps:
+        - image: registry.redhat.io/openshift4/ose-cli:latest
+          env:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+          script: |
+            #!/bin/bash
+            set -e
+            SUCCESSES=0
+            FAILURES=0
+
+            dnf -y install jq git make skopeo
+            snapshotComponents=$(jq -c '.components[]' <<< "${SNAPSHOT}")
+
+            # Look at all images listed in the SNAPSHOT, and verify the tags
+            # that are associated to them.
+            # All tags that contain "on-push" should be ignored, as they reference
+            # already merged code.
+            # All tags containing "on-pull-request-" should be listed, as they
+            # reference newly built images that we want to test.
+            MODIFIED_IMAGES=""
+            while read componentEntry
+            do
+              IMAGE=$(echo "${componentEntry}" | jq -r '.containerImage')
+              TAGS=$(skopeo inspect "docker://${IMAGE}" | jq '.RepoTags')
+
+              # Verify that the image has at least one "on-pull-request-" tag
+              IMAGE_PR_TAG="$(echo "${TAGS}" | grep -q 'on-pull-request-')
+              if [ $? -ne 0 ]; then
+                continue
+              fi
+
+              MODIFIED_IMAGES="${MODIFIED_IMAGES}\n${IMAGE_PR_TAG}"
+              
+            done < <(echo "$snapshotComponents")
+
+            echo -e "Found the following pr- tags in the Snapshot images:"
+            echo "${MODIFIED_IMAGES}"
+
+            # Checkout the sources for the operator to get the build-bundle.sh script
+            # We need to get the same revision that was built in the SNAPSHOT,
+            # in case this script was changed in the PR.
+            srcURL=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.url' <<< "${SNAPSHOT}")
+            srcREV=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.revision' <<< "${SNAPSHOT}")
+
+            git clone ${srcURL} sources
+            cd sources
+            git checkout ${srcREV}
+
+            # Call the build-bundle.sh script with the list of modified images
+            export MODIFIED_IMAGES
+            export VERSION=on-pull-request-$PULL_NUMBER
+            ./tests/build-bundle.sh
+            
+            if [ $? -eq 0 ]; then
+              RESULT="SUCCESS"
+              SUCCESSES=1
+            else
+              RESULT="FAILURE"
+              FAILURES=1
+            fi
+
+            # Output the standardized TEST_OUTPUT result in JSON form
+            TEST_OUTPUT=$(jq -rc --arg date $(date -u --iso-8601=seconds) --arg RESULT "${RESULT}" \
+                --argjson FAILURES ${FAILURES} --argjson SUCCESSES ${SUCCESSES} --null-input \
+                '{result: $RESULT, timestamp: $date, failures: $FAILURES, successes: $SUCCESSES, warnings: 0}')
+            echo -n "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)


### PR DESCRIPTION
The CI jobs we have in konflux are rebuilding images on PRs, but they rebuild the bundle and catalog only on-push (i.e: after a change is merged). Because of that, it is cumbersome to test a change before it is merged: we either have to create a bundle/catalog manually, or replace the image reference in a cluster where our operator is already deployed.

This commit tries to automated the creation of a bundle based on a list of modified images, and the creation of a catalog from that modified bundle.

- build-bundle.sh is a script that, given a list of modified images, will modify the bundle files and build a bundle image out of it. It can be run locally by a developper for testing purposes, but will be used in our CI to automate the process.
- build-test-artifacts.yaml is an integration test definition for Konflux. It is intended to run on every PR, after a build succeeds. It takes the snapshot (list of images) from the build, and calls build-bundle.sh with it to create the related bundle and catalog.

The goal for this change is to make sure that, for every PR, we get a testable catalog and bundle containing the change that are in the PR.

Note that this is still incomplete, as sometimes we need consistent changes accross components from different repositories. In such a case, a single PR cannot contain all changes, and even with group snapshots, we may not be able to ensure the resulting bundle/catalog will be consistent.
This commit tries to tackle the easiest, simpler use case.
