### PR TITLE
Adding more output and RCA to dig.py

### DIFF
--- a/.claude/commands/prowjob-analyze.md
+++ b/.claude/commands/prowjob-analyze.md
@@ -190,7 +190,7 @@ Tests use hardcoded defaults that can be overridden via `osc-config` ConfigMap:
 - Runtime class name (kata, kata-remote)
 - Enable peer pods (true/false)
 - Workload type to test (kata, peer-pods, coco)
-****- Install Kata RPM (true/false)
+- Install Kata RPM (true/false)
 - Enable GPU to include Nvidia GPU drivers in podvm image and run GPU tests
 - Set initdata for the OSC operator
 - Must-gather image

--- a/.claude/commands/prowjob-analyze.md
+++ b/.claude/commands/prowjob-analyze.md
@@ -190,7 +190,7 @@ Tests use hardcoded defaults that can be overridden via `osc-config` ConfigMap:
 - Runtime class name (kata, kata-remote)
 - Enable peer pods (true/false)
 - Workload type to test (kata, peer-pods, coco)
-- Install Kata RPM (true/false)
+****- Install Kata RPM (true/false)
 - Enable GPU to include Nvidia GPU drivers in podvm image and run GPU tests
 - Set initdata for the OSC operator
 - Must-gather image

--- a/scripts/prowjob-analyzer/README.md
+++ b/scripts/prowjob-analyzer/README.md
@@ -17,6 +17,7 @@ The Prow Job Analyzer provides comprehensive analysis of Prow job runs, extracti
 - **Test Summary**: Lists failing tests if tests executed
 - **Multiple Output Formats**: Generates both human-readable markdown and machine-parsable JSON reports
 - **In-Progress Job Handling**: Can wait for running jobs to complete before analysis
+- **Local or Remote Artifacts**: Analyze from a Prow URL, from a local directory or a `.tar.gz` that matches the job artifact tree (`prowjob.json` at the job root). A tarball or directory can be used **without** a URL; report links prefer `status.url` from `prowjob.json` when present
 
 **Level 2: Detailed Test Analysis** (`dig_failed_tests_report.py`):
 - **Full Test Logs**: Extracts complete test execution logs from build-log.txt
@@ -41,8 +42,51 @@ cd scripts/prowjob-analyzer
 ```
 If it succeeded, there is no need to investigate further.
 
+#### Analyzing a local artifact tree or `.tar.gz`
 
-### Further Investgation
+If you already have job artifacts (same layout as the **gsutil** command on the Prow **Artifacts** page: `prowjob.json` at the root, `artifacts/…` below), you can analyze **without** a URL:
+
+```bash
+cd scripts/prowjob-analyzer
+./dig.py --artifacts /path/to/job-artifacts.tar.gz
+# or an extracted directory:
+./dig.py --artifacts /path/to/job-artifacts-dir
+```
+
+You can still pass a URL together with `--artifacts` if you want an explicit job identity or consistent links; otherwise links in the report use `status.url` from `prowjob.json`, or a `file://` URI for the bundle path.
+
+To download artifacts from GCS from the tool (requires `gsutil` on `PATH`), use `--download-artifacts` with a **Prow job URL**; optional `--tar-artifacts` writes `PARENT_DIR/<build-id>.tar.gz` next to the downloaded folder. See **Options** under `dig.py` below.
+
+#### Download, analyze, create a `.tar.gz`, and remove the directory
+
+Yes—with a **single** `dig.py` invocation you can download, analyze, and create the tarball. The analysis step always reads the **extracted directory** (`PARENT_DIR/<build-id>/`); the `.tar.gz` is written from that tree after download (when `--tar-artifacts` is set).
+
+```bash
+cd scripts/prowjob-analyzer
+./dig.py --download-artifacts /tmp --tar-artifacts '<PROW_JOB_URL>'
+```
+
+This produces:
+
+| Path | Role |
+|------|------|
+| `/tmp/<build-id>/` | Full artifact tree; **used for analysis in this run** |
+| `/tmp/<build-id>.tar.gz` | Same content archived for storage or later re-analysis |
+
+`dig.py` does **not** delete the extracted directory automatically (there is no built-in “remove after tar” flag). After the command finishes successfully, if you only want to keep the archive, delete the folder yourself. The directory name is the job’s **build ID** (the last path segment of the Prow URL, or the folder you see under `PARENT_DIR`):
+
+```bash
+rm -rf "/tmp/<build-id>"
+```
+
+You can analyze the saved bundle later without re-downloading:
+
+```bash
+./dig.py --artifacts "/tmp/<build-id>.tar.gz"
+```
+
+
+### Further Investigation
  On failed jobs, you can use Claude (recommended) or `dig_failed_tests_report.py`\
 
 #### Claude via script (Recommended)
@@ -126,6 +170,17 @@ You can also run the dig scripts directly:
 # Basic usage
 ./dig.py <PROW_JOB_URL>
 
+# Local directory or tarball only (no URL)
+./dig.py --artifacts /path/to/job-artifacts.tar.gz
+./dig.py --artifacts /path/to/extracted-artifacts-dir
+
+# Optional: combine URL with a local tree (reads from disk, no per-file HTTP for artifacts)
+./dig.py --artifacts /path/to/dir <PROW_JOB_URL>
+
+# Download artifacts with gsutil (requires URL), then analyze
+./dig.py --download-artifacts . <PROW_JOB_URL>
+./dig.py --download-artifacts /tmp --tar-artifacts <PROW_JOB_URL>
+
 # Generate JSON output
 ./dig.py --json <PROW_JOB_URL> > report.json
 
@@ -154,10 +209,16 @@ You can also run the dig scripts directly:
 ### Options
 
 **dig.py:**
-- `--json`: Output machine-readable JSON format instead of human-readable markdown
+- `url` (optional positional): Prow job URL. **Required** unless you pass `--artifacts` pointing at a directory or `.tar.gz` that contains `prowjob.json`. **Required** for `--download-artifacts`.
+- `--artifacts PATH`: Local directory or `.tar.gz` of job artifacts (Prow layout: `prowjob.json` at job root). Can be used **alone** or with a URL. When set, analysis reads from disk (no per-file HTTP for artifacts).
+- `--download-artifacts [PARENT_DIR]`: With a URL, run `gsutil` to copy the GCS prefix into `PARENT_DIR/<build-id>` (default parent: current directory). Requires `gsutil` on `PATH`.
+- `--tar-artifacts`: With `--download-artifacts`, also write `PARENT_DIR/<build-id>.tar.gz` beside the downloaded directory.
+- `--json`: Output machine-readable JSON instead of human-readable markdown
+- `--csv`: Output one CSV row from the canonical report (see Konflux batch example above)
+- `--no-header`: With `--csv`, omit the header row
 - `--verbose, -v`: Enable verbose logging for debugging
-- `--wait SECONDS`: Set timeout for waiting for in-progress jobs (default: 300 seconds)
-- `--no-wait`: Don't wait for in-progress jobs (analyze immediately)
+- `--wait SECONDS`: Timeout for waiting on in-progress **remote** jobs (default: 300; use `0` or `--no-wait` to disable). Not used when analyzing only from `--artifacts` or a tree produced by `--download-artifacts`.
+- `--no-wait`: Don't wait for in-progress jobs (same as `--wait 0`)
 
 **dig_failed_tests_report.py:**
 - `--json`: Output machine-readable JSON format
@@ -253,7 +314,7 @@ prowjob-analyzer/
    - Validates Prow URLs
 
 2. **dig.py**: Level 1 analysis - overall job status and metadata
-   - Fetches prowjob.json, finished.json, test-results.yaml
+   - Loads `prowjob.json`, `finished.json`, `test-results.yaml`, and step logs from the Prow job URL or from a local directory / `.tar.gz` (`--artifacts`), or after `--download-artifacts`
    - Determines which step(s) failed
    - Lists failing tests (if tests ran)
    - Generates comprehensive report with metadata and artifact links
@@ -265,7 +326,7 @@ prowjob-analyzer/
    - Only runs when tests actually executed and failed
 
 **Library Modules:**
-1. **Fetcher**: URL parsing, artifact downloading with retry logic, step detection
+1. **Fetcher**: URL parsing, HTTP fetching with retries, optional local directory or `.tar.gz` artifact root (same layout as gsutil download), optional `gsutil`-based full-tree download, step detection
 2. **Parser**: prowjob.json and test-results.yaml parsing, job status determination
 3. **Metadata Extractor**: Provider, OCP version, workload type, Kata RPM extraction
 4. **Failure Analyzer**: Failed step identification, test categorization
@@ -287,6 +348,7 @@ When using `/prowjob-analyze` command, Claude follows this workflow:
 
 - Python 3.6+
 - `pyyaml` library (for parsing test-results.yaml)
+- `gsutil` on `PATH` (only if you use `dig.py --download-artifacts` to pull artifacts from GCS)
 
 ### Installing Dependencies
 
@@ -302,7 +364,7 @@ sudo dnf install python3-pyyaml
 
 - `0`: Job passed successfully
 - `1`: Job failed, timed out, or was aborted
-- `2`: Analysis error (cannot fetch artifacts, invalid URL, etc.)
+- `2`: Analysis error (cannot load artifacts, invalid URL, missing `prowjob.json`, CLI usage error such as neither URL nor `--artifacts`, etc.)
 
 ## Examples
 
@@ -367,9 +429,8 @@ The analyzer is tailored for OSC jobs with special handling for:
 
 ### "Failed to fetch prowjob.json"
 
-- Check that the Prow job URL is correct
-- Verify the job has completed (or use --wait to wait for completion)
-- Ensure you have network access to prow.ci.openshift.org
+- **Remote mode**: Check that the Prow job URL is correct, the job has completed (or use `--wait`), and you have network access to prow.ci.openshift.org
+- **Local mode** (`--artifacts`): Confirm the path is a directory or `.tar.gz` whose job root contains `prowjob.json` (if you archived a single top-level folder, the tool looks for a subdirectory that holds `prowjob.json`)
 
 ### "pyyaml not available"
 

--- a/scripts/prowjob-analyzer/dig.py
+++ b/scripts/prowjob-analyzer/dig.py
@@ -93,8 +93,10 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
     test_results = None
     variant = metadata.get('variant')
 
+    extended_finished = None
     if variant and variant != 'unknown':
-        test_results_path = f"artifacts/{variant}/openshift-extended-test/artifacts/test-results.yaml"
+        prefix = f"artifacts/{variant}/openshift-extended-test"
+        test_results_path = f"{prefix}/artifacts/test-results.yaml"
         test_results_content = fetch_artifact(base_url, test_results_path)
 
         if test_results_content:
@@ -104,8 +106,15 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
         else:
             logger.warning("test-results.yaml not found (might be a prow step failure)")
 
-    # Determine job status
-    status = get_job_status(prowjob_json, test_results)
+        finished_path = f"{prefix}/finished.json"
+        extended_finished = fetch_json_artifact(base_url, finished_path)
+        if extended_finished:
+            logger.info(
+                f"openshift-extended-test finished.json: result={extended_finished.get('result')!r}"
+            )
+
+    # Determine job status (test-results primary, then finished.json, then prowjob.json)
+    status = get_job_status(prowjob_json, test_results, extended_finished)
     logger.info(f"Job status: {status}")
 
     # Analyze failures if job failed

--- a/scripts/prowjob-analyzer/dig.py
+++ b/scripts/prowjob-analyzer/dig.py
@@ -27,7 +27,7 @@ from lib.parser import (
     get_job_status,
 )
 from lib.metadata_extractor import extract_metadata
-from lib.failure_analyzer import analyze_failure
+from lib.failure_analyzer import analyze_failure, analyze_post_test_prow_failure
 from lib.report_generator import build_report_data, generate_csv_report, generate_human_report, generate_json_report
 
 # Configure logging
@@ -117,7 +117,7 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
     status = get_job_status(prowjob_json, test_results, extended_finished)
     logger.info(f"Job status: {status}")
 
-    # Analyze failures if job failed
+    # Analyze failures if tests/job failed (test failures)
     failure_analysis = None
     if status != 'success':
         logger.info("Analyzing failure...")
@@ -125,6 +125,18 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
         logger.info(f"Failed step(s): {failure_analysis.get('failure_location')}")
         logger.info(f"Failing tests: {len(failure_analysis.get('failing_tests', []))}")
         logger.info(f"Detected patterns: {failure_analysis.get('detected_patterns')}")
+
+    # Tests passed but overall Prow job failed (e.g. later step) — not a test failure
+    if status == 'success':
+        prow_state = (prowjob_json.get('status') or {}).get('state', '').lower()
+        if prow_state not in ('success', 'pending', ''):
+            post = analyze_post_test_prow_failure(prowjob_json, base_url, metadata)
+            if post:
+                failure_analysis = post
+                logger.info(
+                    "Prow reported non-success after successful tests; "
+                    f"post-test step issue: {post.get('failure_location')}"
+                )
 
     return {
         'prowjob_data': prowjob_data,

--- a/scripts/prowjob-analyzer/dig.py
+++ b/scripts/prowjob-analyzer/dig.py
@@ -20,6 +20,7 @@ from lib.fetcher import (
     fetch_artifact,
     wait_for_artifacts,
     extract_variant_from_job_name,
+    compute_openshift_extended_test_elapsed_display,
 )
 from lib.parser import (
     parse_prowjob,
@@ -113,6 +114,15 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
                 f"openshift-extended-test finished.json: result={extended_finished.get('result')!r}"
             )
 
+    test_elapsed_time = 'unknown'
+    if variant and variant != 'unknown':
+        test_elapsed_time = compute_openshift_extended_test_elapsed_display(
+            base_url, variant, extended_finished
+        )
+        if not test_elapsed_time:
+            test_elapsed_time = 'unknown'
+        logger.info(f"test_elapsed_time: {test_elapsed_time}")
+
     # Determine job status (test-results primary, then finished.json, then prowjob.json)
     status = get_job_status(prowjob_json, test_results, extended_finished)
     logger.info(f"Job status: {status}")
@@ -145,6 +155,7 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
         'test_results': test_results,
         'failure_analysis': failure_analysis,
         'base_url': base_url,
+        'test_elapsed_time': test_elapsed_time,
     }
 
 
@@ -229,6 +240,7 @@ Examples:
         results['test_results'],
         results['failure_analysis'],
         results['base_url'],
+        results.get('test_elapsed_time', ''),
     )
     if args.json:
         logger.info("Generating JSON report...")

--- a/scripts/prowjob-analyzer/dig.py
+++ b/scripts/prowjob-analyzer/dig.py
@@ -36,12 +36,16 @@ logger = logging.getLogger(__name__)
 
 
 def setup_logging(verbose: bool = False):
-    """Configure logging."""
+    """Configure logging (always to stderr so stdout stays clean for --csv / redirects)."""
     level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format='%(levelname)s: %(message)s'
-    )
+    kwargs = {
+        'level': level,
+        'format': '%(levelname)s: %(message)s',
+        'stream': sys.stderr,
+    }
+    if sys.version_info >= (3, 8):
+        kwargs['force'] = True
+    logging.basicConfig(**kwargs)
 
 
 def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
@@ -252,10 +256,13 @@ Examples:
         logger.info("Generating human-readable report...")
         report = generate_human_report(report_data)
 
-    # Output report (no separator line for CSV)
+    # Output report (no separator line for CSV). CSV rows already end with a line
+    # terminator from csv.writer; avoid print()'s extra newline (blank line when appending).
     if not args.csv:
         print("\n" + "="*80 + "\n")
-    print(report)
+        print(report)
+    else:
+        print(report, end="")
 
     # Exit code based on job status
     if results['status'] == 'success':

--- a/scripts/prowjob-analyzer/dig.py
+++ b/scripts/prowjob-analyzer/dig.py
@@ -8,6 +8,7 @@ Analyzes OpenShift Prow job results for OSC testing.
 import argparse
 import logging
 import sys
+from pathlib import Path
 from typing import Optional
 
 # Add lib directory to path
