### PR TITLE
chore(deps): Manually update osc-must-gather to 284e6a028

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -411,7 +411,7 @@ spec:
                 - name: RELATED_IMAGE_PODVM_OCI
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:564494c4f91da66cc187f991ab8e56a8d2f2fc7cfc3283bf67bf31daf84371b5
                 - name: RELATED_IMAGE_MUST_GATHER
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:0d93bfea91741f202a93e5fac8244ca0c9dd95bb25c3ebf341ccc71f0b7bd88b
+                  value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:284e6a0286570b55514a8c8d2b3d3904ce2ad8308c8950811d4975206cbe4fcc
                 - name: RELATED_IMAGE_PCCS
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:8b47f981f385370b0c8621ac93b5cdee187f03875fc9291cb47fa1988b3c813f
                 - name: RELATED_IMAGE_TDX_QGS
@@ -585,7 +585,7 @@ spec:
     name: podvm-payload
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:564494c4f91da66cc187f991ab8e56a8d2f2fc7cfc3283bf67bf31daf84371b5
     name: podvm-oci
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:0d93bfea91741f202a93e5fac8244ca0c9dd95bb25c3ebf341ccc71f0b7bd88b
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:284e6a0286570b55514a8c8d2b3d3904ce2ad8308c8950811d4975206cbe4fcc
     name: must-gather
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:8b47f981f385370b0c8621ac93b5cdee187f03875fc9291cb47fa1988b3c813f
     name: pccs

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -99,7 +99,7 @@ spec:
             - name: RELATED_IMAGE_PODVM_OCI
               value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:564494c4f91da66cc187f991ab8e56a8d2f2fc7cfc3283bf67bf31daf84371b5
             - name: RELATED_IMAGE_MUST_GATHER
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:0d93bfea91741f202a93e5fac8244ca0c9dd95bb25c3ebf341ccc71f0b7bd88b
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:284e6a0286570b55514a8c8d2b3d3904ce2ad8308c8950811d4975206cbe4fcc
             - name: RELATED_IMAGE_PCCS
               value: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:8b47f981f385370b0c8621ac93b5cdee187f03875fc9291cb47fa1988b3c813f
             - name: RELATED_IMAGE_TDX_QGS


### PR DESCRIPTION
Manually changing it because the latest on-push pipeline failed on Konflux. 

Image fetched from the latest image in quay.io [1]

[1] https://quay.io/repository/redhat-user-workloads/ose-osc-tenant/osc-must-gather?tab=tags&tag=latest

Reference: https://github.com/openshift/sandboxed-containers-operator/pull/1899


