### PR TITLE
tests/osc-test-fbc-integration: fix prowjob task name typos in runAfter

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -200,8 +200,8 @@ spec:
           operator: in
           values: ["true"]
       runAfter:
-        - prowjob-ocp21
-        - prowjob-ocp20
+        - prowjob-ocp421
+        - prowjob-ocp420
       taskRef:
         resolver: git
         params:


### PR DESCRIPTION
Correct prowjob-ocp21 to prowjob-ocp421 and prowjob-ocp20 to prowjob-ocp420 in the prowjob-ocp419 task dependencies to match actual task names.

Issue introduced in commit dfc240a697132aaa5e3b14df3706359e28947f0d

Assisted-by: Claude