### PR TITLE
runtimeclass: Only enforce node labels when required

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -970,7 +970,7 @@ func (r *KataConfigOpenShiftReconciler) createRuntimeClass(
 		nodeSelector := r.getNodeSelectorAsMap()
 
 		// Add additional node label if provided
-		if additionalNodeLabels != nil {
+		if r.kataConfig.Spec.CheckNodeEligibility && additionalNodeLabels != nil {
 			maps.Copy(nodeSelector, additionalNodeLabels)
 		}
 


### PR DESCRIPTION
If the user didn't set `checkNodeEligibility`, they certainly don't want node labels to affect the runtime class availability on kata nodes.

This fixes a regression that was observed by QE with the `kata` runtime class : kata pods would remain `Pending` forever because of an unexpected `feature.node.kubernetes.io/runtime.kata=true` label in the runtime class node selector.

Fixes https://issues.redhat.com/browse/KATA-4752
