### PR TITLE
tests/osc-test-fbc-integration: continue pipeline on error

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -127,7 +127,7 @@ spec:
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       # A fail on sanity should stop and fail the pipeline
       onError: stopAndFail
-      timeout: "4h"
+      timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_sanity)"
           operator: in
@@ -160,7 +160,7 @@ spec:
     - name: prowjob-ocp418
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue
-      timeout: "4h"
+      timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp418)"
           operator: in
@@ -198,7 +198,7 @@ spec:
     - name: prowjob-ocp419
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue
-      timeout: "4h"
+      timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp419)"
           operator: in
@@ -236,7 +236,7 @@ spec:
     - name: prowjob-ocp420
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue
-      timeout: "4h"
+      timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp420)"
           operator: in
@@ -271,7 +271,7 @@ spec:
     - name: prowjob-ocp421
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue
-      timeout: "4h"
+      timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp421)"
           operator: in

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -125,6 +125,8 @@ spec:
     # Choose the kata workload test and newest supported OCP version.
     - name: prowjob-sanity
       displayName: "Running prow job $(params.PROWJOB_NAME)"
+      # A fail on sanity should stop and fail the pipeline
+      onError: stopAndFail
       timeout: "4h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_sanity)"
@@ -157,6 +159,7 @@ spec:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-aws-ipi-peerpods
     - name: prowjob-ocp418
       displayName: "Running prow job $(params.PROWJOB_NAME)"
+      onError: continue
       timeout: "4h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp418)"
@@ -194,6 +197,7 @@ spec:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate418-aws-ipi-peerpods
     - name: prowjob-ocp419
       displayName: "Running prow job $(params.PROWJOB_NAME)"
+      onError: continue
       timeout: "4h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp419)"
@@ -231,6 +235,7 @@ spec:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate419-aws-ipi-peerpods
     - name: prowjob-ocp420
       displayName: "Running prow job $(params.PROWJOB_NAME)"
+      onError: continue
       timeout: "4h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp420)"
@@ -265,6 +270,7 @@ spec:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-peerpods
     - name: prowjob-ocp421
       displayName: "Running prow job $(params.PROWJOB_NAME)"
+      onError: continue
       timeout: "4h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_ocp421)"
@@ -299,3 +305,55 @@ spec:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-azure-ipi-kata
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-azure-ipi-peerpods
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate421-aws-ipi-peerpods
+  finally:
+    - name: aggregate-status
+      params:
+        - name: SANITY_STATUS
+          value: $(tasks.prowjob-sanity.status)
+        - name: OCP418_STATUS
+          value: $(tasks.prowjob-ocp418.status)
+        - name: OCP419_STATUS
+          value: $(tasks.prowjob-ocp419.status)
+        - name: OCP420_STATUS
+          value: $(tasks.prowjob-ocp420.status)
+        - name: OCP421_STATUS
+          value: $(tasks.prowjob-ocp421.status)
+      taskSpec:
+        params:
+          - name: SANITY_STATUS
+          - name: OCP418_STATUS
+          - name: OCP419_STATUS
+          - name: OCP420_STATUS
+          - name: OCP421_STATUS
+        steps:
+          - name: check-tasks-statuses
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              #!/bin/bash
+              set -e
+
+              failed_count=0
+              if [ "$(params.SANITY_STATUS)" == "Failed" ]; then
+                echo "Some sanity jobs failed"
+                failed_count=$((failed_count+1))
+              fi
+              if [ "$(params.OCP418_STATUS)" == "Failed" ]; then
+                echo "Some OCP 4.18 jobs failed"
+                failed_count=$((failed_count+1))
+              fi
+              if [ "$(params.OCP419_STATUS)" == "Failed" ]; then
+                echo "Some OCP 4.19 jobs failed"
+                failed_count=$((failed_count+1))
+              fi
+              if [ "$(params.OCP420_STATUS)" == "Failed" ]; then
+                echo "Some OCP 4.20 jobs failed"
+                failed_count=$((failed_count+1))
+              fi
+              if [ "$(params.OCP421_STATUS)" == "Failed" ]; then
+                echo "Some OCP 4.21 jobs failed"
+                failed_count=$((failed_count+1))
+              fi
+
+              if [ ${failed_count} -gt 0 ]; then
+                exit 1
+              fi

--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -126,7 +126,9 @@ spec:
     - name: prowjob-sanity
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       # A fail on sanity should stop and fail the pipeline
-      onError: stopAndFail
+      #onError: stopAndFail
+      # TODO: revert to stopAndFail when AWS deprovision is fixed
+      onError: continue
       timeout: "8h"
       when:
         - input: "$(tasks.determine-prowjobs.results.run_sanity)"


### PR DESCRIPTION
The konflux pipelines are fail-fast (e.g. abort on first error) by default. However, in our integration tests pipeline we want to run all the prow jobs. Well, expect for the sanity tests jobs, because these are meant to prevent prow jobs to run unnecessarily in case of infraestructure problems.

So on this PR:

* run pipeline tasks with `onError: continue` parameter to keep the pipeline alive on any error. In practice, tekton mark the task failed but ignore it and continue on.
* the last task run on `finally` and should fail the entire pipeline status if any task failed
  *  I tried to make at last task to consume and report an aggregate of the results of the previous tasks, however, if any of these tasks are skipped then the finally task is simple skipped too. In other words, it is not guaranteed the finally task to run if it it depends on the results of other tasks