@@ -21,6 +22,10 @@ from lib.fetcher import (
     wait_for_artifacts,
     extract_variant_from_job_name,
     compute_openshift_extended_test_elapsed_display,
+    configure_artifact_source,
+    download_job_artifacts,
+    write_job_artifacts_tarball,
+    is_local_artifact_mode,
 )
 from lib.parser import (
     parse_prowjob,
@@ -48,37 +53,65 @@ def setup_logging(verbose: bool = False):
     logging.basicConfig(**kwargs)
 
 
-def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
+_LOCAL_ONLY_FETCH_BASE = 'local://artifact-bundle'
+
+
+def analyze_prowjob(
+    url: Optional[str] = None,
+    wait_timeout: int = 300,
+    artifact_source: Optional[str] = None,
+) -> Optional[dict]:
     """
-    Analyze a Prow job from its URL.
+    Analyze a Prow job from its URL and/or local artifact tree.
 
     Args:
-        url: Prow job URL
+        url: Prow job URL (optional if ``artifact_source`` is a directory or ``.tar.gz``
+            containing ``prowjob.json``; links in reports use ``status.url`` from that file
+            or a ``file://`` URI for the bundle path).
         wait_timeout: Timeout for waiting for artifacts (seconds)
+        artifact_source: Optional path to a local directory or ``.tar.gz`` whose layout
+            matches Prow (``prowjob.json`` at job root). When set (including after
+            ``gsutil`` download via ``--download-artifacts``), all artifact reads use
+            this tree only—no per-file HTTP fetches.
 
     Returns:
         Analysis results as dict, or None on error
     """
     try:
-        # Parse URL
-        logger.info(f"Parsing Prow job URL...")
-        base_url, job_name, build_id = parse_prow_url(url)
-        logger.info(f"Job: {job_name}")
-        logger.info(f"Build ID: {build_id}")
-
-    except ValueError as e:
-        logger.error(str(e))
+        configure_artifact_source(artifact_source)
+    except (OSError, ValueError) as e:
+        logger.error("%s", e)
         return None
 
-    # Wait for artifacts if needed
-    if wait_timeout > 0:
+    if url:
+        try:
+            logger.info("Parsing Prow job URL...")
+            base_url, job_name, build_id = parse_prow_url(url)
+            logger.info(f"Job: {job_name}")
+            logger.info(f"Build ID: {build_id}")
+        except ValueError as e:
+            logger.error(str(e))
+            return None
+        fetch_base = base_url
+    else:
+        if not is_local_artifact_mode():
+            logger.error(
+                "Provide a Prow job URL or --artifacts PATH (directory or .tar.gz)."
+            )
+            return None
+        logger.info("Analyzing from local artifacts only (no Prow URL)")
+        fetch_base = _LOCAL_ONLY_FETCH_BASE
+        base_url = ''
+
+    # Wait for remote artifacts only when not using a local tree (dir or extracted tar).
+    if wait_timeout > 0 and not is_local_artifact_mode():
         logger.info("Checking if artifacts are ready...")
         if not wait_for_artifacts(base_url, timeout=wait_timeout):
             logger.warning("Artifacts not ready yet, attempting analysis anyway...")
 
     # Fetch prowjob.json
     logger.info("Fetching prowjob.json...")
-    prowjob_json = fetch_json_artifact(base_url, "prowjob.json")
+    prowjob_json = fetch_json_artifact(fetch_base, "prowjob.json")
 
     if not prowjob_json:
         logger.error("Failed to fetch prowjob.json - cannot analyze job")
@@ -87,6 +120,19 @@ def analyze_prowjob(url: str, wait_timeout: int = 300) -> Optional[dict]:
     # Parse prowjob
     logger.info("Parsing prowjob data...")
     prowjob_data = parse_prowjob(prowjob_json)
+
+    if not url:
+        su = (prowjob_data.get('url') or '').strip()
+        if su:
+            base_url = su
+        elif artifact_source:
+            base_url = Path(
+                os.path.abspath(os.path.expanduser(artifact_source))
+            ).as_uri()
+        else:
+            base_url = _LOCAL_ONLY_FETCH_BASE
+        logger.info(f"Job: {prowjob_data.get('job_name', 'unknown')}")
+        logger.info(f"Build ID: {prowjob_data.get('build_id', 'unknown')}")
 
     # Extract metadata
     logger.info("Extracting metadata...")
@@ -172,15 +218,68 @@ def main():
 Examples:
   %(prog)s https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate-aws-ipi-peerpods/1987995564184178688
 
+  %(prog)s --artifacts /path/to/job-artifacts.tar.gz
+
+  %(prog)s --artifacts /path/to/job-artifacts-dir <URL>
+
+  %(prog)s --download-artifacts . <URL>
+
+  %(prog)s --download-artifacts /tmp --tar-artifacts <URL>
+
   %(prog)s --json <URL> > report.json
 
   %(prog)s --verbose --no-wait <URL>
+
+Artifact layout:
+  The Prow job Artifacts page lists a gsutil command to download the GCS prefix into a
+  local directory. That tree (prowjob.json at the root, artifacts/...) is the same layout
+  expected by --artifacts. Use --download-artifacts to run gsutil from this tool (requires
+  gsutil on PATH); otherwise run the gsutil command from the UI and pass the directory with
+  --artifacts.
         '''
     )
 
     parser.add_argument(
         'url',
-        help='Prow job URL'
+        nargs='?',
+        default=None,
+        help=(
+            'Prow job URL (optional if --artifacts is a directory or .tar.gz containing '
+            'prowjob.json)'
+        ),
+    )
+
+    parser.add_argument(
+        '--artifacts',
+        metavar='PATH',
+        help=(
+            'Local directory or .tar.gz of job artifacts (prowjob.json at root). '
+            'Same layout as a directory produced by the gsutil command on the Prow '
+            'Artifacts page. Reads are cached in memory. May be used alone (no URL) '
+            'or with a URL for explicit job identity and links.'
+        ),
+    )
+
+    parser.add_argument(
+        '--download-artifacts',
+        nargs='?',
+        const='.',
+        default=None,
+        metavar='PARENT_DIR',
+        help=(
+            'Run gsutil -m cp -r gs://... (derived like the Prow Artifacts page) into '
+            'PARENT_DIR/<build-id> (default parent: current directory). Requires gsutil '
+            'on PATH. Analysis uses this folder unless --artifacts is set.'
+        ),
+    )
+
+    parser.add_argument(
+        '--tar-artifacts',
+        action='store_true',
+        help=(
+            'With --download-artifacts, also write PARENT_DIR/<build-id>.tar.gz '
+            'next to the downloaded directory.'
+        ),
     )
 
     parser.add_argument(
@@ -223,14 +322,68 @@ Examples:
 
     args = parser.parse_args()
 
+    if args.tar_artifacts and args.download_artifacts is None:
+        parser.error('--tar-artifacts requires --download-artifacts')
+
+    if not args.url and not args.artifacts:
+        parser.error(
+            'Provide a Prow job URL or --artifacts PATH (directory or .tar.gz)'
+        )
+
+    if args.download_artifacts is not None and not args.url:
+        parser.error('--download-artifacts requires a Prow job URL')
+
     # Setup logging
     setup_logging(args.verbose)
+    logger = logging.getLogger(__name__)
 
     # Determine wait timeout
     wait_timeout = 0 if args.no_wait else args.wait
 
-    # Analyze job
-    results = analyze_prowjob(args.url, wait_timeout=wait_timeout)
+    base_url = None
+    job_name = None
+    build_id = None
+    if args.url:
+        try:
+            base_url, job_name, build_id = parse_prow_url(args.url)
+        except ValueError as e:
+            logger.error(str(e))
+            sys.exit(2)
+
+    downloaded_dir = None
+    if args.download_artifacts is not None:
+        parent_dir = args.download_artifacts
+        if wait_timeout > 0:
+            logger.info('Checking if artifacts are ready before download...')
+            if not wait_for_artifacts(base_url, timeout=wait_timeout):
+                logger.warning(
+                    'Artifacts may be incomplete; continuing with download anyway.'
+                )
+        try:
+            downloaded_dir = download_job_artifacts(base_url, parent_dir, build_id)
+        except (OSError, ValueError, RuntimeError) as e:
+            logger.error('Download failed: %s', e)
+            sys.exit(2)
+        if args.tar_artifacts:
+            tar_path = os.path.join(
+                os.path.abspath(os.path.expanduser(parent_dir)),
+                f'{build_id}.tar.gz',
+            )
+            try:
+                write_job_artifacts_tarball(downloaded_dir, tar_path)
+            except OSError as e:
+                logger.error('Tarball failed: %s', e)
+                sys.exit(2)
+
+    artifact_source = args.artifacts if args.artifacts else downloaded_dir
+    use_local_tree = bool(args.artifacts or downloaded_dir)
+
+    # Analyze: no remote wait when a directory/tar.gz or fresh download supplies artifacts
+    results = analyze_prowjob(
+        url=args.url,
+        wait_timeout=0 if use_local_tree else wait_timeout,
+        artifact_source=artifact_source,
+    )
 
     if results is None:
         logger.error("Analysis failed")

--- a/scripts/prowjob-analyzer/lib/__init__.py
+++ b/scripts/prowjob-analyzer/lib/__init__.py
@@ -7,7 +7,18 @@ specifically tailored for OpenShift Sandboxed Containers (OSC) testing.
 
 __version__ = "1.0.0"
 
-from .fetcher import parse_prow_url, fetch_artifact, wait_for_artifacts
+from .fetcher import (
+    parse_prow_url,
+    fetch_artifact,
+    wait_for_artifacts,
+    configure_artifact_source,
+    clear_artifact_cache,
+    is_local_artifact_mode,
+    download_job_artifacts,
+    write_job_artifacts_tarball,
+    gcs_uri_from_gcsweb_https,
+    gcs_uri_for_job_artifacts,
+)
 from .parser import parse_prowjob, parse_test_results, get_job_status
 from .metadata_extractor import extract_metadata
 from .failure_analyzer import analyze_failure
@@ -17,6 +28,13 @@ __all__ = [
     "parse_prow_url",
     "fetch_artifact",
     "wait_for_artifacts",
+    "configure_artifact_source",
+    "clear_artifact_cache",
+    "is_local_artifact_mode",
+    "download_job_artifacts",
+    "write_job_artifacts_tarball",
+    "gcs_uri_from_gcsweb_https",
+    "gcs_uri_for_job_artifacts",
     "parse_prowjob",
     "parse_test_results",
     "get_job_status",

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -131,6 +131,76 @@ def identify_failure_location(
     return 'unknown'
 
 
+def analyze_post_test_prow_failure(
+    prowjob_raw: Dict,
+    base_url: str,
+    metadata: Dict,
+) -> Optional[Dict]:
+    """
+    When openshift-extended-test succeeded (caller already set status to success)
+    but the overall Prow job did not succeed, summarize failed steps after the test phase.
+
+    These are Prow/pipeline issues, not test-case failures.
+    """
+    status_block = prowjob_raw.get('status') or {}
+    prow_state = (status_block.get('state') or '').lower()
+    if prow_state in ('success', 'pending', ''):
+        return None
+
+    variant = metadata.get('variant') or ''
+    failed_steps: List[str] = []
+    if variant and variant != 'unknown':
+        failed_steps = get_failed_steps(base_url, variant)
+
+    # Defensive: extended test phase is already known-good from test-results/finished.json
+    failed_steps = [s for s in failed_steps if s != 'openshift-extended-test']
+
+    summary_note = (
+        'One or more Prow steps failed after openshift-extended-test completed successfully. '
+        'This is not a test-case failure.'
+    )
+
+    if not failed_steps:
+        return {
+            'failure_kind': 'prow_pipeline_after_tests',
+            'failure_location': 'prowjob',
+            'post_test_failed_steps': [],
+            'failing_tests': [],
+            'failing_tests_by_category': {},
+            'detected_patterns': [],
+            'analyzed_files': [],
+            'root_cause': {
+                'likely_cause': (
+                    f'Prow job state is {prow_state!r} while the extended test phase reported success. '
+                    'A later pipeline step may have failed, or step-level artifacts could not be enumerated.'
+                ),
+                'confidence': 'medium',
+                'suggested_actions': [
+                    'Review the Prow UI step timeline and build-log.txt for the failing step.',
+                    'Confirm whether a post-test step (e.g. gather, teardown) failed.',
+                ],
+            },
+            'summary_note': summary_note,
+        }
+
+    return {
+        'failure_kind': 'prow_pipeline_after_tests',
+        'failure_location': ', '.join(failed_steps),
+        'post_test_failed_steps': failed_steps,
+        'failing_tests': [],
+        'failing_tests_by_category': {},
+        'detected_patterns': [],
+        'analyzed_files': [],
+        'root_cause': {
+            'likely_cause': summary_note,
+            'confidence': 'high',
+            'suggested_actions': [
+                f'Inspect finished.json and logs under artifacts for: {", ".join(failed_steps)}.',
+                'This does not indicate failing OSC extended tests.',
+            ],
+        },
+        'summary_note': summary_note,
+    }
 
 
 def extract_azure_quota_details(log_content: str) -> Dict[str, Optional[int]]:

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, List, Optional
 from collections import defaultdict
 from .parser import categorize_test_by_name, extract_failing_tests, add_execution_order_to_tests
-from .fetcher import fetch_artifact, get_failed_steps
+from .fetcher import fetch_artifact, get_failed_steps, is_openshift_extended_test_failure_label
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ def analyze_post_test_prow_failure(
         failed_steps = get_failed_steps(base_url, variant)
 
     # Defensive: extended test phase is already known-good from test-results/finished.json
-    failed_steps = [s for s in failed_steps if s != 'openshift-extended-test']
+    failed_steps = [s for s in failed_steps if not is_openshift_extended_test_failure_label(s)]
 
     summary_note = (
         'One or more Prow steps failed after openshift-extended-test completed successfully. '

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -781,11 +781,16 @@ def analyze_failure(
             try:
                 ext_bl_text = ext_step_build.decode('utf-8', errors='ignore')
                 extended_build_log_case_ids = extract_failed_case_ids_from_extended_build_log(ext_bl_text)
-                # RPM install runs in BeforeEach; only the first spec's log avoids repeated failures.
+                # Patterns (timeout/OOM/network/…): scan full step log so later specs are visible.
+                patterns_oet_full = check_log_for_patterns(
+                    ext_bl_text,
+                    'openshift-extended-test/build-log.txt',
+                )
+                detected_patterns.extend(patterns_oet_full)
+                # RPM install in BeforeEach: composite detection uses first-spec prefix only.
                 oet_first_test_prefix = extended_build_log_first_test_prefix(ext_bl_text)
-                oet_src = "openshift-extended-test/build-log.txt (first test)"
-                patterns_oet = check_log_for_patterns(oet_first_test_prefix, oet_src)
-                detected_patterns.extend(patterns_oet)
+                oet_src = 'openshift-extended-test/build-log.txt (first test)'
+                oet_pf = len(patterns_oet_full)
                 composite_rpm = detect_kata_rpm_install_context(oet_first_test_prefix)
                 if composite_rpm:
                     have = {p['pattern'] for p in detected_patterns}
@@ -794,9 +799,7 @@ def analyze_failure(
                             'pattern': 'rpm_install',
                             'source': f'{oet_src}, composite',
                         })
-                oet_pf = len(patterns_oet)
-                if composite_rpm and not any(p['pattern'] == 'rpm_install' for p in patterns_oet):
-                    oet_pf += 1
+                        oet_pf += 1
                 analyzed_files.append({
                     'name': 'openshift-extended-test/build-log.txt',
                     'path': ext_step_build_path,
@@ -807,8 +810,8 @@ def analyze_failure(
                     extended_build_log_case_ids,
                 )
                 logger.debug(
-                    "Patterns from openshift-extended-test/build-log (first test): %s",
-                    [p['pattern'] for p in patterns_oet],
+                    "Patterns from openshift-extended-test/build-log (full): %s",
+                    [p['pattern'] for p in patterns_oet_full],
                 )
             except Exception as e:
                 logger.warning(f"Failed to parse openshift-extended-test/build-log.txt: {e}")

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -70,7 +70,6 @@ FAILURE_PATTERNS = {
     'rpm_install': [
         # oc debug on worker + kata RPM (BeforeEach); see detect_kata_rpm_install_context too
         r'debug\s+node/[^\s]*worker[^\s]*.*kata-containers\.rpm',
-        r'error:\s*Failed dependencies',
         r'is needed by kata-containers',
         r'error:.*Failed dependencies',
         r'error:.*package.*is needed by kata',

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, List, Optional
 from collections import defaultdict
 from .parser import categorize_test_by_name, extract_failing_tests, add_execution_order_to_tests
-from .fetcher import fetch_artifact, get_failed_steps, is_openshift_extended_test_failure_label
+from .fetcher import fetch_artifact, get_failed_steps
 
 logger = logging.getLogger(__name__)
 
@@ -141,9 +141,10 @@ def analyze_post_test_prow_failure(
 ) -> Optional[Dict]:
     """
     When openshift-extended-test succeeded (caller already set status to success)
-    but the overall Prow job did not succeed, summarize failed steps after the test phase.
+    but the overall Prow job did not succeed, summarize failed steps from artifacts.
 
-    These are Prow/pipeline issues, not test-case failures.
+    Typically these are later pipeline steps or infrastructure; the list can still include
+    openshift-extended-test (or its build-log label) when step-level state disagrees with junit.
     """
     status_block = prowjob_raw.get('status') or {}
     prow_state = (status_block.get('state') or '').lower()
@@ -155,12 +156,11 @@ def analyze_post_test_prow_failure(
     if variant and variant != 'unknown':
         failed_steps = get_failed_steps(base_url, variant)
 
-    # Defensive: extended test phase is already known-good from test-results/finished.json
-    failed_steps = [s for s in failed_steps if not is_openshift_extended_test_failure_label(s)]
-
     summary_note = (
-        'One or more Prow steps failed after openshift-extended-test completed successfully. '
-        'This is not a test-case failure.'
+        'Overall Prow state is not success while the extended test phase was treated as successful '
+        'from test-results/finished.json. Failed steps may include openshift-extended-test or its '
+        'build-log summary when step-level artifacts disagree with junit; other entries are typically '
+        'later pipeline steps. This is not necessarily a failing test case in the junit report.'
     )
 
     if not failed_steps:
@@ -199,7 +199,7 @@ def analyze_post_test_prow_failure(
             'confidence': 'high',
             'suggested_actions': [
                 f'Inspect finished.json and logs under artifacts for: {", ".join(failed_steps)}.',
-                'This does not indicate failing OSC extended tests.',
+                "If openshift-extended-test appears, compare test-results.yaml with that step's build-log and finished.json.",
             ],
         },
         'summary_note': summary_note,

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -278,6 +278,43 @@ def extract_kata_rpm_dependency_detail(text: str) -> Optional[str]:
     return None
 
 
+def _rpm_install_is_verified_kata_worker(
+    detected_patterns: List[Dict],
+    oet_build_log_first_test: Optional[str],
+) -> bool:
+    """
+    True only when ``rpm_install`` is tied to oc debug on a worker + kata RPM context.
+
+    Generic ``FAILURE_PATTERNS['rpm_install']`` regexes can match unrelated RPM errors in
+    top-level build-log.txt or extended.log; avoid high-confidence Kata remediation until
+    verified via openshift-extended-test (or composite injection from
+    :func:`detect_kata_rpm_install_context`).
+    """
+    for p in detected_patterns:
+        if p.get('pattern') != 'rpm_install':
+            continue
+        src = (p.get('source') or '')
+        # analyze_failure appends this only when detect_kata_rpm_install_context(oet prefix)
+        if 'composite' in src:
+            return True
+
+    oet = oet_build_log_first_test or ''
+    if not oet.strip():
+        return False
+
+    if detect_kata_rpm_install_context(oet):
+        return True
+
+    detail = extract_kata_rpm_dependency_detail(oet)
+    if not detail:
+        return False
+    if not re.search(r'debug\s+node/[^\s]*worker', oet, re.I):
+        return False
+    if not re.search(r'kata-containers\.rpm|rpm\s+-Uvh\s+\S*kata|needed by kata-containers', oet, re.I):
+        return False
+    return True
+
+
 def check_log_for_patterns(log_content: str, source_name: str = "unknown") -> List[Dict[str, str]]:
     """
     Check log content for known failure patterns.
@@ -449,30 +486,54 @@ def determine_root_cause(
     if 'rpm_install' in pattern_names:
         root_cause['primary_pattern'] = 'rpm_install'
         root_cause['pattern_source'] = find_pattern_source('rpm_install')
-        root_cause['confidence'] = 'high'
-        detail = None
-        if oet_build_log_first_test:
-            detail = extract_kata_rpm_dependency_detail(oet_build_log_first_test)
-        if detail:
-            root_cause['likely_cause'] = (
-                f'Kata RPM install on a worker (oc debug) failed: missing dependency. {detail}'
-            )
+        kata_worker_verified = _rpm_install_is_verified_kata_worker(
+            detected_patterns, oet_build_log_first_test
+        )
+        root_cause['kata_worker_context_verified'] = kata_worker_verified
+
+        if kata_worker_verified:
+            root_cause['confidence'] = 'high'
+            detail = None
+            if oet_build_log_first_test:
+                detail = extract_kata_rpm_dependency_detail(oet_build_log_first_test)
+            if detail:
+                root_cause['likely_cause'] = (
+                    f'Kata RPM install on a worker (oc debug) failed: missing dependency. {detail}'
+                )
+            else:
+                root_cause['likely_cause'] = (
+                    'Kata RPM install on a worker node failed (BeforeEach): missing or unsatisfied '
+                    'dependencies for kata-containers'
+                )
+            root_cause['suggested_actions'] = [
+                'Use the first test block in openshift-extended-test/build-log.txt only; later tests '
+                'repeat the same RPM install failure',
+                'Resolve the dependency shown under StdOut from oc debug (e.g. qemu-kvm-core)',
+                'Verify RHCOS layer and kata-containers RPM versions match test expectations',
+            ]
+            if 'rpm_cascading' in pattern_names:
+                root_cause['cascading_errors'] = ['rpm_cascading']
+                root_cause['note'] = (
+                    'Additional ostree "already unlocked" errors are usually cascading from the initial RPM failure'
+                )
         else:
+            root_cause['confidence'] = 'low'
             root_cause['likely_cause'] = (
-                'Kata RPM install on a worker node failed (BeforeEach): missing or unsatisfied '
-                'dependencies for kata-containers'
+                'RPM installation or dependency error matched generic log patterns; not confirmed '
+                'as Kata worker install via oc debug. Inspect the log in pattern_source for the '
+                'exact rpm/dnf error before applying Kata-specific fixes.'
             )
-        root_cause['suggested_actions'] = [
-            'Use the first test block in openshift-extended-test/build-log.txt only; later tests '
-            'repeat the same RPM install failure',
-            'Resolve the dependency shown under StdOut from oc debug (e.g. qemu-kvm-core)',
-            'Verify RHCOS layer and kata-containers RPM versions match test expectations',
-        ]
-        if 'rpm_cascading' in pattern_names:
-            root_cause['cascading_errors'] = ['rpm_cascading']
-            root_cause['note'] = (
-                'Additional ostree "already unlocked" errors are usually cascading from the initial RPM failure'
-            )
+            root_cause['suggested_actions'] = [
+                'Open the file listed in pattern_source and locate the failing rpm/dnf line',
+                'If the failure is openshift-extended-test installing kata on a worker, confirm '
+                'oc debug node/…worker… + kata-containers in openshift-extended-test/build-log.txt',
+            ]
+            if 'rpm_cascading' in pattern_names:
+                root_cause['cascading_errors'] = ['rpm_cascading']
+                root_cause['note'] = (
+                    'Additional ostree "already unlocked" errors may be related to an earlier RPM/ostree '
+                    'issue in the same log; verify context before treating as Kata-specific cascade'
+                )
     elif 'timeout' in pattern_names:
         root_cause['primary_pattern'] = 'timeout'
         root_cause['pattern_source'] = find_pattern_source('timeout')

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -291,7 +291,75 @@ def categorize_test_list(failing_tests: List[Dict]) -> Dict[str, List[Dict]]:
     return dict(categorized)
 
 
-def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict], metadata: Dict, build_log_text: Optional[str] = None) -> Dict:
+def _failed_test_case_ids(failing_tests: List[Dict]) -> List[str]:
+    """Unique C##### identifiers from failing test entries, stable order."""
+    seen: List[str] = []
+    for t in failing_tests:
+        cid = (t.get('test_case_number') or '').strip()
+        if cid and cid not in seen:
+            seen.append(cid)
+    return seen
+
+
+def _merge_case_ids(test_ids: List[str], log_ids: Optional[List[str]]) -> List[str]:
+    """Append log-only IDs after test-results order, de-duplicated."""
+    out: List[str] = list(test_ids)
+    if not log_ids:
+        return out
+    for cid in log_ids:
+        if cid not in out:
+            out.append(cid)
+    return out
+
+
+def extract_failed_case_ids_from_extended_build_log(log_text: str) -> List[str]:
+    """
+    Find failed OSC test case IDs (C#####) in openshift-extended-test/build-log.txt.
+
+    Used when test-results.yaml is missing or the step was interrupted; logs still
+    often mention ``-C#####-`` on failure lines or in trailing summaries.
+    """
+    if not log_text:
+        return []
+
+    seen: List[str] = []
+    id_in_name = re.compile(r'-C(\d+)-')
+    # Lines that suggest a failure context (avoid counting passing test name mentions)
+    failure_hint = re.compile(
+        r'(?i)(fail|failure|failed|error|panic|timeout|interrupt|aborted|'
+        r'SIGKILL|SIGTERM|OOMKilled|•\s*Failure|\[Fail\]|Summarizing\s+\d+\s+Failure)'
+    )
+
+    for line in log_text.splitlines():
+        if not failure_hint.search(line):
+            continue
+        for m in id_in_name.finditer(line):
+            cid = f"C{m.group(1)}"
+            if cid not in seen:
+                seen.append(cid)
+
+    # Tail often has failure summaries after interruption or OOM
+    if not seen:
+        tail = log_text[-200000:] if len(log_text) > 200000 else log_text
+        tail_fail = re.compile(r'(?i)(fail|failure|error|panic|timeout|interrupt|abort)')
+        for line in tail.splitlines():
+            if not tail_fail.search(line):
+                continue
+            for m in id_in_name.finditer(line):
+                cid = f"C{m.group(1)}"
+                if cid not in seen:
+                    seen.append(cid)
+
+    return seen
+
+
+def determine_root_cause(
+    failing_tests: List[Dict],
+    detected_patterns: List[Dict],
+    metadata: Dict,
+    build_log_text: Optional[str] = None,
+    extended_build_log_case_ids: Optional[List[str]] = None,
+) -> Dict:
     """
     Attempt to determine root cause of failure.
 
@@ -299,7 +367,8 @@ def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict
         failing_tests: List of failing tests
         detected_patterns: List of detected failure patterns with sources
         metadata: Job metadata
-        build_log_text: Build log content for extracting additional details
+        build_log_text: Top-level Prow build log content for extracting additional details
+        extended_build_log_case_ids: C##### IDs parsed from openshift-extended-test/build-log.txt
 
     Returns:
         Dictionary with root cause analysis
@@ -447,6 +516,41 @@ def determine_root_cause(failing_tests: List[Dict], detected_patterns: List[Dict
         root_cause['suggested_actions'].append('Review cluster health and OSC installation logs')
         root_cause['suggested_actions'].append('IMPORTANT: When most/all tests fail, examine the FIRST test\'s logs for the root cause - subsequent test errors are often cascading failures')
 
+    # openshift-extended-test: failed test case numbers from test-results.yaml and/or step build-log.txt
+    test_ids = _failed_test_case_ids(failing_tests)
+    merged_ids = _merge_case_ids(test_ids, extended_build_log_case_ids)
+    only_from_log: List[str] = []
+    if extended_build_log_case_ids:
+        ts = set(test_ids)
+        only_from_log = [c for c in extended_build_log_case_ids if c not in ts]
+
+    if merged_ids:
+        root_cause['failed_test_case_numbers'] = merged_ids
+        if only_from_log:
+            root_cause['failed_test_case_numbers_from_build_log'] = only_from_log
+        case_part = f"Failed test case(s): {', '.join(merged_ids)}."
+        if only_from_log:
+            case_part += " (includes IDs from openshift-extended-test/build-log.txt)."
+    elif failing_tests:
+        root_cause['failed_test_case_numbers'] = []
+        case_part = (
+            f"openshift-extended-test: {len(failing_tests)} failing test(s) "
+            "(no C##### id in test names or build-log.txt)."
+        )
+    elif extended_build_log_case_ids is not None:
+        root_cause['failed_test_case_numbers'] = []
+        case_part = (
+            "openshift-extended-test: step failed or interrupted; "
+            "no C##### ids found in openshift-extended-test/build-log.txt (inspect artifact manually)."
+        )
+    else:
+        return root_cause
+
+    if root_cause.get('likely_cause'):
+        root_cause['likely_cause'] = f"{root_cause['likely_cause'].rstrip()} {case_part}"
+    else:
+        root_cause['likely_cause'] = case_part
+
     return root_cause
 
 
@@ -496,6 +600,7 @@ def analyze_failure(
     build_log_text = None
     build_log_text_full = None  # Keep full log for execution order extraction
     analyzed_files = []
+    extended_build_log_case_ids: Optional[List[str]] = None
 
     # First check the main build log for infrastructure-level failures (e.g., Azure quota)
     build_log_content = fetch_artifact(base_url, "build-log.txt")
@@ -541,6 +646,26 @@ def analyze_failure(
             except Exception as e:
                 logger.warning(f"Failed to analyze extended log: {e}")
 
+        # openshift-extended-test/build-log.txt — C##### when test-results is incomplete or step interrupted
+        ext_step_build_path = f"artifacts/{variant}/openshift-extended-test/build-log.txt"
+        ext_step_build = fetch_artifact(base_url, ext_step_build_path)
+        if ext_step_build:
+            try:
+                ext_bl_text = ext_step_build.decode('utf-8', errors='ignore')
+                extended_build_log_case_ids = extract_failed_case_ids_from_extended_build_log(ext_bl_text)
+                analyzed_files.append({
+                    'name': 'openshift-extended-test/build-log.txt',
+                    'path': ext_step_build_path,
+                    'patterns_found': len(extended_build_log_case_ids),
+                })
+                logger.debug(
+                    "Case IDs from openshift-extended-test/build-log.txt: %s",
+                    extended_build_log_case_ids,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to parse openshift-extended-test/build-log.txt: {e}")
+                extended_build_log_case_ids = []
+
     # Store detected patterns with sources and analyzed files info
     analysis['detected_patterns'] = detected_patterns
     analysis['analyzed_files'] = analyzed_files
@@ -559,7 +684,8 @@ def analyze_failure(
         analysis['failing_tests'],
         analysis['detected_patterns'],
         metadata,
-        build_log_text
+        build_log_text,
+        extended_build_log_case_ids,
     )
 
     return analysis

--- a/scripts/prowjob-analyzer/lib/failure_analyzer.py
+++ b/scripts/prowjob-analyzer/lib/failure_analyzer.py
@@ -68,6 +68,10 @@ FAILURE_PATTERNS = {
         r'failed to create sandbox',
     ],
     'rpm_install': [
+        # oc debug on worker + kata RPM (BeforeEach); see detect_kata_rpm_install_context too
+        r'debug\s+node/[^\s]*worker[^\s]*.*kata-containers\.rpm',
+        r'error:\s*Failed dependencies',
+        r'is needed by kata-containers',
         r'error:.*Failed dependencies',
         r'error:.*package.*is needed by kata',
         r'rpm.*installation failed',
@@ -227,6 +231,54 @@ def extract_azure_quota_details(log_content: str) -> Dict[str, Optional[int]]:
     return quota_details
 
 
+def extended_build_log_first_test_prefix(log_text: str, max_chars: int = 1_500_000) -> str:
+    """
+    Text through the end of the first ginkgo spec block. RPM install in BeforeEach and the
+    first failure are before/at the second ``started: (i/total/n)`` line; later specs repeat
+    the same install failure and add noise.
+    """
+    if not log_text:
+        return ''
+    text = log_text if len(log_text) <= max_chars else log_text[:max_chars]
+    # Second ``started: (a/b/c)`` begins the next spec (Ginkgo/openshift-tests).
+    pat = re.compile(r'^\s*started:\s*\(\d+/\d+/\d+\)', re.MULTILINE)
+    matches = list(pat.finditer(text))
+    if len(matches) >= 2:
+        return text[: matches[1].start()]
+    return text
+
+
+def detect_kata_rpm_install_context(text: str) -> bool:
+    """
+    True when ``oc debug node/…worker…`` failed while installing kata-containers.rpm
+    (Failed dependencies / needed by kata-containers).
+    """
+    if not text or len(text) < 80:
+        return False
+    if not re.search(r'debug\s+node/[^\s]*worker', text, re.I):
+        return False
+    if not re.search(r'kata-containers\.rpm|rpm\s+-Uvh\s+\S*kata', text, re.I):
+        return False
+    if not re.search(r'Failed dependencies|is needed by kata-containers', text, re.I):
+        return False
+    return True
+
+
+def extract_kata_rpm_dependency_detail(text: str) -> Optional[str]:
+    """First dependency line mentioning kata-containers, or Failed dependencies header."""
+    if not text:
+        return None
+    for line in text.splitlines():
+        s = line.strip()
+        if re.search(r'is needed by kata-containers', s, re.I):
+            return s[:500]
+    m = re.search(r'error:\s*Failed dependencies', text, re.I)
+    if m:
+        rest = text[m.start() :]
+        return rest.split('\n', 1)[0].strip()[:500]
+    return None
+
+
 def check_log_for_patterns(log_content: str, source_name: str = "unknown") -> List[Dict[str, str]]:
     """
     Check log content for known failure patterns.
@@ -359,6 +411,7 @@ def determine_root_cause(
     metadata: Dict,
     build_log_text: Optional[str] = None,
     extended_build_log_case_ids: Optional[List[str]] = None,
+    oet_build_log_first_test: Optional[str] = None,
 ) -> Dict:
     """
     Attempt to determine root cause of failure.
@@ -369,6 +422,8 @@ def determine_root_cause(
         metadata: Job metadata
         build_log_text: Top-level Prow build log content for extracting additional details
         extended_build_log_case_ids: C##### IDs parsed from openshift-extended-test/build-log.txt
+        oet_build_log_first_test: openshift-extended-test/build-log.txt truncated to the first spec
+            (used for kata RPM dependency extraction; avoids cascading repeats)
 
     Returns:
         Dictionary with root cause analysis
@@ -390,8 +445,36 @@ def determine_root_cause(
                 return pattern_info['source']
         return None
 
-    # Analyze patterns
-    if 'timeout' in pattern_names:
+    # Analyze patterns (rpm_install before timeout: logs often contain both Prow/step timeouts
+    # and the real Kata RPM failure on workers)
+    if 'rpm_install' in pattern_names:
+        root_cause['primary_pattern'] = 'rpm_install'
+        root_cause['pattern_source'] = find_pattern_source('rpm_install')
+        root_cause['confidence'] = 'high'
+        detail = None
+        if oet_build_log_first_test:
+            detail = extract_kata_rpm_dependency_detail(oet_build_log_first_test)
+        if detail:
+            root_cause['likely_cause'] = (
+                f'Kata RPM install on a worker (oc debug) failed: missing dependency. {detail}'
+            )
+        else:
+            root_cause['likely_cause'] = (
+                'Kata RPM install on a worker node failed (BeforeEach): missing or unsatisfied '
+                'dependencies for kata-containers'
+            )
+        root_cause['suggested_actions'] = [
+            'Use the first test block in openshift-extended-test/build-log.txt only; later tests '
+            'repeat the same RPM install failure',
+            'Resolve the dependency shown under StdOut from oc debug (e.g. qemu-kvm-core)',
+            'Verify RHCOS layer and kata-containers RPM versions match test expectations',
+        ]
+        if 'rpm_cascading' in pattern_names:
+            root_cause['cascading_errors'] = ['rpm_cascading']
+            root_cause['note'] = (
+                'Additional ostree "already unlocked" errors are usually cascading from the initial RPM failure'
+            )
+    elif 'timeout' in pattern_names:
         root_cause['primary_pattern'] = 'timeout'
         root_cause['pattern_source'] = find_pattern_source('timeout')
         root_cause['likely_cause'] = 'Test execution exceeded time limits'
@@ -481,22 +564,6 @@ def determine_root_cause(
             'Review cluster health and provisioning logs',
             'Verify cluster installation completed',
         ]
-    elif 'rpm_install' in pattern_names:
-        root_cause['primary_pattern'] = 'rpm_install'
-        root_cause['pattern_source'] = find_pattern_source('rpm_install')
-        root_cause['likely_cause'] = 'RPM installation failed due to missing dependencies'
-        root_cause['confidence'] = 'high'
-        root_cause['suggested_actions'] = [
-            'Check the first test logs for the specific missing dependency',
-            'Verify the Kata RPM package dependencies are available in the repository',
-            'Check if the RPM repository is accessible and configured correctly',
-            'Verify the RPM version compatibility with the target OS',
-        ]
-
-        # If rpm_cascading is also present, note it's a secondary error
-        if 'rpm_cascading' in pattern_names:
-            root_cause['cascading_errors'] = ['rpm_cascading']
-            root_cause['note'] = 'Multiple "Deployment is already in unlocked state" errors are cascading failures from the initial RPM dependency error'
     else:
         # Unknown pattern type: use first detected pattern
         if detected_patterns:
@@ -601,6 +668,7 @@ def analyze_failure(
     build_log_text_full = None  # Keep full log for execution order extraction
     analyzed_files = []
     extended_build_log_case_ids: Optional[List[str]] = None
+    oet_first_test_prefix: Optional[str] = None
 
     # First check the main build log for infrastructure-level failures (e.g., Azure quota)
     build_log_content = fetch_artifact(base_url, "build-log.txt")
@@ -653,14 +721,34 @@ def analyze_failure(
             try:
                 ext_bl_text = ext_step_build.decode('utf-8', errors='ignore')
                 extended_build_log_case_ids = extract_failed_case_ids_from_extended_build_log(ext_bl_text)
+                # RPM install runs in BeforeEach; only the first spec's log avoids repeated failures.
+                oet_first_test_prefix = extended_build_log_first_test_prefix(ext_bl_text)
+                oet_src = "openshift-extended-test/build-log.txt (first test)"
+                patterns_oet = check_log_for_patterns(oet_first_test_prefix, oet_src)
+                detected_patterns.extend(patterns_oet)
+                composite_rpm = detect_kata_rpm_install_context(oet_first_test_prefix)
+                if composite_rpm:
+                    have = {p['pattern'] for p in detected_patterns}
+                    if 'rpm_install' not in have:
+                        detected_patterns.append({
+                            'pattern': 'rpm_install',
+                            'source': f'{oet_src}, composite',
+                        })
+                oet_pf = len(patterns_oet)
+                if composite_rpm and not any(p['pattern'] == 'rpm_install' for p in patterns_oet):
+                    oet_pf += 1
                 analyzed_files.append({
                     'name': 'openshift-extended-test/build-log.txt',
                     'path': ext_step_build_path,
-                    'patterns_found': len(extended_build_log_case_ids),
+                    'patterns_found': oet_pf,
                 })
                 logger.debug(
                     "Case IDs from openshift-extended-test/build-log.txt: %s",
                     extended_build_log_case_ids,
+                )
+                logger.debug(
+                    "Patterns from openshift-extended-test/build-log (first test): %s",
+                    [p['pattern'] for p in patterns_oet],
                 )
             except Exception as e:
                 logger.warning(f"Failed to parse openshift-extended-test/build-log.txt: {e}")
@@ -686,6 +774,7 @@ def analyze_failure(
         metadata,
         build_log_text,
         extended_build_log_case_ids,
+        oet_build_log_first_test=oet_first_test_prefix,
     )
 
     return analysis

--- a/scripts/prowjob-analyzer/lib/fetcher.py
+++ b/scripts/prowjob-analyzer/lib/fetcher.py
@@ -2,17 +2,32 @@
 Artifact Fetcher Module
 
 Handles URL parsing and fetching artifacts from Prow/GCS.
+Supports in-memory caching, a local directory tree, or a .tar.gz of the same layout.
 """
 
-import re
-import time
 import json
 import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
 from typing import Dict, Optional, Tuple, List
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 
 logger = logging.getLogger(__name__)
+
+# Bytes fetched over HTTP or read from disk (keyed by root + relative path).
+_artifact_cache: Dict[str, Optional[bytes]] = {}
+# Resolved directory containing prowjob.json (and artifacts/, …); None = fetch over HTTP only.
+_local_artifacts_root: Optional[str] = None
+# Temp directory created when configuring from a .tar.gz (removed on next configure or process exit).
+_tar_extract_temp_dir: Optional[str] = None
 
 
 def parse_prow_url(url: str) -> Tuple[str, str, str]:
@@ -137,19 +152,214 @@ def discover_gcs_url_from_prow(prow_url: str) -> Optional[str]:
     return None
 
 
-def fetch_artifact(base_url: str, artifact_path: str, max_retries: int = 3) -> Optional[bytes]:
+def gcs_uri_from_gcsweb_https(https_url: str) -> Optional[str]:
     """
-    Fetch an artifact from Prow/GCS with retry logic.
-    Dynamically discovers the GCS web URL if Prow returns HTML.
+    Convert a gcsweb HTTPS URL (``.../gcs/BUCKET/path``) to ``gs://BUCKET/path``.
+
+    If ``https_url`` is already ``gs://``, return it unchanged.
+    """
+    u = https_url.strip()
+    if u.lower().startswith('gs://'):
+        return u.rstrip('/')
+    base = u.split('?')[0].split('#')[0].rstrip('/')
+    idx = base.find('/gcs/')
+    if idx == -1:
+        return None
+    rest = base[idx + len('/gcs/') :].strip('/')
+    if not rest:
+        return None
+    if '/' in rest:
+        bucket, path = rest.split('/', 1)
+        return f'gs://{bucket}/{path}'
+    return f'gs://{rest}'
+
+
+def gcs_uri_for_job_artifacts(prow_job_base_url: str) -> str:
+    """
+    Resolve the ``gs://`` prefix for the job artifact tree (same object prefix as on
+    the Prow Artifacts page / ``gsutil`` examples).
+    """
+    u = prow_job_base_url.strip().rstrip('/')
+    if u.lower().startswith('gs://'):
+        return u
+    https = u
+    if 'gcsweb' not in u.lower():
+        gcs = discover_gcs_url_from_prow(u)
+        if not gcs:
+            raise ValueError(
+                'Could not discover a gcsweb URL from this Prow page. Open the job '
+                'Artifacts tab, run the gsutil command shown there, then pass the '
+                'downloaded directory with --artifacts.'
+            )
+        https = gcs
+    uri = gcs_uri_from_gcsweb_https(https)
+    if not uri:
+        raise ValueError(
+            'Could not convert the artifact URL to a gs:// URI. Use gsutil from the '
+            'Prow Artifacts page and --artifacts with the local directory.'
+        )
+    return uri
+
+
+def download_job_artifacts(prow_job_base_url: str, parent_directory: str, build_id: str) -> str:
+    """
+    Download the job artifact tree into ``parent_directory/build_id/`` using ``gsutil``.
+
+    Runs the same style of command as on the Prow Artifacts page: ``gsutil -m cp -r``
+    from the job's ``gs://`` prefix into the destination directory. Requires ``gsutil``
+    on ``PATH`` (Google Cloud SDK).
 
     Args:
-        base_url: Base URL of the Prow job
-        artifact_path: Relative path to the artifact (e.g., "prowjob.json")
-        max_retries: Maximum number of retry attempts
+        prow_job_base_url: Prow job base URL from :func:`parse_prow_url`
+        parent_directory: Directory in which to create the ``build_id`` folder
+        build_id: Last path segment of the job URL (folder name)
 
     Returns:
-        Artifact content as bytes, or None if not found
+        Absolute path to ``parent_directory/build_id``
     """
+    gcs_uri = gcs_uri_for_job_artifacts(prow_job_base_url)
+
+    dest = os.path.abspath(os.path.join(os.path.expanduser(parent_directory), build_id))
+    if os.path.exists(dest) and not os.path.isdir(dest):
+        raise FileExistsError(dest)
+    os.makedirs(dest, exist_ok=True)
+
+    src = gcs_uri.rstrip('/') + '/'
+    logger.info("Downloading artifacts with gsutil ( %s -> %s )", src, dest)
+    try:
+        subprocess.run(
+            ['gsutil', '-m', 'cp', '-r', src, dest],
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            'gsutil not found; install Google Cloud SDK so gsutil is on PATH, '
+            'or download artifacts manually using the command from the Prow Artifacts page.'
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f'gsutil failed with exit code {e.returncode}'
+        ) from e
+
+    return dest
+
+
+def write_job_artifacts_tarball(artifact_dir: str, tar_gz_path: str) -> None:
+    """
+    Write a gzip-compressed tar of ``artifact_dir`` (top-level folder name preserved).
+
+    Args:
+        artifact_dir: Path to the job artifacts directory (e.g. ``.../build_id``)
+        tar_gz_path: Output file path (e.g. ``.../build_id.tar.gz``)
+    """
+    artifact_dir = os.path.abspath(artifact_dir)
+    if not os.path.isdir(artifact_dir):
+        raise NotADirectoryError(artifact_dir)
+    base = os.path.basename(artifact_dir.rstrip(os.sep))
+    tar_abs = os.path.abspath(tar_gz_path)
+    tar_parent = os.path.dirname(tar_abs)
+    if tar_parent:
+        os.makedirs(tar_parent, exist_ok=True)
+    logger.info("Writing tarball %s from %s", tar_abs, artifact_dir)
+    with tarfile.open(tar_abs, 'w:gz') as tf:
+        tf.add(artifact_dir, arcname=base)
+
+
+def clear_artifact_cache() -> None:
+    """Clear the in-memory artifact cache (e.g. before switching artifact source)."""
+    _artifact_cache.clear()
+
+
+def is_local_artifact_mode() -> bool:
+    """True when reads come from a configured local directory or extracted archive."""
+    return _local_artifacts_root is not None
+
+
+def _find_job_root(path: str) -> str:
+    """
+    If ``prowjob.json`` is not at ``path``, use the first subdirectory that contains it
+    (common for tar layouts with a single top-level folder).
+    """
+    if os.path.isfile(os.path.join(path, 'prowjob.json')):
+        return path
+    try:
+        names = sorted(os.listdir(path))
+    except OSError:
+        return path
+    for name in names:
+        sub = os.path.join(path, name)
+        if os.path.isdir(sub) and os.path.isfile(os.path.join(sub, 'prowjob.json')):
+            return sub
+    return path
+
+
+def configure_artifact_source(path: Optional[str]) -> None:
+    """
+    Use a local directory or ``.tar.gz`` of job artifacts instead of (or before) HTTP.
+
+    Layout matches Prow: ``prowjob.json``, ``finished.json``, ``artifacts/<variant>/…``.
+
+    Clears the artifact cache. Call with ``None`` to use only network fetches again.
+    Removes a previously extracted tar temp directory when reconfiguring.
+    """
+    global _local_artifacts_root, _tar_extract_temp_dir
+
+    clear_artifact_cache()
+
+    if _tar_extract_temp_dir and os.path.isdir(_tar_extract_temp_dir):
+        shutil.rmtree(_tar_extract_temp_dir, ignore_errors=True)
+    _tar_extract_temp_dir = None
+    _local_artifacts_root = None
+
+    if not path:
+        return
+
+    path = os.path.abspath(os.path.expanduser(path.strip()))
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    if path.lower().endswith(('.tar.gz', '.tgz')):
+        if not os.path.isfile(path):
+            raise ValueError(f"Not a file: {path}")
+        td = tempfile.mkdtemp(prefix='prowjob-analyzer-artifacts-')
+        _tar_extract_temp_dir = td
+        logger.info(f"Extracting artifact archive to {td}...")
+        with tarfile.open(path, 'r:*') as tf:
+            if sys.version_info >= (3, 12):
+                tf.extractall(td, filter='data')
+            else:
+                tf.extractall(td)
+        _local_artifacts_root = _find_job_root(td)
+    elif os.path.isdir(path):
+        _local_artifacts_root = _find_job_root(path)
+    else:
+        raise ValueError(f"Expected a directory or .tar.gz, got: {path}")
+
+    if not os.path.isfile(os.path.join(_local_artifacts_root, 'prowjob.json')):
+        logger.warning(
+            f"No prowjob.json under artifact root {_local_artifacts_root!r}; "
+            "analysis may fail."
+        )
+    logger.info(f"Artifact source: local root {_local_artifacts_root}")
+
+
+def _artifact_cache_key(base_url: str, artifact_path: str) -> str:
+    root = _local_artifacts_root or base_url
+    return f"{root}\0{artifact_path}"
+
+
+def _read_local_artifact(artifact_path: str) -> Optional[bytes]:
+    if not _local_artifacts_root:
+        return None
+    full = os.path.join(_local_artifacts_root, artifact_path.replace('/', os.sep))
+    if not os.path.isfile(full):
+        return None
+    with open(full, 'rb') as f:
+        return f.read()
+
+
+def _fetch_artifact_http(base_url: str, artifact_path: str, max_retries: int = 3) -> Optional[bytes]:
+    """HTTP(S) fetch only (no cache)."""
     url = f"{base_url}/{artifact_path}"
 
     for attempt in range(max_retries):
@@ -222,6 +432,43 @@ def fetch_artifact(base_url: str, artifact_path: str, max_retries: int = 3) -> O
     return None
 
 
+def fetch_artifact(base_url: str, artifact_path: str, max_retries: int = 3) -> Optional[bytes]:
+    """
+    Read an artifact from the configured local tree, or fetch from Prow/GCS over HTTP.
+
+    When :func:`configure_artifact_source` has set a local directory or extracted
+    ``.tar.gz``, **only disk reads** are used for job artifacts—``base_url`` is ignored
+    for retrieval (still used as a cache key). Otherwise HTTP is used with retries.
+
+    Successful reads are cached in-memory for the lifetime of the process (including
+    ``None`` for missing files) to avoid duplicate network or disk reads.
+
+    Args:
+        base_url: Base URL of the Prow job (cache key; used for HTTP when not local)
+        artifact_path: Relative path to the artifact (e.g., "prowjob.json")
+        max_retries: Maximum number of retry attempts (HTTP only)
+
+    Returns:
+        Artifact content as bytes, or None if not found
+    """
+    key = _artifact_cache_key(base_url, artifact_path)
+    if key in _artifact_cache:
+        return _artifact_cache[key]
+
+    if _local_artifacts_root:
+        data = _read_local_artifact(artifact_path)
+        _artifact_cache[key] = data
+        if data is not None:
+            logger.debug(f"Read local artifact {artifact_path} ({len(data)} bytes)")
+        else:
+            logger.debug(f"Local artifact not found: {artifact_path}")
+        return data
+
+    data = _fetch_artifact_http(base_url, artifact_path, max_retries=max_retries)
+    _artifact_cache[key] = data
+    return data
+
+
 def fetch_json_artifact(base_url: str, artifact_path: str) -> Optional[Dict]:
     """
     Fetch and parse a JSON artifact.
@@ -261,7 +508,10 @@ def check_artifacts_ready(base_url: str) -> bool:
 
 def wait_for_artifacts(base_url: str, timeout: int = 300, poll_interval: int = 10) -> bool:
     """
-    Wait for job artifacts to become available.
+    Wait for job artifacts to become available on the remote job (HTTP polling).
+
+    When a local artifact tree is configured, does not poll the network: checks once
+    for ``finished.json`` under the local root.
 
     Args:
         base_url: Base URL of the Prow job
@@ -271,6 +521,13 @@ def wait_for_artifacts(base_url: str, timeout: int = 300, poll_interval: int = 1
     Returns:
         True if artifacts became ready, False if timeout
     """
+    if _local_artifacts_root:
+        if check_artifacts_ready(base_url):
+            logger.info("Local artifacts present (finished.json found).")
+            return True
+        logger.warning("Local artifact root is missing finished.json.")
+        return False
+
     start_time = time.time()
 
     logger.info(f"Waiting for job artifacts (timeout: {timeout}s)...")
@@ -291,7 +548,7 @@ def wait_for_artifacts(base_url: str, timeout: int = 300, poll_interval: int = 1
 
 def get_artifact_url(base_url: str, artifact_path: str) -> str:
     """
-    Generate a GCS web URL for an artifact.
+    Generate a GCS web URL for an artifact, or a ``file://`` URI when using local artifacts.
 
     Args:
         base_url: Base URL of the Prow job
@@ -300,6 +557,10 @@ def get_artifact_url(base_url: str, artifact_path: str) -> str:
     Returns:
         Full URL to the artifact
     """
+    if _local_artifacts_root:
+        full = os.path.join(_local_artifacts_root, artifact_path.replace('/', os.sep))
+        if os.path.isfile(full):
+            return Path(full).resolve().as_uri()
     return f"{base_url}/{artifact_path}"
 
 
@@ -314,6 +575,25 @@ def get_step_directories(base_url: str, variant: str) -> List[str]:
     Returns:
         List of step directory names
     """
+    if _local_artifacts_root:
+        base = os.path.join(_local_artifacts_root, 'artifacts', variant)
+        if not os.path.isdir(base):
+            logger.debug(f"No local artifacts/{variant}/ directory: {base}")
+            return []
+        step_dirs: List[str] = []
+        try:
+            for name in sorted(os.listdir(base)):
+                if name in ('.', '..', 'artifacts'):
+                    continue
+                p = os.path.join(base, name)
+                if os.path.isdir(p):
+                    step_dirs.append(name)
+        except OSError as e:
+            logger.warning(f"Failed to list local step directories {base}: {e}")
+            return []
+        logger.debug(f"Found {len(step_dirs)} local step directories in {variant}")
+        return step_dirs
+
     artifacts_url = f"{base_url}/artifacts/{variant}/"
 
     try:

--- a/scripts/prowjob-analyzer/lib/fetcher.py
+++ b/scripts/prowjob-analyzer/lib/fetcher.py
@@ -482,3 +482,345 @@ def get_failed_steps(base_url: str, variant: str) -> List[str]:
 
     logger.debug(f"Found {len(failed_steps)} failed steps: {failed_steps}")
     return failed_steps
+
+
+def _podutils_json_timestamp(obj: Optional[Dict]) -> Optional[int]:
+    """Epoch seconds from a Prow step ``started.json`` / ``finished.json``."""
+    if not isinstance(obj, dict):
+        return None
+    t = obj.get('timestamp')
+    if t is None:
+        return None
+    try:
+        return int(float(t))
+    except (TypeError, ValueError):
+        return None
+
+
+def go_duration_to_seconds(s: str) -> Optional[int]:
+    """Parse a Go-style duration fragment (e.g. ``1h30m5s``, ``45m0s``) to seconds."""
+    s = (s or '').strip()
+    if not s:
+        return None
+    total = 0.0
+    # Milliseconds before ``m`` (minutes): ``813ms`` must not match as 813 minutes.
+    for m in re.finditer(r'(\d+(?:\.\d+)?)ms', s):
+        total += float(m.group(1)) / 1000.0
+    s = re.sub(r'(\d+(?:\.\d+)?)ms', ' ', s)
+    for m in re.finditer(r'(\d+(?:\.\d+)?)h', s):
+        total += float(m.group(1)) * 3600
+    for m in re.finditer(r'(\d+(?:\.\d+)?)m', s):
+        total += float(m.group(1)) * 60
+    for m in re.finditer(r'(\d+(?:\.\d+)?)s', s):
+        total += float(m.group(1))
+    if total <= 0:
+        return None
+    return int(round(total))
+
+
+def parse_test_step_duration_from_build_log(text: str) -> Optional[int]:
+    """
+    Duration from ``error: X fail, V pass, W skip (DURATION)`` in build-log.txt
+    (openshift-tests suite summary). When this line appears, use the last match as the
+    step elapsed time; it overrides per-test ``failed: (…)`` durations elsewhere in the log.
+    """
+    if not text:
+        return None
+    matches = list(
+        re.finditer(
+            r'(?i)error:\s*\d+\s*fail,\s*\d+\s*pass,\s*\d+\s*skip\s*\(\s*([^)]+)\s*\)',
+            text,
+        )
+    )
+    if not matches:
+        return None
+    return go_duration_to_seconds(matches[-1].group(1))
+
+
+def parse_ginkgo_failed_durations_max(text: str) -> Optional[int]:
+    """
+    Longest ``failed: (3h1m37s)``-style duration from ginkgo output (per-test timeout).
+    """
+    if not text:
+        return None
+    best: Optional[int] = None
+    for m in re.finditer(r'(?im)^\s*failed:\s*\(\s*([^)]+)\s*\)', text):
+        secs = go_duration_to_seconds(m.group(1).strip())
+        if secs is not None and secs > 0:
+            if best is None or secs > best:
+                best = secs
+    return best
+
+
+def _line_is_prow_entrypoint_noise(line: str) -> bool:
+    """Skip Prow sidecar JSON lines (grace period, global timeout) — not suite duration."""
+    s = line.lower()
+    if '"component"' in s and 'entrypoint' in s:
+        return True
+    if 'grace period' in s or 'gracefullyterminate' in s:
+        return True
+    if 'did not finish before' in s and 'timeout' in s:
+        return True
+    return False
+
+
+def parse_build_log_duration_fallback(text: str) -> Optional[int]:
+    """
+    Parenthesized Go durations in the log tail, excluding Prow entrypoint JSON lines
+    (which often end the file with ``10m0s`` grace, etc.).
+    """
+    if not text:
+        return None
+    tail = text[-400000:] if len(text) > 400000 else text
+    best: Optional[int] = None
+    for line in tail.splitlines():
+        if _line_is_prow_entrypoint_noise(line):
+            continue
+        for m in re.finditer(r'\(\s*([^)]+)\s*\)', line):
+            g = m.group(1).strip()
+            if not re.search(r'\d', g):
+                continue
+            if not re.search(r'\d+\s*[hms]', g, re.I):
+                continue
+            secs = go_duration_to_seconds(g)
+            if secs is not None and secs > 0:
+                if best is None or secs > best:
+                    best = secs
+    return best
+
+
+def _step_started_timestamp(base_url: str, variant: str, step_name: str) -> Optional[int]:
+    """Epoch seconds from ``artifacts/{variant}/{step}/started.json``."""
+    path = f"artifacts/{variant}/{step_name}/started.json"
+    data = fetch_json_artifact(base_url, path)
+    return _podutils_json_timestamp(data)
+
+
+def _duration_openshift_extended_test_via_next_step(
+    base_url: str, variant: str,
+) -> Optional[int]:
+    """
+    Duration = start time of the next pipeline step minus openshift-extended-test start.
+
+    Steps are ordered by ``started.json`` timestamp (sequential ci-operator steps). The
+    step immediately after openshift-extended-test in that order is used when this step's
+    ``finished.json`` is missing or unreliable (e.g. timeout).
+    """
+    step_dirs = get_step_directories(base_url, variant)
+    if not step_dirs or 'openshift-extended-test' not in step_dirs:
+        return None
+
+    entries: List[Tuple[int, str]] = []
+    for step in step_dirs:
+        st = _step_started_timestamp(base_url, variant, step)
+        if st is not None:
+            entries.append((st, step))
+
+    if len(entries) < 2:
+        return None
+
+    entries.sort(key=lambda x: (x[0], x[1]))
+
+    for i in range(len(entries) - 1):
+        if entries[i][1] == 'openshift-extended-test':
+            t_oet = entries[i][0]
+            t_next = entries[i + 1][0]
+            if t_next > t_oet:
+                return t_next - t_oet
+            return None
+
+    return None
+
+
+def _build_log_shows_test_step_finished(text: Optional[str]) -> bool:
+    """True if build-log contains the final openshift-tests error summary line."""
+    if not text:
+        return False
+    return bool(
+        re.search(
+            r'(?i)error:\s*\d+\s*fail,\s*\d+\s*pass,\s*\d+\s*skip',
+            text,
+        )
+    )
+
+
+def _oet_step_has_finished(
+    ts: Optional[int],
+    tf: Optional[int],
+    finished_json: Optional[Dict],
+    build_log_text: Optional[str],
+) -> bool:
+    """
+    Step is done if Prow wrote a finished record, we have an end timestamp, or build-log
+    has the final test summary (tests completed / failed, not mid-run).
+    """
+    if finished_json is not None:
+        if _podutils_json_timestamp(finished_json) is not None:
+            return True
+        if str(finished_json.get('result', '')).strip() != '':
+            return True
+        if 'passed' in finished_json:
+            return True
+    if ts is not None and tf is not None and tf >= ts:
+        return True
+    return _build_log_shows_test_step_finished(build_log_text)
+
+
+def _parse_build_log_duration_seconds(build_log_text: Optional[str]) -> Optional[int]:
+    """
+    Best-effort seconds from build-log: the final ``error: N fail, … (duration)`` line from
+    openshift-tests is treated as the suite elapsed time when present; otherwise longest
+    ginkgo ``failed: (…)``, then other parenthesized durations (excluding Prow entrypoint
+    noise).
+    """
+    if not build_log_text:
+        return None
+    suite = parse_test_step_duration_from_build_log(build_log_text)
+    if suite is not None and suite > 0:
+        return suite
+    candidates: List[int] = []
+    b = parse_ginkgo_failed_durations_max(build_log_text)
+    if b is not None and b > 0:
+        candidates.append(b)
+    c = parse_build_log_duration_fallback(build_log_text)
+    if c is not None and c > 0:
+        candidates.append(c)
+    return max(candidates) if candidates else None
+
+
+def _merge_wall_and_log_seconds(
+    sec_wall: Optional[int],
+    sec_log: Optional[int],
+) -> int:
+    """
+    Prefer wall-clock when it is at least one minute; otherwise prefer build-log.
+    If both are positive, use the larger (covers sub-minute wall vs full suite in log).
+    """
+    w = sec_wall if sec_wall is not None else 0
+    l = sec_log if sec_log is not None else 0
+    if w >= 60:
+        return max(w, l) if l > 0 else w
+    if l > 0:
+        return max(w, l)
+    return w
+
+
+def _oet_step_ended(
+    ts: Optional[int],
+    tf: Optional[int],
+    fin_json: Optional[Dict],
+    build_log_text: Optional[str],
+    sec_next: Optional[int],
+) -> bool:
+    """
+    True if the step is no longer running: Prow finished, test summary in log, or the
+    next ci-operator step has started (interrupt/timeout without a clean finished.json).
+    """
+    if _oet_step_has_finished(ts, tf, fin_json, build_log_text):
+        return True
+    if ts is not None and sec_next is not None and sec_next > 0:
+        return True
+    return False
+
+
+def _prefer_next_step_wall_duration(
+    fin_json: Optional[Dict],
+    build_log_text: Optional[str],
+) -> bool:
+    """
+    Use (next step started − OET started) as wall duration when the step was killed,
+    timed out, or never got a reliable finished.json timestamp.
+    """
+    if fin_json is None:
+        return True
+    r = str(fin_json.get('result', '')).strip().upper()
+    if r in ('ABORTED', 'TIMEOUT'):
+        return True
+    if build_log_text and r == 'FAILURE':
+        if re.search(
+            r'(?i)(timeout|deadline exceeded|context deadline|interrupted|SIGKILL|SIGTERM)',
+            build_log_text,
+        ):
+            return True
+    return False
+
+
+def compute_openshift_extended_test_elapsed_display(
+    base_url: str,
+    variant: str,
+    extended_finished_json: Optional[Dict] = None,
+) -> str:
+    """
+    How long the openshift-extended-test step ran, as ``HH:MM``.
+
+    ``00:00`` only when the step never started or is still running (no finish artifact/log).
+
+    When the step has finished, duration is: wall-clock from ``finished.json`` when
+    reliable; on interrupt/timeout or missing finish time, prefer **next step's
+    ``started.json`` minus this step's start**. Merged with ``build-log.txt`` when
+    wall-clock is missing or sub-minute.
+    """
+    if not variant or variant == 'unknown':
+        return ''
+
+    from .parser import format_hours_minutes_test_step_display
+
+    prefix = f"artifacts/{variant}/openshift-extended-test"
+    started = fetch_json_artifact(base_url, f"{prefix}/started.json")
+    ts = _podutils_json_timestamp(started)
+
+    fin_json = extended_finished_json
+    if fin_json is None:
+        fin_json = fetch_json_artifact(base_url, f"{prefix}/finished.json")
+
+    tf = _podutils_json_timestamp(fin_json)
+
+    bl = fetch_artifact(base_url, f"{prefix}/build-log.txt")
+    build_log_text: Optional[str] = None
+    if bl:
+        try:
+            build_log_text = bl.decode('utf-8', errors='ignore')
+        except Exception as e:
+            logger.debug(f"Could not decode openshift-extended-test build-log.txt: {e}")
+
+    sec_next: Optional[int] = None
+    if ts is not None:
+        sec_next = _duration_openshift_extended_test_via_next_step(base_url, variant)
+
+    ended = _oet_step_ended(ts, tf, fin_json, build_log_text, sec_next)
+    finished_prow = _oet_step_has_finished(ts, tf, fin_json, build_log_text)
+    not_started = ts is None and not finished_prow
+    running = ts is not None and not ended
+
+    sec_log = _parse_build_log_duration_seconds(build_log_text)
+
+    if not_started:
+        return '00:00'
+    if running:
+        return '00:00'
+
+    # Ended: prefer tf−ts, or (next step start − OET start) for interrupt/timeout
+    sec_tf: Optional[int] = None
+    if ts is not None and tf is not None and tf >= ts:
+        sec_tf = tf - ts
+
+    # finished.json tf−ts is authoritative whenever present; do not let prefer_next
+    # overwrite with next-step duration (often wrong on timeout when sorting mis-orders).
+    sec_wall: Optional[int] = None
+    prefer_next = _prefer_next_step_wall_duration(fin_json, build_log_text)
+
+    if sec_tf is not None and sec_tf > 0:
+        sec_wall = sec_tf
+    elif prefer_next and sec_next is not None and sec_next > 0:
+        sec_wall = sec_next
+    elif sec_next is not None and sec_next > 0:
+        sec_wall = sec_next
+    else:
+        sec_wall = None
+
+    secs = _merge_wall_and_log_seconds(sec_wall, sec_log)
+
+    if secs <= 0:
+        return 'unknown'
+
+    return format_hours_minutes_test_step_display(secs)

--- a/scripts/prowjob-analyzer/lib/fetcher.py
+++ b/scripts/prowjob-analyzer/lib/fetcher.py
@@ -723,28 +723,6 @@ def _oet_step_ended(
     return False
 
 
-def _prefer_next_step_wall_duration(
-    fin_json: Optional[Dict],
-    build_log_text: Optional[str],
-) -> bool:
-    """
-    Use (next step started − OET started) as wall duration when the step was killed,
-    timed out, or never got a reliable finished.json timestamp.
-    """
-    if fin_json is None:
-        return True
-    r = str(fin_json.get('result', '')).strip().upper()
-    if r in ('ABORTED', 'TIMEOUT'):
-        return True
-    if build_log_text and r == 'FAILURE':
-        if re.search(
-            r'(?i)(timeout|deadline exceeded|context deadline|interrupted|SIGKILL|SIGTERM)',
-            build_log_text,
-        ):
-            return True
-    return False
-
-
 def compute_openshift_extended_test_elapsed_display(
     base_url: str,
     variant: str,
@@ -755,10 +733,10 @@ def compute_openshift_extended_test_elapsed_display(
 
     ``00:00`` only when the step never started or is still running (no finish artifact/log).
 
-    When the step has finished, duration is: wall-clock from ``finished.json`` when
-    reliable; on interrupt/timeout or missing finish time, prefer **next step's
-    ``started.json`` minus this step's start**. Merged with ``build-log.txt`` when
-    wall-clock is missing or sub-minute.
+    When the step has finished, wall duration is ``finished`` minus ``started`` from
+    ``finished.json`` / ``started.json`` when that delta is positive; otherwise **next
+    step's ``started.json`` minus this step's start**. Merged with ``build-log.txt``
+    when wall-clock is missing or sub-minute.
     """
     if not variant or variant == 'unknown':
         return ''
@@ -794,29 +772,17 @@ def compute_openshift_extended_test_elapsed_display(
 
     sec_log = _parse_build_log_duration_seconds(build_log_text)
 
-    if not_started:
-        return '00:00'
-    if running:
+    if not_started or running:
         return '00:00'
 
-    # Ended: prefer tf−ts, or (next step start − OET start) for interrupt/timeout
-    sec_tf: Optional[int] = None
-    if ts is not None and tf is not None and tf >= ts:
-        sec_tf = tf - ts
-
-    # finished.json tf−ts is authoritative whenever present; do not let prefer_next
-    # overwrite with next-step duration (often wrong on timeout when sorting mis-orders).
+    # Ended: prefer positive finished.json wall delta; else next-step start − OET start.
     sec_wall: Optional[int] = None
-    prefer_next = _prefer_next_step_wall_duration(fin_json, build_log_text)
-
-    if sec_tf is not None and sec_tf > 0:
-        sec_wall = sec_tf
-    elif prefer_next and sec_next is not None and sec_next > 0:
+    if ts is not None and tf is not None and tf >= ts:
+        d = tf - ts
+        if d > 0:
+            sec_wall = d
+    if sec_wall is None and sec_next is not None and sec_next > 0:
         sec_wall = sec_next
-    elif sec_next is not None and sec_next > 0:
-        sec_wall = sec_next
-    else:
-        sec_wall = None
 
     secs = _merge_wall_and_log_seconds(sec_wall, sec_log)
 

--- a/scripts/prowjob-analyzer/lib/fetcher.py
+++ b/scripts/prowjob-analyzer/lib/fetcher.py
@@ -358,6 +358,58 @@ def get_step_directories(base_url: str, variant: str) -> List[str]:
         return []
 
 
+def summarize_openshift_extended_test_build_log(log_text: str) -> Optional[str]:
+    """
+    Build a short label for openshift-extended-test from build-log.txt.
+
+    - If the step finished with a test failure: ``error: X fail, V pass, W skip`` →
+      ``"X fail, V pass, W skip"``.
+    - If tests were interrupted (no final error line): last ``started: (X/Y/Z)`` →
+      ``"(X/Y/Z)"`` (X failed, Y started, Z total).
+    """
+    if not log_text:
+        return None
+
+    error_re = re.compile(
+        r'(?i)error:\s*(\d+)\s*fail,\s*(\d+)\s*pass,\s*(\d+)\s*skip',
+    )
+    err_matches = list(error_re.finditer(log_text))
+    if err_matches:
+        m = err_matches[-1]
+        return f"{m.group(1)} fail, {m.group(2)} pass, {m.group(3)} skip"
+
+    started_re = re.compile(
+        r'(?i)started:\s*\(\s*(\d+)\s*/\s*(\d+)\s*/\s*(\d+)\s*\)',
+    )
+    started_matches = list(started_re.finditer(log_text))
+    if started_matches:
+        m = started_matches[-1]
+        return f"({m.group(1)}/{m.group(2)}/{m.group(3)})"
+
+    return None
+
+
+def is_openshift_extended_test_failure_label(step_label: str) -> bool:
+    """
+    True if this string is the openshift-extended-test step or a build-log summary
+    derived from that step (instead of the bare directory name).
+    """
+    if step_label == 'openshift-extended-test':
+        return True
+    if re.fullmatch(r'\d+ fail, \d+ pass, \d+ skip', step_label):
+        return True
+    if re.fullmatch(r'\(\d+/\d+/\d+\)', step_label):
+        return True
+    return False
+
+
+def artifact_dir_for_failed_step_label(step_label: str) -> str:
+    """Directory under artifacts/{variant}/ for linking (summaries map to openshift-extended-test)."""
+    if is_openshift_extended_test_failure_label(step_label):
+        return 'openshift-extended-test'
+    return step_label
+
+
 def get_failed_steps(base_url: str, variant: str) -> List[str]:
     """
     Identify which steps failed by checking their finished.json files.
@@ -370,7 +422,9 @@ def get_failed_steps(base_url: str, variant: str) -> List[str]:
         variant: Job variant (e.g., "aws-ipi-peerpods")
 
     Returns:
-        List of failed step names
+        List of failed step labels. For openshift-extended-test, this may be a summary
+        from build-log.txt (e.g. ``3 fail, 10 pass, 2 skip`` or ``(0/5/40)``) instead of
+        the bare step name.
     """
     step_dirs = get_step_directories(base_url, variant)
     failed_steps = []
@@ -406,8 +460,25 @@ def get_failed_steps(base_url: str, variant: str) -> List[str]:
                             logger.debug(f"Step {step} has test failures: failures={failures}, errors={errors}")
 
             if step_failed:
-                failed_steps.append(step)
-                logger.debug(f"Step {step} failed: passed={passed}, result={result}")
+                if step == 'openshift-extended-test':
+                    label: Optional[str] = None
+                    bl_path = f"artifacts/{variant}/{step}/build-log.txt"
+                    bl_content = fetch_artifact(base_url, bl_path)
+                    if bl_content:
+                        try:
+                            label = summarize_openshift_extended_test_build_log(
+                                bl_content.decode('utf-8', errors='ignore')
+                            )
+                        except Exception as e:
+                            logger.debug(f"Could not summarize openshift-extended-test build-log: {e}")
+                    failed_steps.append(label or step)
+                    logger.debug(
+                        "Step %s failed: passed=%s, result=%s, label=%s",
+                        step, passed, result, label or step,
+                    )
+                else:
+                    failed_steps.append(step)
+                    logger.debug(f"Step {step} failed: passed={passed}, result={result}")
 
     logger.debug(f"Found {len(failed_steps)} failed steps: {failed_steps}")
     return failed_steps

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -115,7 +115,7 @@ def get_job_status(
 
     Priority for openshift-extended-test outcomes:
     1. ``artifacts/.../openshift-extended-test/artifacts/test-results.yaml`` —
-       if parsed and contains ``failures``, ``failures == 0`` means success (primary).
+       if parsed and contains ``failures`` and/or ``errors``, both must be zero for success (primary).
     2. ``artifacts/.../openshift-extended-test/finished.json`` —
        ``"result": "SUCCESS"`` when all test cases passed (no failures).
     3. Top-level ``prowjob.json`` ``status.state`` when the above are absent.
@@ -128,9 +128,13 @@ def get_job_status(
     Returns:
         Status string: 'success', 'failure', 'timeout', 'error', 'aborted', 'pending'
     """
-    # Primary: test-results.yaml failures count (openshift-extended-test)
-    if test_results is not None and 'failures' in test_results:
-        return 'success' if test_results['failures'] == 0 else 'failure'
+    # Primary: test-results.yaml failures/errors counts (openshift-extended-test)
+    if test_results is not None and (
+        'failures' in test_results or 'errors' in test_results
+    ):
+        failures = test_results.get('failures', 0)
+        errors = test_results.get('errors', 0)
+        return 'success' if failures == 0 and errors == 0 else 'failure'
 
     # Secondary: finished.json result (e.g. SUCCESS when no cases failed)
     if extended_test_finished is not None:
@@ -147,7 +151,10 @@ def get_job_status(
     state = status.get('state', '').lower()
 
     if state == 'success':
-        if test_results and test_results.get('failures', 0) > 0:
+        if test_results and (
+            test_results.get('failures', 0) > 0
+            or test_results.get('errors', 0) > 0
+        ):
             return 'failure'
         return 'success'
     elif state == 'failure':
@@ -160,7 +167,10 @@ def get_job_status(
         return 'error'
     else:
         if test_results:
-            if test_results.get('failures', 0) == 0:
+            if (
+                test_results.get('failures', 0) == 0
+                and test_results.get('errors', 0) == 0
+            ):
                 return 'success'
             else:
                 return 'failure'

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -416,3 +416,28 @@ def format_duration(seconds: int) -> str:
         minutes = (seconds % 3600) // 60
         secs = seconds % 60
         return f"{hours}h {minutes}m {secs}s"
+
+
+def format_hours_minutes(seconds: int) -> str:
+    """
+    Format duration as ``HH:MM`` (hours and whole minutes, floor seconds).
+    """
+    if seconds < 0:
+        seconds = 0
+    total_minutes = seconds // 60
+    h = total_minutes // 60
+    m = total_minutes % 60
+    return f"{h:02d}:{m:02d}"
+
+
+def format_hours_minutes_test_step_display(seconds: int) -> str:
+    """
+    ``HH:MM`` for openshift-extended-test elapsed. Sub-minute positive durations show as
+    ``00:01`` so the value is never ``00:00`` when ``seconds > 0``.
+    """
+    if seconds <= 0:
+        return format_hours_minutes(0)
+    s = format_hours_minutes(seconds)
+    if s == '00:00' and seconds > 0:
+        return '00:01'
+    return s

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -105,6 +105,67 @@ def parse_test_results(test_results_content: bytes) -> Optional[Dict]:
         return None
 
 
+def _count_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _oet_finished_json_has_timestamp(fin: Dict) -> bool:
+    """True if openshift-extended-test ``finished.json`` has a pod-utils timestamp."""
+    t = fin.get('timestamp')
+    if t is None:
+        return False
+    try:
+        return int(float(t)) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _job_status_from_test_results(test_results: Optional[Dict]) -> Optional[str]:
+    """
+    Derive ``success`` / ``failure`` from test-results.yaml body when possible.
+
+    Handles junit-style ``failures``/``errors``, ``failingScenarios``, per-test ``tests``,
+    a top-level ``failed`` count, or ``total``/``passed``/``skipped``.
+    """
+    if not test_results or not isinstance(test_results, dict):
+        return None
+
+    if 'failures' in test_results or 'errors' in test_results:
+        failures = _count_int(test_results.get('failures', 0))
+        errors = _count_int(test_results.get('errors', 0))
+        return 'success' if failures == 0 and errors == 0 else 'failure'
+
+    failing_scenarios = test_results.get('failingScenarios') or []
+    if failing_scenarios:
+        return 'failure'
+
+    tests = test_results.get('tests')
+    if isinstance(tests, list) and len(tests) > 0:
+        for t in tests:
+            if not isinstance(t, dict):
+                continue
+            if t.get('state') == 'failed' or t.get('failed') is True:
+                return 'failure'
+        return 'success'
+
+    if 'failed' in test_results:
+        failed = _count_int(test_results.get('failed'))
+        return 'success' if failed == 0 else 'failure'
+
+    if 'total' in test_results and 'passed' in test_results:
+        total = _count_int(test_results.get('total'))
+        passed = _count_int(test_results.get('passed'))
+        skipped = _count_int(test_results.get('skipped', 0))
+        if total > 0:
+            failed = total - passed - skipped
+            return 'success' if failed <= 0 else 'failure'
+
+    return None
+
+
 def get_job_status(
     prowjob_data: Dict,
     test_results: Optional[Dict] = None,
@@ -114,11 +175,13 @@ def get_job_status(
     Determine overall job status.
 
     Priority for openshift-extended-test outcomes:
-    1. ``artifacts/.../openshift-extended-test/artifacts/test-results.yaml`` —
-       if parsed and contains ``failures`` and/or ``errors``, both must be zero for success (primary).
-    2. ``artifacts/.../openshift-extended-test/finished.json`` —
-       ``"result": "SUCCESS"`` when all test cases passed (no failures).
-    3. Top-level ``prowjob.json`` ``status.state`` when the above are absent.
+    1. ``artifacts/.../openshift-extended-test/artifacts/test-results.yaml`` when the
+       body supports a clear outcome (failures/errors, ``failingScenarios``, ``tests``,
+       ``failed`` count, or ``total``/``passed``/``skipped``).
+    2. ``artifacts/.../openshift-extended-test/finished.json`` — ``result`` and/or a
+       ``timestamp`` proving the step finished (avoids ``pending`` when Prow job state
+       lags later ci-operator steps).
+    3. Top-level ``prowjob.json`` ``status.state`` when the above are inconclusive.
 
     Args:
         prowjob_data: Parsed prowjob.json (raw dict)
@@ -126,34 +189,39 @@ def get_job_status(
         extended_test_finished: Parsed openshift-extended-test/finished.json (optional)
 
     Returns:
-        Status string: 'success', 'failure', 'timeout', 'error', 'aborted', 'pending'
+        Status string: 'success', 'failure', 'timeout', 'error', 'aborted', 'pending',
+        'unknown'
     """
-    # Primary: test-results.yaml failures/errors counts (openshift-extended-test)
-    if test_results is not None and (
-        'failures' in test_results or 'errors' in test_results
-    ):
-        failures = test_results.get('failures', 0)
-        errors = test_results.get('errors', 0)
-        return 'success' if failures == 0 and errors == 0 else 'failure'
+    tr_status = _job_status_from_test_results(test_results)
+    if tr_status is not None:
+        return tr_status
 
-    # Secondary: finished.json result (e.g. SUCCESS when no cases failed)
-    if extended_test_finished is not None:
+    if extended_test_finished is not None and isinstance(extended_test_finished, dict):
         result = extended_test_finished.get('result')
-        if result is not None:
-            r = str(result).strip().upper()
-            if r == 'SUCCESS':
+        r = str(result).strip().upper() if result is not None else ''
+        if r:
+            if r in ('SUCCESS', 'PASS', 'PASSED', 'SUCCEEDED'):
                 return 'success'
             if r in ('FAILURE', 'FAILED', 'FAIL'):
                 return 'failure'
-            # Other values: defer to prowjob.json
+            if r in ('TIMEOUT', 'TIMEDOUT'):
+                return 'timeout'
+            if r in ('ABORTED', 'INTERRUPTED'):
+                return 'aborted'
+            if r == 'ERROR':
+                return 'error'
+            return 'unknown'
+
+        if _oet_finished_json_has_timestamp(extended_test_finished):
+            return 'unknown'
 
     status = prowjob_data.get('status', {})
-    state = status.get('state', '').lower()
+    state = (status.get('state') or '').lower()
 
     if state == 'success':
         if test_results and (
-            test_results.get('failures', 0) > 0
-            or test_results.get('errors', 0) > 0
+            _count_int(test_results.get('failures', 0)) > 0
+            or _count_int(test_results.get('errors', 0)) > 0
         ):
             return 'failure'
         return 'success'
@@ -162,18 +230,14 @@ def get_job_status(
     elif state == 'aborted':
         return 'aborted'
     elif state == 'pending':
+        if extended_test_finished is not None and isinstance(
+            extended_test_finished, dict
+        ) and _oet_finished_json_has_timestamp(extended_test_finished):
+            return 'unknown'
         return 'pending'
     elif state == 'error':
         return 'error'
     else:
-        if test_results:
-            if (
-                test_results.get('failures', 0) == 0
-                and test_results.get('errors', 0) == 0
-            ):
-                return 'success'
-            else:
-                return 'failure'
         return 'unknown'
 
 

--- a/scripts/prowjob-analyzer/lib/parser.py
+++ b/scripts/prowjob-analyzer/lib/parser.py
@@ -105,23 +105,48 @@ def parse_test_results(test_results_content: bytes) -> Optional[Dict]:
         return None
 
 
-def get_job_status(prowjob_data: Dict, test_results: Optional[Dict] = None) -> str:
+def get_job_status(
+    prowjob_data: Dict,
+    test_results: Optional[Dict] = None,
+    extended_test_finished: Optional[Dict] = None,
+) -> str:
     """
     Determine overall job status.
 
+    Priority for openshift-extended-test outcomes:
+    1. ``artifacts/.../openshift-extended-test/artifacts/test-results.yaml`` —
+       if parsed and contains ``failures``, ``failures == 0`` means success (primary).
+    2. ``artifacts/.../openshift-extended-test/finished.json`` —
+       ``"result": "SUCCESS"`` when all test cases passed (no failures).
+    3. Top-level ``prowjob.json`` ``status.state`` when the above are absent.
+
     Args:
-        prowjob_data: Parsed prowjob.json
-        test_results: Optional parsed test-results.yaml
+        prowjob_data: Parsed prowjob.json (raw dict)
+        test_results: Parsed test-results.yaml from openshift-extended-test (optional)
+        extended_test_finished: Parsed openshift-extended-test/finished.json (optional)
 
     Returns:
         Status string: 'success', 'failure', 'timeout', 'error', 'aborted', 'pending'
     """
+    # Primary: test-results.yaml failures count (openshift-extended-test)
+    if test_results is not None and 'failures' in test_results:
+        return 'success' if test_results['failures'] == 0 else 'failure'
+
+    # Secondary: finished.json result (e.g. SUCCESS when no cases failed)
+    if extended_test_finished is not None:
+        result = extended_test_finished.get('result')
+        if result is not None:
+            r = str(result).strip().upper()
+            if r == 'SUCCESS':
+                return 'success'
+            if r in ('FAILURE', 'FAILED', 'FAIL'):
+                return 'failure'
+            # Other values: defer to prowjob.json
+
     status = prowjob_data.get('status', {})
     state = status.get('state', '').lower()
 
-    # Map Prow states to our status
     if state == 'success':
-        # Double-check with test results if available
         if test_results and test_results.get('failures', 0) > 0:
             return 'failure'
         return 'success'
@@ -134,7 +159,6 @@ def get_job_status(prowjob_data: Dict, test_results: Optional[Dict] = None) -> s
     elif state == 'error':
         return 'error'
     else:
-        # Try to infer from test results
         if test_results:
             if test_results.get('failures', 0) == 0:
                 return 'success'

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -10,7 +10,7 @@ import json
 import logging
 from typing import Dict, List, Optional
 from datetime import datetime
-from .parser import format_duration
+from .parser import format_hours_minutes
 from .fetcher import get_artifact_url, artifact_dir_for_failed_step_label
 
 logger = logging.getLogger(__name__)
@@ -226,14 +226,20 @@ def build_report_data(
     test_results: Optional[Dict],
     failure_analysis: Optional[Dict],
     base_url: str,
+    test_elapsed_time: str = '',
 ) -> Dict:
     """
     Build the canonical report dict (single source of truth).
     JSON dumps it in full; human report reads a subset from this dict.
     """
+    prowjob_ds = int(prowjob_data.get('duration_seconds', 0) or 0)
+    prowjob_elapsed_time = format_hours_minutes(prowjob_ds) if prowjob_ds > 0 else 'unknown'
+
     report = {
         'version': '1.0',
         'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'test_elapsed_time': test_elapsed_time or 'unknown',
+        'prowjob_elapsed_time': prowjob_elapsed_time,
         'prowjob': {
             'url': base_url,
             'name': metadata['job_name'],
@@ -335,7 +341,7 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
     Generate one row of CSV from the canonical report_data.
     Columns: trigger, start_time, catalog_full_tag, catalog_build_date, provider,
     ocp_version, prowjob_url, workload_type, kata_rpm_version, prowjob_status,
-    failed_steps, primary_pattern, confidence, root_cause.
+    test_elapsed_time, failed_steps, primary_pattern, confidence, root_cause.
     """
     prowjob = report_data['prowjob']
     metadata = report_data['metadata']
@@ -357,6 +363,7 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
         metadata.get('workload_type', ''),
         metadata.get('kata_rpm_version', ''),
         (prowjob.get('status') or '').upper(),
+        report_data.get('test_elapsed_time', ''),
         failure_analysis.get('failure_location', ''),
         root_cause.get('primary_pattern', ''),
         root_cause.get('confidence', ''),
@@ -368,7 +375,8 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
         writer.writerow([
             'trigger', 'start_time', 'catalog_full_tag', 'catalog_build_date',
             'provider', 'ocp_version', 'prowjob_url', 'workload_type',
-            'kata_rpm_version', 'prowjob_status', 'failed_steps', 'primary_pattern',
+            'kata_rpm_version', 'prowjob_status', 'test_elapsed_time', 'failed_steps',
+            'primary_pattern',
             'confidence', 'root_cause',
         ])
     writer.writerow(row)
@@ -406,15 +414,16 @@ def generate_human_report(report_data: Dict) -> str:
     if prowjob.get('release_stage'):
         report += f"- **Release Stage**: {prowjob['release_stage']}\n"
 
-    duration = prowjob.get('duration_seconds', 0)
-    if duration > 0:
-        report += f"- **Duration**: {format_duration(duration)}\n"
-
     start_time = prowjob.get('start_time', '')
     if start_time:
         report += f"- **Started**: {start_time}\n"
 
     report += f"- **URL**: {base_url}\n"
+
+    report += f"- **test_elapsed_time**: {report_data.get('test_elapsed_time', 'unknown')} "
+    report += "(openshift-extended-test step, start to finish or interruption)\n"
+    report += f"- **prowjob_elapsed_time**: {report_data.get('prowjob_elapsed_time', 'unknown')} "
+    report += "(entire Prow job wall time)\n"
 
     root_cause = report_data.get('root_cause') or {}
     if root_cause.get('likely_cause'):

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -370,7 +370,9 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
         root_cause.get('likely_cause', ''),
     ]
     out = io.StringIO()
-    writer = csv.writer(out)
+    # Single \n line endings; strip any stray leading newlines (avoids a blank first line
+    # when appending rows with --no-header or odd csv.writer/CRLF combinations).
+    writer = csv.writer(out, lineterminator='\n')
     if header:
         writer.writerow([
             'trigger', 'start_time', 'catalog_full_tag', 'catalog_build_date',
@@ -380,7 +382,7 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
             'confidence', 'root_cause',
         ])
     writer.writerow(row)
-    return out.getvalue()
+    return out.getvalue().lstrip('\r\n')
 
 
 def generate_human_report(report_data: Dict) -> str:

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -151,6 +151,42 @@ def generate_failure_analysis_section(failure_analysis: Dict, base_url: str, var
     return section
 
 
+def generate_post_test_prow_pipeline_section(
+    failure_analysis: Dict, base_url: str, variant: str
+) -> str:
+    """Section when tests passed but a later Prow step failed."""
+    section = "\n## Prow pipeline issue (not a test failure)\n\n"
+    steps = failure_analysis.get('post_test_failed_steps') or []
+    loc = failure_analysis.get('failure_location', 'unknown')
+    if steps:
+        step_list = ', '.join(f'`{s}`' for s in steps)
+        section += f"**Failed Prow step(s) after tests**: {step_list}\n\n"
+    else:
+        section += (
+            f"**Failed step(s)**: could not be listed from artifacts "
+            f"(location hint: `{loc}`).\n\n"
+        )
+    note = failure_analysis.get('summary_note', '')
+    if note:
+        section += f"{note}\n\n"
+    root_cause = failure_analysis.get('root_cause', {})
+    if root_cause.get('likely_cause'):
+        section += f"**Details**: {root_cause['likely_cause']}\n\n"
+    suggested = root_cause.get('suggested_actions', [])
+    if suggested:
+        section += "**Suggested actions**:\n"
+        for action in suggested:
+            section += f"- {action}\n"
+        section += "\n"
+    if variant and variant != 'unknown' and steps:
+        section += "### Step artifact links\n\n"
+        for step in steps:
+            prefix = f"artifacts/{variant}/{step}/"
+            section += f"- [`{step}`]({get_artifact_url(base_url, prefix)})\n"
+        section += "\n"
+    return section
+
+
 def generate_artifacts_section(base_url: str, variant: str, test_results_available: bool, analyzed_files: List[Dict] = None) -> str:
     """Generate artifacts links section."""
     section = "\n## Artifacts\n\n"
@@ -202,6 +238,7 @@ def build_report_data(
             'name': metadata['job_name'],
             'build_id': metadata['build_id'],
             'status': status,
+            'prow_reported_state': prowjob_data.get('state', 'unknown'),
             'trigger': metadata['trigger_source'],
             'release_stage': metadata.get('release_stage', ''),
             'duration_seconds': prowjob_data.get('duration_seconds', 0),
@@ -243,6 +280,8 @@ def build_report_data(
     if failure_analysis:
         failing_tests = failure_analysis.get('failing_tests', [])
         report['failure_analysis'] = {
+            'failure_kind': failure_analysis.get('failure_kind'),
+            'post_test_failed_steps': failure_analysis.get('post_test_failed_steps'),
             'failure_location': failure_analysis.get('failure_location', 'unknown'),
             'failing_tests': [
                 {
@@ -260,6 +299,13 @@ def build_report_data(
             'detected_patterns': failure_analysis.get('detected_patterns', []),
             'analyzed_files': failure_analysis.get('analyzed_files', []),
             'root_cause': failure_analysis.get('root_cause', {}),
+        }
+
+    if failure_analysis and failure_analysis.get('failure_kind') == 'prow_pipeline_after_tests':
+        report['prow_pipeline_issue'] = {
+            'failed_steps': failure_analysis.get('post_test_failed_steps') or [],
+            'failure_location': failure_analysis.get('failure_location', ''),
+            'summary': failure_analysis.get('summary_note', ''),
         }
 
     # Artifacts
@@ -341,9 +387,14 @@ def generate_human_report(report_data: Dict) -> str:
 
     report = "# Prow Job Analysis Report\n\n"
 
-    # Status
+    # Status (tests can be SUCCESS while Prow still reports a later pipeline failure)
     status_emoji = format_status_emoji(status)
     report += f"## Status: {status_emoji} {status.upper()}\n\n"
+    if report_data.get('prow_pipeline_issue'):
+        report += (
+            "> **Note:** Extended tests passed. Prow reported a failure in a **later pipeline step** "
+            "(not a failing test case). See [Prow pipeline issue](#prow-pipeline-issue-not-a-test-failure) below.\n\n"
+        )
 
     # Job Overview (job_name, build_id, trigger live in prowjob in canonical report)
     report += "## Job Overview\n\n"
@@ -412,7 +463,12 @@ def generate_human_report(report_data: Dict) -> str:
     if test_results:
         report += generate_test_results_section(test_results, failure_analysis or {})
 
-    if status != 'success' and failure_analysis:
+    fa_kind = (failure_analysis or {}).get('failure_kind')
+    if failure_analysis and fa_kind == 'prow_pipeline_after_tests':
+        report += generate_post_test_prow_pipeline_section(
+            failure_analysis, base_url, metadata.get('variant', '')
+        )
+    elif status != 'success' and failure_analysis:
         report += generate_failure_analysis_section(failure_analysis, base_url, metadata.get('variant', ''))
 
     analyzed_files = failure_analysis.get('analyzed_files', []) if failure_analysis else []

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -387,7 +387,7 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
 
 def generate_human_report(report_data: Dict) -> str:
     """
-    Generate human-readable markdown report from the canonical repor dict.
+    Generate human-readable markdown report from the canonical report dict.
     """
     prowjob = report_data['prowjob']
     metadata = report_data['metadata']

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -11,7 +11,7 @@ import logging
 from typing import Dict, List, Optional
 from datetime import datetime
 from .parser import format_duration
-from .fetcher import get_artifact_url
+from .fetcher import get_artifact_url, artifact_dir_for_failed_step_label
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,8 @@ def generate_post_test_prow_pipeline_section(
     if variant and variant != 'unknown' and steps:
         section += "### Step artifact links\n\n"
         for step in steps:
-            prefix = f"artifacts/{variant}/{step}/"
+            step_dir = artifact_dir_for_failed_step_label(step)
+            prefix = f"artifacts/{variant}/{step_dir}/"
             section += f"- [`{step}`]({get_artifact_url(base_url, prefix)})\n"
         section += "\n"
     return section

--- a/scripts/prowjob-analyzer/lib/report_generator.py
+++ b/scripts/prowjob-analyzer/lib/report_generator.py
@@ -376,7 +376,7 @@ def generate_csv_report(report_data: Dict, header: bool = True) -> str:
 
 def generate_human_report(report_data: Dict) -> str:
     """
-    Generate human-readable markdown report from the canonical report dict.
+    Generate human-readable markdown report from the canonical repor dict.
     """
     prowjob = report_data['prowjob']
     metadata = report_data['metadata']

--- a/scripts/prowjob-analyzer/tests/test_failure_analyzer.py
+++ b/scripts/prowjob-analyzer/tests/test_failure_analyzer.py
@@ -3,6 +3,7 @@
 import unittest
 
 from lib.failure_analyzer import (
+    determine_root_cause,
     detect_kata_rpm_install_context,
     extract_failed_case_ids_from_extended_build_log,
     extract_kata_rpm_dependency_detail,
@@ -167,6 +168,83 @@ error: Failed dependencies:
         self.assertIsNone(
             extract_kata_rpm_dependency_detail("only unrelated log lines\n"),
         )
+
+
+class TestDetermineRootCauseRpmInstall(unittest.TestCase):
+    def test_high_confidence_when_composite_source_even_if_first_match_is_build_log(
+        self,
+    ) -> None:
+        """Composite rpm_install is only added when detect_kata passed on OET prefix."""
+        rc = determine_root_cause(
+            [],
+            [
+                {'pattern': 'rpm_install', 'source': 'build-log.txt'},
+                {
+                    'pattern': 'rpm_install',
+                    'source': 'openshift-extended-test/build-log.txt (first test), composite',
+                },
+            ],
+            {},
+            oet_build_log_first_test=None,
+        )
+        self.assertEqual(rc['primary_pattern'], 'rpm_install')
+        self.assertEqual(rc['confidence'], 'high')
+        self.assertTrue(rc.get('kata_worker_context_verified'))
+        self.assertIn('Kata RPM install', rc['likely_cause'])
+
+    def test_high_confidence_when_oet_prefix_matches_kata_worker_context(self) -> None:
+        oet = _kata_rpm_install_log_snippet()
+        rc = determine_root_cause(
+            [],
+            [
+                {
+                    'pattern': 'rpm_install',
+                    'source': 'openshift-extended-test/build-log.txt (first test)',
+                },
+            ],
+            {},
+            oet_build_log_first_test=oet,
+        )
+        self.assertEqual(rc['confidence'], 'high')
+        self.assertTrue(rc.get('kata_worker_context_verified'))
+        self.assertIn('Kata RPM install', rc['likely_cause'])
+
+    def test_low_confidence_for_generic_build_log_match_without_oet_verification(
+        self,
+    ) -> None:
+        rc = determine_root_cause(
+            [],
+            [{'pattern': 'rpm_install', 'source': 'build-log.txt'}],
+            {},
+            oet_build_log_first_test=None,
+        )
+        self.assertEqual(rc['confidence'], 'low')
+        self.assertFalse(rc.get('kata_worker_context_verified'))
+        self.assertIn('not confirmed', rc['likely_cause'].lower())
+        self.assertNotIn('qemu-kvm-core', ' '.join(rc.get('suggested_actions', [])))
+
+    def test_low_confidence_when_oet_does_not_show_worker_kata_context(self) -> None:
+        # Matches generic rpm_install regex (Failed dependencies) but not Kata worker path
+        oet = (
+            "oc debug node/ci-op-xyz-master-0-abcd -n openshift-machine-api "
+            + "y" * 40
+            + "\n"
+            "error: Failed dependencies:\n"
+            "  some-other-pkg is needed by unrelated-package\n"
+        )
+        rc = determine_root_cause(
+            [],
+            [
+                {
+                    'pattern': 'rpm_install',
+                    'source': 'openshift-extended-test/build-log.txt (first test)',
+                },
+            ],
+            {},
+            oet_build_log_first_test=oet,
+        )
+        self.assertEqual(rc['confidence'], 'low')
+        self.assertFalse(rc.get('kata_worker_context_verified'))
 
 
 if __name__ == "__main__":

--- a/scripts/prowjob-analyzer/tests/test_failure_analyzer.py
+++ b/scripts/prowjob-analyzer/tests/test_failure_analyzer.py
@@ -1,0 +1,173 @@
+"""Unit tests for failure_analyzer helpers."""
+
+import unittest
+
+from lib.failure_analyzer import (
+    detect_kata_rpm_install_context,
+    extract_failed_case_ids_from_extended_build_log,
+    extract_kata_rpm_dependency_detail,
+)
+
+
+class TestExtractFailedCaseIdsFromExtendedBuildLog(unittest.TestCase):
+    def test_empty_returns_empty_list(self) -> None:
+        self.assertEqual(extract_failed_case_ids_from_extended_build_log(""), [])
+
+    def test_collects_ids_on_failure_hint_lines(self) -> None:
+        log = """\
+• Failure [sig-foo] test -C12345- something [Serial]
+panic: boom for case -C67890- extra
+"""
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C12345", "C67890"],
+        )
+
+    def test_skips_lines_without_failure_context(self) -> None:
+        log = """\
+[sig-bar] happy path -C11111- passed
+timeout: unrelated
+"""
+        self.assertEqual(extract_failed_case_ids_from_extended_build_log(log), [])
+
+    def test_deduplicates_preserving_order(self) -> None:
+        log = """\
+error: failed test -C42424- and -C42424- again
+failure: another -C77777-
+"""
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C42424", "C77777"],
+        )
+
+    def test_tail_fallback_when_no_primary_hits(self) -> None:
+        # ``abort`` matches tail_fail but not failure_hint (which uses ``aborted``), so
+        # IDs on this line are only picked up in the tail scan when the first pass
+        # found nothing.
+        log = """\
+[sig] quiet line with -C00001- only
+abort: cleanup for -C99999- done
+"""
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C99999"],
+        )
+
+    def test_summarizing_failures_line(self) -> None:
+        log = "Summarizing 3 Failure: [sig] case -C50001- and -C50002- more text\n"
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C50001", "C50002"],
+        )
+
+    def test_fail_bracket_tag(self) -> None:
+        log = "[Fail] [sig-foo] Kata test -C88888- description [Serial]\n"
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C88888"],
+        )
+
+    def test_primary_hits_prevent_tail_scan(self) -> None:
+        # Tail fallback runs only when the first loop finds no IDs; IDs from later
+        # ``abort`` lines must not be merged in once something matched earlier.
+        log = """\
+error: failed -C11111- first
+abort: later -C99999- ignored for tail because primary already had hits
+"""
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C11111"],
+        )
+
+    def test_oom_killed_hint(self) -> None:
+        log = "OOMKilled pod for test -C30303- after timeout\n"
+        self.assertEqual(
+            extract_failed_case_ids_from_extended_build_log(log),
+            ["C30303"],
+        )
+
+
+def _kata_rpm_install_log_snippet() -> str:
+    """>=80 chars, satisfies oc debug worker + kata rpm + failed dependencies."""
+    return (
+        "oc debug node/ci-op-xyz-worker-eastus1-abcd -n openshift-machine-api "
+        + "x" * 20
+        + "\n"
+        "Installing kata-containers.rpm on worker\n"
+        "error: Failed dependencies:\n"
+        "  libfoo is needed by kata-containers\n"
+    )
+
+
+class TestDetectKataRpmInstallContext(unittest.TestCase):
+    def test_detects_typical_failure(self) -> None:
+        self.assertTrue(detect_kata_rpm_install_context(_kata_rpm_install_log_snippet()))
+
+    def test_false_when_text_too_short(self) -> None:
+        self.assertFalse(
+            detect_kata_rpm_install_context(
+                "oc debug node/w-worker-1\nkata-containers.rpm\nFailed dependencies\n"
+            )
+        )
+
+    def test_false_without_debug_node_worker(self) -> None:
+        text = _kata_rpm_install_log_snippet().replace("worker-eastus1", "master-0")
+        self.assertFalse(detect_kata_rpm_install_context(text))
+
+    def test_false_without_kata_rpm_marker(self) -> None:
+        text = _kata_rpm_install_log_snippet().replace("kata-containers.rpm", "other.rpm")
+        self.assertFalse(detect_kata_rpm_install_context(text))
+
+    def test_false_without_dependency_error(self) -> None:
+        text = _kata_rpm_install_log_snippet()
+        text = text.replace("Failed dependencies", "Something else")
+        text = text.replace("needed by kata-containers", "needed by other")
+        self.assertFalse(detect_kata_rpm_install_context(text))
+
+    def test_accepts_rpm_uvh_kata_form(self) -> None:
+        text = _kata_rpm_install_log_snippet().replace(
+            "Installing kata-containers.rpm on worker",
+            "rpm -Uvh /tmp/foo-kata-1.rpm",
+        )
+        self.assertTrue(detect_kata_rpm_install_context(text))
+
+
+class TestExtractKataRpmDependencyDetail(unittest.TestCase):
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(extract_kata_rpm_dependency_detail(""))
+
+    def test_prefers_is_needed_by_line(self) -> None:
+        log = """\
+error: Failed dependencies:
+  some-lib is needed by kata-containers
+"""
+        self.assertEqual(
+            extract_kata_rpm_dependency_detail(log),
+            "some-lib is needed by kata-containers",
+        )
+
+    def test_first_needed_by_wins(self) -> None:
+        log = """\
+  first-dep is needed by kata-containers
+  second-dep is needed by kata-containers
+"""
+        self.assertEqual(
+            extract_kata_rpm_dependency_detail(log),
+            "first-dep is needed by kata-containers",
+        )
+
+    def test_failed_dependencies_header_when_no_needed_by_line(self) -> None:
+        log = "prefix\nerror: Failed dependencies:\nmore lines\n"
+        self.assertEqual(
+            extract_kata_rpm_dependency_detail(log),
+            "error: Failed dependencies:",
+        )
+
+    def test_returns_none_when_no_match(self) -> None:
+        self.assertIsNone(
+            extract_kata_rpm_dependency_detail("only unrelated log lines\n"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/prowjob-analyzer/tests/test_fetcher.py
+++ b/scripts/prowjob-analyzer/tests/test_fetcher.py
@@ -1,0 +1,187 @@
+"""Unit tests for fetcher helpers."""
+
+import unittest
+
+from lib.fetcher import (
+    go_duration_to_seconds,
+    parse_build_log_duration_fallback,
+    parse_ginkgo_failed_durations_max,
+    parse_test_step_duration_from_build_log,
+    summarize_openshift_extended_test_build_log,
+)
+
+
+class TestGoDurationToSeconds(unittest.TestCase):
+    def test_empty_or_whitespace_returns_none(self) -> None:
+        self.assertIsNone(go_duration_to_seconds(""))
+        self.assertIsNone(go_duration_to_seconds("   "))
+
+    def test_hours_minutes_seconds(self) -> None:
+        self.assertEqual(go_duration_to_seconds("1h"), 3600)
+        self.assertEqual(go_duration_to_seconds("30m"), 30 * 60)
+        self.assertEqual(go_duration_to_seconds("45s"), 45)
+        self.assertEqual(go_duration_to_seconds("1h30m5s"), 3600 + 30 * 60 + 5)
+
+    def test_fractional_components(self) -> None:
+        self.assertEqual(go_duration_to_seconds("1.5h"), int(round(1.5 * 3600)))
+        self.assertEqual(go_duration_to_seconds("2m30.5s"), int(round(2 * 60 + 30.5)))
+
+    def test_milliseconds_not_minutes(self) -> None:
+        # "813ms" must not be parsed as 813 minutes; ms is stripped first.
+        self.assertEqual(go_duration_to_seconds("813ms"), int(round(0.813)))
+
+    def test_milliseconds_sum(self) -> None:
+        self.assertEqual(
+            go_duration_to_seconds("500ms300ms"),
+            int(round(0.8)),
+        )
+
+    def test_zero_or_negative_total_returns_none(self) -> None:
+        self.assertIsNone(go_duration_to_seconds("0s"))
+        self.assertIsNone(go_duration_to_seconds("0h"))
+
+    def test_combined_ginkgo_style(self) -> None:
+        self.assertEqual(go_duration_to_seconds("3h1m37s"), 3 * 3600 + 60 + 37)
+
+
+class TestSummarizeOpenshiftExtendedTestBuildLog(unittest.TestCase):
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(summarize_openshift_extended_test_build_log(""))
+
+    def test_error_summary_last_match(self) -> None:
+        log = """\
+line1
+error: 1 fail, 10 pass, 2 skip
+ERROR: 3 fail, 5 pass, 0 skip
+"""
+        self.assertEqual(
+            summarize_openshift_extended_test_build_log(log),
+            "3 fail, 5 pass, 0 skip",
+        )
+
+    def test_started_tuple_when_no_error_line(self) -> None:
+        log = """\
+started: (0/1/100)
+started: (2/40/200)
+"""
+        self.assertEqual(
+            summarize_openshift_extended_test_build_log(log),
+            "(2/40/200)",
+        )
+
+    def test_error_takes_precedence_over_started(self) -> None:
+        log = """\
+started: (9/9/9)
+error: 1 fail, 2 pass, 3 skip
+"""
+        self.assertEqual(
+            summarize_openshift_extended_test_build_log(log),
+            "1 fail, 2 pass, 3 skip",
+        )
+
+    def test_no_matching_lines_returns_none(self) -> None:
+        self.assertIsNone(
+            summarize_openshift_extended_test_build_log("just some build output\n"),
+        )
+
+
+class TestParseTestStepDurationFromBuildLog(unittest.TestCase):
+    """``error: X fail, Y pass, Z skip (DURATION)`` — last match, duration → seconds."""
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(parse_test_step_duration_from_build_log(""))
+
+    def test_requires_parenthesized_duration(self) -> None:
+        self.assertIsNone(
+            parse_test_step_duration_from_build_log(
+                "error: 1 fail, 2 pass, 3 skip\n",
+            )
+        )
+
+    def test_parses_duration_seconds(self) -> None:
+        log = "error: 0 fail, 1 pass, 0 skip (90s)\n"
+        self.assertEqual(parse_test_step_duration_from_build_log(log), 90)
+
+    def test_last_match_wins(self) -> None:
+        log = """\
+error: 1 fail, 0 pass, 0 skip (10m)
+ERROR: 0 fail, 5 pass, 0 skip (2h)
+"""
+        self.assertEqual(
+            parse_test_step_duration_from_build_log(log),
+            2 * 3600,
+        )
+
+    def test_zero_duration_returns_none(self) -> None:
+        log = "error: 1 fail, 0 pass, 0 skip (0s)\n"
+        self.assertIsNone(parse_test_step_duration_from_build_log(log))
+
+
+class TestParseGinkgoFailedDurationsMax(unittest.TestCase):
+    """``failed: (DURATION)`` at line start — longest positive duration in seconds."""
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(parse_ginkgo_failed_durations_max(""))
+
+    def test_no_failed_lines_returns_none(self) -> None:
+        self.assertIsNone(
+            parse_ginkgo_failed_durations_max("passed: (3h)\nerror: (1h)\n"),
+        )
+
+    def test_single_line(self) -> None:
+        log = "failed: (1h30m)\n"
+        self.assertEqual(parse_ginkgo_failed_durations_max(log), 3600 + 30 * 60)
+
+    def test_takes_maximum(self) -> None:
+        log = """\
+failed: (10m)
+  failed: (2h)
+failed: (30s)
+"""
+        self.assertEqual(parse_ginkgo_failed_durations_max(log), 2 * 3600)
+
+    def test_ignores_zero_duration(self) -> None:
+        log = "failed: (0s)\n"
+        self.assertIsNone(parse_ginkgo_failed_durations_max(log))
+
+    def test_line_must_start_with_failed(self) -> None:
+        log = "message failed: (5h)\n"
+        self.assertIsNone(parse_ginkgo_failed_durations_max(log))
+
+
+class TestParseBuildLogDurationFallback(unittest.TestCase):
+    """Parenthesized Go durations in log tail; skips Prow entrypoint noise lines."""
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(parse_build_log_duration_fallback(""))
+
+    def test_picks_max_parenthesized_duration(self) -> None:
+        log = """\
+phase complete (5m)
+wrapper (2h30m)
+"""
+        self.assertEqual(parse_build_log_duration_fallback(log), 2 * 3600 + 30 * 60)
+
+    def test_skips_prow_entrypoint_noise_line(self) -> None:
+        log = """\
+normal (30m)
+{"component": "entrypoint", "x": "y"} (999h)
+footer (1h)
+"""
+        self.assertEqual(parse_build_log_duration_fallback(log), 3600)
+
+    def test_skips_grace_period_line(self) -> None:
+        log = """\
+suite (40m)
+grace period 10m0s remaining (99h)
+tail (15m)
+"""
+        self.assertEqual(parse_build_log_duration_fallback(log), 40 * 60)
+
+    def test_ignores_non_duration_parens(self) -> None:
+        log = "counts (1/2/3) and (0s)\n"
+        self.assertIsNone(parse_build_log_duration_fallback(log))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/prowjob-analyzer/tests/test_fetcher.py
+++ b/scripts/prowjob-analyzer/tests/test_fetcher.py
@@ -1,9 +1,20 @@
 """Unit tests for fetcher helpers."""
 
+import os
+import shutil
+import tarfile
+import tempfile
 import unittest
+from unittest.mock import patch
 
 from lib.fetcher import (
+    clear_artifact_cache,
+    configure_artifact_source,
+    fetch_artifact,
+    gcs_uri_from_gcsweb_https,
+    get_step_directories,
     go_duration_to_seconds,
+    write_job_artifacts_tarball,
     parse_build_log_duration_fallback,
     parse_ginkgo_failed_durations_max,
     parse_test_step_duration_from_build_log,
@@ -181,6 +192,89 @@ tail (15m)
     def test_ignores_non_duration_parens(self) -> None:
         log = "counts (1/2/3) and (0s)\n"
         self.assertIsNone(parse_build_log_duration_fallback(log))
+
+
+class TestGcsUriFromGcsweb(unittest.TestCase):
+    def test_gcsweb_https_to_gs(self) -> None:
+        url = 'https://gcsweb.example/gcs/test-platform-results/logs/job-name/12345'
+        self.assertEqual(
+            gcs_uri_from_gcsweb_https(url),
+            'gs://test-platform-results/logs/job-name/12345',
+        )
+
+    def test_already_gs_uri(self) -> None:
+        self.assertEqual(
+            gcs_uri_from_gcsweb_https('gs://b/prefix'),
+            'gs://b/prefix',
+        )
+
+
+class TestArtifactCacheAndLocal(unittest.TestCase):
+    def tearDown(self) -> None:
+        configure_artifact_source(None)
+        clear_artifact_cache()
+
+    @patch('lib.fetcher._fetch_artifact_http')
+    def test_http_fetch_cached_second_call_skips_network(self, mock_http) -> None:
+        mock_http.return_value = b'{"ok": true}'
+        base = 'https://example.com/view/gs/bucket/logs/job/123'
+        fetch_artifact(base, 'prowjob.json')
+        fetch_artifact(base, 'prowjob.json')
+        self.assertEqual(mock_http.call_count, 1)
+
+    def test_local_directory_reads_file(self) -> None:
+        root = tempfile.mkdtemp()
+        try:
+            os.makedirs(os.path.join(root, 'artifacts', 'aws-ipi-peerpods', 'openshift-extended-test'))
+            with open(os.path.join(root, 'prowjob.json'), 'w', encoding='utf-8') as f:
+                f.write('{"status":{}}')
+            with open(
+                os.path.join(root, 'artifacts', 'aws-ipi-peerpods', 'openshift-extended-test', 'x.txt'),
+                'wb',
+            ) as f:
+                f.write(b'hello')
+            configure_artifact_source(root)
+            self.assertEqual(fetch_artifact('http://ignored', 'prowjob.json'), b'{"status":{}}')
+            self.assertEqual(
+                fetch_artifact('http://ignored', 'artifacts/aws-ipi-peerpods/openshift-extended-test/x.txt'),
+                b'hello',
+            )
+            steps = get_step_directories('http://ignored', 'aws-ipi-peerpods')
+            self.assertIn('openshift-extended-test', steps)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_tar_gz_extracts_and_reads(self) -> None:
+        root = tempfile.mkdtemp()
+        try:
+            inner = os.path.join(root, 'jobdir')
+            os.makedirs(inner)
+            pj = os.path.join(inner, 'prowjob.json')
+            with open(pj, 'w', encoding='utf-8') as f:
+                f.write('{}')
+            tar_path = os.path.join(root, 'a.tar.gz')
+            with tarfile.open(tar_path, 'w:gz') as tf:
+                tf.add(inner, arcname='jobdir')
+            configure_artifact_source(tar_path)
+            self.assertEqual(fetch_artifact('http://x', 'prowjob.json'), b'{}')
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_write_job_artifacts_tarball_roundtrip(self) -> None:
+        root = tempfile.mkdtemp()
+        try:
+            job = os.path.join(root, '12345')
+            os.makedirs(job)
+            with open(os.path.join(job, 'prowjob.json'), 'wb') as f:
+                f.write(b'{}')
+            out = os.path.join(root, '12345.tar.gz')
+            write_job_artifacts_tarball(job, out)
+            self.assertTrue(os.path.isfile(out))
+            with tarfile.open(out, 'r:gz') as tf:
+                names = tf.getnames()
+            self.assertTrue(any(n.endswith('prowjob.json') for n in names))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
dig.py does a static pass over the prowjob URL to determine if a HUMAN needs to analyze it further

If the openshift-extended-test step is SUCCESS, no analysis of the test results needs to be done.
If a prow step after the test step fails, the output show flag it as a prow error, but not necessarily a test FAILURE

If a prow step before the test step fails, the test step is a FAILURE

Some of the pre steps failure can be detected and output so further analysis is not need.  ex: azure quota, rpm failed to upload

Usually dig.py is used to create a csv to import into  a spreadsheet.  Many runs can be added at one time and the spreadsheet can be looked at to decide analysis.  A human will correct the spreadsheet after analysis.

This PR is to add to the root cause and other output.  This should reduce analysis time.  Most of the code changes were done with claude and cursor

-  Test success is primarily determined by the openshift-extended-test results in prow
   - dig.py was waiting for the post steps to finish
   - dig.py was not always using the test-results.yaml of finished.json artifacts as the primary way to find success
   - A human had to keep correcting output
- If a post test fails, don't change the test result.  Flag it in the output
- Output the failed test case numbers, especially in the csv
- When the test fails, show # failed/passed/skipped.  If the test was interrupted find the last test that was started which will have (# failed/#started/# total tests) and show the test was timed out
- Add the duration of the test step to the output
  -  add a column to the csv output for this
  - this will be in the test step or in the time of the steps
- remove blank lines in the csv output
  - if URLS is a list of the prowjob URLs this will make import easier:
 ```bash
echo '' > /tmp/x
for URL in $URLS
do
  echo $URL; 
  scripts/prowjob-analyzer/dig.py $URL --csv --no-header --no-wait >> /tmp/x
done
grep -v '^$' /tmp/x > ~/Downloads/x.csv
```
- Add rpm install failure to the RCA so analysis is not needed
