### PR TITLE
runtimeclass: fix nvidia sandbox device plugin label

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -96,11 +96,11 @@ const (
 var (
 	// node labels for NVIDIA GPU
 	nvidiaGPUNodeLabels = map[string]string{
-		"nvidia.com/gpu.present":                      "true",
-		"nvidia.com/gpu.deploy.vfio-manager":          "true",
-		"nvidia.com/gpu.deploy.sandbox-device-plugin": "true",
-		"nvidia.com/cc.mode.state":                    "off",
-		"nvidia.com/cc.ready.state":                   "false",
+		"nvidia.com/gpu.present":                           "true",
+		"nvidia.com/gpu.deploy.vfio-manager":               "true",
+		"nvidia.com/gpu.deploy.kata-sandbox-device-plugin": "true",
+		"nvidia.com/cc.mode.state":                         "off",
+		"nvidia.com/cc.ready.state":                        "false",
 	}
 )
 


### PR DESCRIPTION
Update sandbox device plugin label to match latest nvidia gpu-operator label for kata sandbox device plugins

Fixes: https://redhat.atlassian.net/browse/KATA-4756

**- Description of the problem which is fixed/What is the use case**
Label verification fails since old label is not used anymore.

**- What I did**
Update label

**- How to verify it**
TBD

**- Description for the changelog**
Fix incorrect label for kata sandbox device plugin
