### PR TITLE
tests/osc-test-fbc-integration: trigger jobs for OCP 4.21

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -19,7 +19,7 @@ spec:
       description: >-
         Which prowjobs to run. Options: "sanity" (default, runs only sanity checks),
         "all" (runs all prowjobs), or specific job names like "ocp419 ocp420"
-        (runs only those OCP version jobs, space-separated). Available job names: ocp418, ocp419, ocp420
+        (runs only those OCP version jobs, space-separated). Available job names: ocp418, ocp419, ocp420, ocp421
       default: "sanity"
   tasks:
     - name: get-catalog-image
@@ -63,6 +63,8 @@ spec:
             description: "Whether to run OCP 4.19 prowjobs"
           - name: run_ocp420
             description: "Whether to run OCP 4.20 prowjobs"
+          - name: run_ocp421
+            description: "Whether to run OCP 4.21 prowjobs"
         steps:
           - name: determine
             image: registry.redhat.io/ubi9/ubi-minimal:latest
@@ -74,7 +76,7 @@ spec:
               set -e
 
               # Supported OCP versions
-              OCP_VERSIONS="418 419 420"
+              OCP_VERSIONS="418 419 420 421"
 
               # Function to check if a value is in the space-separated list
               contains() {
@@ -161,7 +163,6 @@ spec:
           operator: in
           values: ["true"]
       runAfter:
-        - prowjob-ocp420
         - prowjob-ocp419
       taskRef:
         resolver: git
@@ -199,7 +200,8 @@ spec:
           operator: in
           values: ["true"]
       runAfter:
-        - prowjob-sanity
+        - prowjob-ocp21
+        - prowjob-ocp20
       taskRef:
         resolver: git
         params:
@@ -261,3 +263,39 @@ spec:
           - name: PROWJOB_NAME
             value:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-peerpods
+    - name: prowjob-ocp421
+      displayName: "Running prow job $(params.PROWJOB_NAME)"
+      timeout: "4h"
+      when:
+        - input: "$(tasks.determine-prowjobs.results.run_ocp421)"
+          operator: in
+          values: ["true"]
+      runAfter:
+        - prowjob-sanity
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/openshift/konflux-tasks
+        - name: revision
+          value: 4826f365057d22d0189fa0db00d953c151f90c77
+        - name: pathInRepo
+          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: VARIANT
+          value: downstream-candidate421
+        - name: ENVS
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.25.0-2.rhaos4.21.el9"
+        - name: RETRY_DELAY
+          value: "60"
+        - name: MAX_RETRIES
+          value: "5"
+      matrix:
+        params:
+          - name: PROWJOB_NAME
+            value:
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-azure-ipi-kata
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-azure-ipi-peerpods
+              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-aws-ipi-peerpods


### PR DESCRIPTION
Added a trigger for OCP 4.21.

Re-arranged the sequence of executions to:
 sanity -> 4.20/4.21 (parallel) -> 4.19 -> 4.18

Depends on https://github.com/openshift/release/pull/76027