### PR TITLE
Add dashboard namespace to the cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -119,7 +119,8 @@ func main() {
 				&corev1.ConfigMap{}: {
 					// Same for config maps
 					Namespaces: map[string]cache.Config{
-						controllers.OperatorNamespace: {},
+						controllers.OperatorNamespace:           {},
+						controllers.DashboardConfigMapNamespace: {},
 					},
 				},
 			},

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -77,7 +77,7 @@ type customKernelConfig struct {
 
 const (
 	OperatorNamespace             = "openshift-sandboxed-containers-operator"
-	dashboard_configmap_name      = "grafana-dashboard-sandboxed-containers"
+	dashboardConfigMapName        = "grafana-dashboard-sandboxed-containers"
 	DashboardConfigMapNamespace   = "openshift-config-managed"
 	container_runtime_config_name = "kata-crio-config"
 	extension_mc_name             = "50-enable-sandboxed-containers-extension"
@@ -505,7 +505,7 @@ func (r *KataConfigOpenShiftReconciler) processDashboardConfigMap() *corev1.Conf
 
 	// retrieve content of the dashboard from our own namespace
 	foundCm := &corev1.ConfigMap{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: dashboard_configmap_name, Namespace: OperatorNamespace}, foundCm)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: dashboardConfigMapName, Namespace: OperatorNamespace}, foundCm)
 	if err != nil {
 		r.Log.Error(err, "could not get dashboard data")
 		return nil
@@ -517,7 +517,7 @@ func (r *KataConfigOpenShiftReconciler) processDashboardConfigMap() *corev1.Conf
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dashboard_configmap_name,
+			Name:      dashboardConfigMapName,
 			Namespace: DashboardConfigMapNamespace,
 			Labels:    cmLabels,
 		},

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -78,7 +78,7 @@ type customKernelConfig struct {
 const (
 	OperatorNamespace             = "openshift-sandboxed-containers-operator"
 	dashboard_configmap_name      = "grafana-dashboard-sandboxed-containers"
-	dashboard_configmap_namespace = "openshift-config-managed"
+	DashboardConfigMapNamespace   = "openshift-config-managed"
 	container_runtime_config_name = "kata-crio-config"
 	extension_mc_name             = "50-enable-sandboxed-containers-extension"
 	KataAddonConfigMapName        = "kata-addon-artifacts"
@@ -518,7 +518,7 @@ func (r *KataConfigOpenShiftReconciler) processDashboardConfigMap() *corev1.Conf
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dashboard_configmap_name,
-			Namespace: dashboard_configmap_namespace,
+			Namespace: DashboardConfigMapNamespace,
 			Labels:    cmLabels,
 		},
 		Data: foundCm.Data,


### PR DESCRIPTION
This was missed by PR https://github.com/openshift/sandboxed-containers-operator/pull/1775. It causes this error :

ERROR	controllers.KataConfig	could not get dashboard info, try again	{"error": "unable to get: openshift-config-managed/grafana-dashboard-sandboxed-containers because of unknown namespace for the cache"}

Fix the name of the dashboard namespace variable to follow official go coding style [1], export the variable [2] and use it in the cache filter.