### PR TITLE
Fix OCP version check for baremetal CoCo

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
+	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
 	configv1 "github.com/openshift/api/config/v1"
@@ -159,12 +161,16 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 }
 
 // validateOCPVersion checks if the current OpenShift cluster is valid based on
-// minimal version in minOCPVersion.
-// Returns false if OCP version is < to minimal version
-// Returns true otherwise
+// minimal versions in minOCPVersions.
+// Returns false if OCP version is < to all minimal versions
+// Returns false if OCP version is < to the minimal version matching major.minor
+// Returns true otherwise (i.e. assume that any higher OCP version has support)
 // Returns error if cluster version is not available or cannot be retrieved.
 func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
-	minOCPVersion := "4.20.6"
+	// Sorted slice of minimal OCP z-stream releases.
+	minOCPVersions := slices.Sorted(slices.Values([]string{
+		"4.20.6",
+	}))
 
 	clusterVersion := &configv1.ClusterVersion{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
@@ -182,22 +188,50 @@ func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
 		return false, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
 	}
 
-	minVersion := minOCPVersion
-	min, err := semver.NewVersion(minVersion)
-	if err != nil {
-		return false, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
+	supported := false
+	for i, minVersion := range minOCPVersions {
+		min, err := semver.NewVersion(minVersion)
+		if err != nil {
+			return false, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
+		}
+
+		if current.Major() < min.Major() {
+			// major is too low to be even considered.
+			break
+		}
+
+		if current.Major() == min.Major() {
+			if current.Minor() < min.Minor() {
+				// minor is too low to be even considered.
+				break
+			}
+
+			if current.Minor() == min.Minor() {
+				// Same major/minor, just compare the patch.
+				supported = !current.LessThan(min)
+				break
+			}
+		}
+
+		if i == len(minOCPVersions)-1 {
+			// Higher major/minor than the last version is assumed to have proper support.
+			supported = true
+		}
 	}
 
-	if current.LessThan(min) {
-		r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", currentVersion, "minVersion", minVersion)
+	if !supported {
+		minVersions := strings.Join(minOCPVersions, ", ")
+
+		r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", currentVersion, "minVersions", minVersions)
 		cond := r.retrieveInProgressConditionForChange()
 		cond.Status = corev1.ConditionFalse
 		cond.Reason = "UnsupportedOCPVersion"
-		cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: %s or higher)", currentVersion, minVersion)
+		cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: %s or higher)", currentVersion, minVersions)
 
 		return false, nil
 	}
 
+	r.Log.Info("OpenShift version supports CoCo bare metal", "version", currentVersion)
 	return true, nil
 }
 

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -169,7 +169,9 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
 	// Sorted slice of minimal OCP z-stream releases.
 	minOCPVersions := slices.Sorted(slices.Values([]string{
-		"4.20.6",
+		"4.19.27",
+		"4.20.17",
+		"4.21.8",
 	}))
 
 	clusterVersion := &configv1.ClusterVersion{}

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -177,6 +177,7 @@ func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
 
 	currentVersion := os.Getenv("BM_COCO_OVERRIDE_OCP_VERSION")
 	if currentVersion == "" {
+		// FIXME: Look into having a single util function to return the ClusterVersion
 		clusterVersion := &configv1.ClusterVersion{}
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 		if err != nil {

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"maps"
 
+	semver "github.com/Masterminds/semver/v3"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -153,6 +156,34 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 	}
 
 	return nil
+}
+
+// isOCPVersionLessThan checks if the current OpenShift cluster version is less than the specified minimum version.
+// Returns (true, version, nil) if current version < minVersion, (false, version, nil) if current >= minVersion.
+// Returns error if cluster version is not available or cannot be retrieved.
+func (r *KataConfigOpenShiftReconciler) isOCPVersionLessThan(minVersion string) (bool, string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	if err != nil {
+		return false, "", err
+	}
+
+	currentVersion := clusterVersion.Status.Desired.Version
+	if currentVersion == "" {
+		return false, "", fmt.Errorf("cluster version not available yet")
+	}
+
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false, currentVersion, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
+	}
+
+	min, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return false, currentVersion, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
+	}
+
+	return current.LessThan(min), currentVersion, nil
 }
 
 // handleConfidentialBaremetal configures confidential computing for baremetal deployments.

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 
@@ -174,15 +175,18 @@ func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
 		"4.21.8",
 	}))
 
