### PR TITLE
Fix `make-test` failures in CI

### DIFF
--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -43,9 +43,10 @@ spec:
             srcURL=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.url' <<< "${SNAPSHOT}")
             srcREV=$(jq -r '.components[] | select(.name=="osc-operator") | .source.git.revision' <<< "${SNAPSHOT}")
 
-            git clone --recurse-submodules ${srcURL} sources
+            git clone ${srcURL} sources
             cd sources
             git checkout ${srcREV}
+            git submodule update --init --recursive
             GOMAXPROCS=2 make test
 
             # After the tests finish, record the overall result in the RESULT variable

--- a/tests/make-test.yaml
+++ b/tests/make-test.yaml
@@ -34,7 +34,7 @@ spec:
             value: $(params.SNAPSHOT)
           script: |
             #!/bin/bash
-            set -e
+            set -ex
             SUCCESSES=0
             FAILURES=0
             WARNINGS=0


### PR DESCRIPTION
Fix `make test` failures when `git clone --recurse-submodules` doesn't clone submodules.