-	clusterVersion := &configv1.ClusterVersion{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
-	if err != nil {
-		return false, err
-	}
-
-	currentVersion := clusterVersion.Status.Desired.Version
+	currentVersion := os.Getenv("BM_COCO_OVERRIDE_OCP_VERSION")
 	if currentVersion == "" {
-		return false, fmt.Errorf("cluster version not available yet")
+		clusterVersion := &configv1.ClusterVersion{}
+		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+		if err != nil {
+			return false, err
+		}
+
+		currentVersion = clusterVersion.Status.Desired.Version
+		if currentVersion == "" {
+			return false, fmt.Errorf("cluster version not available yet")
+		}
 	}
 
 	current, err := semver.NewVersion(currentVersion)

--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -158,32 +158,47 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialPeerPods(state Feature
 	return nil
 }
 
-// isOCPVersionLessThan checks if the current OpenShift cluster version is less than the specified minimum version.
-// Returns (true, version, nil) if current version < minVersion, (false, version, nil) if current >= minVersion.
+// validateOCPVersion checks if the current OpenShift cluster is valid based on
+// minimal version in minOCPVersion.
+// Returns false if OCP version is < to minimal version
+// Returns true otherwise
 // Returns error if cluster version is not available or cannot be retrieved.
-func (r *KataConfigOpenShiftReconciler) isOCPVersionLessThan(minVersion string) (bool, string, error) {
+func (r *KataConfigOpenShiftReconciler) validateOCPVersion() (bool, error) {
+	minOCPVersion := "4.20.6"
+
 	clusterVersion := &configv1.ClusterVersion{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 	if err != nil {
-		return false, "", err
+		return false, err
 	}
 
 	currentVersion := clusterVersion.Status.Desired.Version
 	if currentVersion == "" {
-		return false, "", fmt.Errorf("cluster version not available yet")
+		return false, fmt.Errorf("cluster version not available yet")
 	}
 
 	current, err := semver.NewVersion(currentVersion)
 	if err != nil {
-		return false, currentVersion, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
+		return false, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
 	}
 
+	minVersion := minOCPVersion
 	min, err := semver.NewVersion(minVersion)
 	if err != nil {
-		return false, currentVersion, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
+		return false, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
 	}
 
-	return current.LessThan(min), currentVersion, nil
+	if current.LessThan(min) {
+		r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", currentVersion, "minVersion", minVersion)
+		cond := r.retrieveInProgressConditionForChange()
+		cond.Status = corev1.ConditionFalse
+		cond.Reason = "UnsupportedOCPVersion"
+		cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: %s or higher)", currentVersion, minVersion)
+
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // handleConfidentialBaremetal configures confidential computing for baremetal deployments.
@@ -192,17 +207,12 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 	// if confidential feature gate enabled
 	if state == Enabled {
 		if !r.kataConfig.Spec.EnablePeerPods {
-			isLess, version, err := r.isOCPVersionLessThan("4.20.6")
+			isValid, err := r.validateOCPVersion()
 			if err != nil {
 				// Return error to trigger reconcile retry (cluster version not available yet or API error)
 				return err
 			}
-			if isLess {
-				r.Log.Info("WARNING: OpenShift version does not support CoCo bare metal", "version", version, "minVersion", "4.20.6")
-				cond := r.retrieveInProgressConditionForChange()
-				cond.Status = corev1.ConditionFalse
-				cond.Reason = "UnsupportedOCPVersion"
-				cond.Message = fmt.Sprintf("OpenShift version %s does not support CoCo bare metal (minimum required: 4.20.6)", version)
+			if !isValid {
 				return nil
 			}
 		}

--- a/controllers/confidential_handler_test.go
+++ b/controllers/confidential_handler_test.go
@@ -1,0 +1,184 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"os"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kataconfigurationv1 "github.com/openshift/sandboxed-containers-operator/api/v1"
+)
+
+var _ = Describe("validateOCPVersion", func() {
+	var (
+		reconciler *KataConfigOpenShiftReconciler
+		origEnv    string
+	)
+
+	BeforeEach(func() {
+		// Save original environment variable
+		origEnv = os.Getenv("BM_COCO_OVERRIDE_OCP_VERSION")
+
+		// Create a minimal reconciler for testing
+		reconciler = &KataConfigOpenShiftReconciler{
+			Log:        logr.Discard(), // Use discard logger for tests
+			kataConfig: &kataconfigurationv1.KataConfig{},
+		}
+	})
+
+	AfterEach(func() {
+		// Restore original environment variable
+		if origEnv != "" {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", origEnv)
+		} else {
+			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+		}
+	})
+
+	Context("when testing version validation logic", func() {
+		// Test cases for versions below minimum requirements
+		DescribeTable("should return false for versions below minimum",
+			func(version string) {
+				os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)
+				valid, err := reconciler.validateOCPVersion()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(valid).To(BeFalse())
+			},
+			Entry("version 4.18.0 (major.minor too low)", "4.18.0"),
+			Entry("version 4.19.0 (patch too low)", "4.19.0"),
+			Entry("version 4.19.26 (patch one below minimum)", "4.19.26"),
+			Entry("version 4.20.0 (patch too low)", "4.20.0"),
+			Entry("version 4.20.16 (patch one below minimum)", "4.20.16"),
+			Entry("version 4.21.0 (patch too low)", "4.21.0"),
+			Entry("version 4.21.7 (patch one below minimum)", "4.21.7"),
+		)
+
+		// Test cases for versions at or above minimum requirements
+		DescribeTable("should return true for versions at or above minimum",
+			func(version string) {
+				os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", version)
+				valid, err := reconciler.validateOCPVersion()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(valid).To(BeTrue())
+			},
+			Entry("version 4.19.27 (exact minimum for 4.19)", "4.19.27"),
+			Entry("version 4.19.28 (above minimum for 4.19)", "4.19.28"),
+			Entry("version 4.19.100 (well above minimum for 4.19)", "4.19.100"),
+			Entry("version 4.20.17 (exact minimum for 4.20)", "4.20.17"),
+			Entry("version 4.20.18 (above minimum for 4.20)", "4.20.18"),
+			Entry("version 4.20.100 (well above minimum for 4.20)", "4.20.100"),
+			Entry("version 4.21.8 (exact minimum for 4.21)", "4.21.8"),
+			Entry("version 4.21.9 (above minimum for 4.21)", "4.21.9"),
+			Entry("version 4.21.100 (well above minimum for 4.21)", "4.21.100"),
+			Entry("version 4.22.0 (higher minor, assumed supported)", "4.22.0"),
+			Entry("version 4.25.1 (much higher minor, assumed supported)", "4.25.1"),
+			Entry("version 5.0.0 (higher major, assumed supported)", "5.0.0"),
+		)
+
+		// Test cases for invalid version formats
+		It("should return error for invalid version format", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "invalid-version")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).To(HaveOccurred())
+			Expect(valid).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("unable to parse current OCP version"))
+		})
+
+		It("should return error for malformed version", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "not-a-version")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).To(HaveOccurred())
+			Expect(valid).To(BeFalse())
+		})
+
+		It("should handle version with pre-release suffix", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.8-rc1")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).ToNot(HaveOccurred())
+			// Pre-release versions (4.21.8-rc1) are considered LESS than their base (4.21.8) by semver
+			// So this should return false since it's technically below the minimum
+			Expect(valid).To(BeFalse())
+		})
+	})
+
+	Context("when BM_COCO_OVERRIDE_OCP_VERSION is not set", func() {
+		It("should attempt to fetch from cluster", func() {
+			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+
+			// In unit test environment, this will use the test k8s client from suite_test.go
+			// The cluster won't have the version CRD populated, so it should return an error
+			reconciler.Client = k8sClient
+			_, err := reconciler.validateOCPVersion()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("edge cases", func() {
+		It("should handle version 4.19.26 correctly (just below threshold)", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.26")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(valid).To(BeFalse())
+		})
+
+		It("should handle version 4.19.27 correctly (exactly at threshold)", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.19.27")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(valid).To(BeTrue())
+		})
+
+		It("should handle versions between supported minors", func() {
+			// 4.19.27+ is supported, 4.20.17+ is supported
+			// But 4.20.0 to 4.20.16 should not be supported
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.20.10")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(valid).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("validateOCPVersion integration", func() {
+	var reconciler *KataConfigOpenShiftReconciler
+
+	BeforeEach(func() {
+		reconciler = &KataConfigOpenShiftReconciler{
+			Client:     k8sClient,
+			Log:        ctrl.Log.WithName("test").WithName("validateOCPVersion"),
+			Scheme:     k8sManager.GetScheme(),
+			kataConfig: &kataconfigurationv1.KataConfig{},
+		}
+	})
+
+	Context("with environment override", func() {
+		AfterEach(func() {
+			os.Unsetenv("BM_COCO_OVERRIDE_OCP_VERSION")
+		})
+
+		It("should use environment variable when set", func() {
+			os.Setenv("BM_COCO_OVERRIDE_OCP_VERSION", "4.21.8")
+			valid, err := reconciler.validateOCPVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(valid).To(BeTrue())
+		})
+	})
+})

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -570,6 +570,7 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 		return extension, nil
 	}
 
+	// FIXME: Look into having a single util function to return the ClusterVersion
 	clusterVersion := &configv1.ClusterVersion{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 	if err != nil {

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	semver "github.com/Masterminds/semver/v3"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -592,34 +591,6 @@ func (r *KataConfigOpenShiftReconciler) getExtensionName() (string, error) {
 
 	// As RHCOS is rather special variant, use "kata-containers" by default, which also applies to FCOS/SCOS
 	return "kata-containers", nil
-}
-
-// isOCPVersionLessThan checks if the current OpenShift cluster version is less than the specified minimum version.
-// Returns (true, version, nil) if current version < minVersion, (false, version, nil) if current >= minVersion.
-// Returns error if cluster version is not available or cannot be retrieved.
-func (r *KataConfigOpenShiftReconciler) isOCPVersionLessThan(minVersion string) (bool, string, error) {
-	clusterVersion := &configv1.ClusterVersion{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
-	if err != nil {
-		return false, "", err
-	}
-
-	currentVersion := clusterVersion.Status.Desired.Version
-	if currentVersion == "" {
-		return false, "", fmt.Errorf("cluster version not available yet")
-	}
-
-	current, err := semver.NewVersion(currentVersion)
-	if err != nil {
-		return false, currentVersion, fmt.Errorf("unable to parse current OCP version %s: %w", currentVersion, err)
-	}
-
-	min, err := semver.NewVersion(minVersion)
-	if err != nil {
-		return false, currentVersion, fmt.Errorf("invalid minimum version format %s: %w", minVersion, err)
-	}
-
-	return current.LessThan(min), currentVersion, nil
 }
 
 // getCustomKernelConfig retrieves the kata addon configuration from the "kata-addon-artifacts" ConfigMap in the operator namespace.

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -191,6 +191,7 @@ func isConfigMapRelevant(configMapName string) bool {
 
 // Method to get cluster id from ClusterVersion object
 func getClusterID(c client.Client) (string, error) {
+	// FIXME: Look into having a single util function to return the ClusterVersion
 	clusterVersion := &configv1.ClusterVersion{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 	if err != nil {
@@ -246,6 +247,7 @@ func updateConfigMap(client client.Client, logger logr.Logger, cmName string, na
 // It searches for the componentName in the release info and returns the corresponding Docker image.
 func GetImageForComponent(componentName string, client client.Client) (string, error) {
 	// Fetch the cluster version
+	// FIXME: Look into having a single util function to return the ClusterVersion
 	clusterVersion := &configv1.ClusterVersion{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
 	if err != nil {


### PR DESCRIPTION
Baremetal CoCo was TP in OSC 1.11 with a very limited _support_ matrix : OCP 4.20 only, starting with OCP 4.20.6.

Baremetal CoCo will be GA with OSC 1.12 and the support matrix is bigger : OCP 4.19, 4.20 and 4.21, starting with specific z-stream versions that will ship the appropriate kata-containers RPM.

Adapt the validation logic to handle these new OCP versions. The respective z-streams are hardcoded and not configurable for the sake of simplicity. They can be adjusted just before the release of OSC 1.12 if needed.

A _hidden_ knob is provided to override the OCP version used in the validation check. This is to allow testing of
baremetal CoCo on with existing OCP versions that would fail obviously validation.
