### PR TITLE
caa: fix idempotency and missing configmap event handling

### DIFF
--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -43,7 +43,7 @@ func MountProgagationRef(mode corev1.MountPropagationMode) *corev1.MountPropagat
 	return &mode
 }
 
-func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA() *appsv1.DaemonSet {
+func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
 	var (
 		runPrivileged                = true
 		runAsUser              int64 = 0
@@ -62,129 +62,126 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA() *appsv1.DaemonS
 		r.Log.Info("RELATED_IMAGE_CAA env var is unset or empty, cloud-api-adaptor pods will not run")
 	}
 
-	return &appsv1.DaemonSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "DaemonSet",
+	ds.TypeMeta = metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "DaemonSet",
+	}
+
+	ds.Spec = appsv1.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: dsLabelSelectors,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      caaDsName,
-			Namespace: os.Getenv("PEERPODS_NAMESPACE"),
-		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: dsLabelSelectors,
-			},
-			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
-				Type: "RollingUpdate",
-				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 1,
-					},
+		UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+			Type: "RollingUpdate",
+			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
 			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: dsLabelSelectors,
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: "default",
-					NodeSelector:       nodeSelector,
-					HostNetwork:        true,
-					Containers: []corev1.Container{
-						{
-							Name:            "caa-pod",
-							Image:           imageString,
-							ImagePullPolicy: "Always",
-							SecurityContext: &corev1.SecurityContext{
-								// TODO - do we really need to run as root?
-								Privileged: &runPrivileged,
-								RunAsUser:  &runAsUser,
-							},
-							Command: []string{"/usr/local/bin/entrypoint.sh"},
-							Env: []corev1.EnvVar{
-								{
-									Name: "NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: dsLabelSelectors,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "default",
+				NodeSelector:       nodeSelector,
+				HostNetwork:        true,
+				Containers: []corev1.Container{
+					{
+						Name:            "caa-pod",
+						Image:           imageString,
+						ImagePullPolicy: "Always",
+						SecurityContext: &corev1.SecurityContext{
+							// TODO - do we really need to run as root?
+							Privileged: &runPrivileged,
+							RunAsUser:  &runAsUser,
+						},
+						Command: []string{"/usr/local/bin/entrypoint.sh"},
+						Env: []corev1.EnvVar{
+							{
+								Name: "NODE_NAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "spec.nodeName",
 									},
 								},
 							},
-							EnvFrom: []corev1.EnvFromSource{
-								{
-									SecretRef: &corev1.SecretEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "peer-pods-secret",
-										},
-									},
-								},
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "peer-pods-cm",
-										},
+						},
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								SecretRef: &corev1.SecretEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "peer-pods-secret",
 									},
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "auth-json-volume",
-									MountPath: "/root/containers/",
-									ReadOnly:  true,
-								}, {
-									Name:      "ssh",
-									MountPath: "/root/.ssh",
-									ReadOnly:  true,
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "peer-pods-cm",
+									},
 								},
-								{
-									MountPath: "/run/peerpod",
-									Name:      "pods-dir",
-								},
-								{
-									MountPath:        "/run/netns",
-									MountPropagation: MountProgagationRef(corev1.MountPropagationHostToContainer),
-									Name:             "netns",
-								},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "auth-json-volume",
+								MountPath: "/root/containers/",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "ssh",
+								MountPath: "/root/.ssh",
+								ReadOnly:  true,
+							},
+							{
+								MountPath: "/run/peerpod",
+								Name:      "pods-dir",
+							},
+							{
+								MountPath:        "/run/netns",
+								MountPropagation: MountProgagationRef(corev1.MountPropagationHostToContainer),
+								Name:             "netns",
 							},
 						},
 					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "auth-json-volume",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName:  "auth-json-secret",
-									DefaultMode: &defaultMode,
-									Optional:    &authJsonSecretOptional,
-								},
-							},
-						}, {
-							Name: "ssh",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName:  "ssh-key-secret",
-									DefaultMode: &defaultMode,
-									Optional:    &sshSecretOptional,
-								},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "auth-json-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  "auth-json-secret",
+								DefaultMode: &defaultMode,
+								Optional:    &authJsonSecretOptional,
 							},
 						},
-						{
-							Name: "pods-dir",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/run/peerpod",
-								},
+					},
+					{
+						Name: "ssh",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  "ssh-key-secret",
+								DefaultMode: &defaultMode,
+								Optional:    &sshSecretOptional,
 							},
 						},
-						{
-							Name: "netns",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/run/netns",
-								},
+					},
+					{
+						Name: "pods-dir",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/run/peerpod",
+							},
+						},
+					},
+					{
+						Name: "netns",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/run/netns",
 							},
 						},
 					},
@@ -192,6 +189,8 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA() *appsv1.DaemonS
 			},
 		},
 	}
+
+	return ds
 }
 
 // Handles provider specific parts of the CAA Ds
@@ -282,8 +281,15 @@ func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.Daem
 
 // Create the PeerPodConfig CRDs and misc configs required for peer-pods
 func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caaDsName,
+			Namespace: os.Getenv("PEERPODS_NAMESPACE"),
+		},
+	}
+
 	// Create the CAA daemonset
-	ds := r.processDaemonsetForCAA()
+	ds = r.processDaemonsetForCAA(ds)
 	if err := r.processProviderConfigCAA(ds); err != nil {
 		r.Log.Error(err, "Failed setting cloud provider specific configuration for cloud-api-adaptor DS")
 		return err
@@ -336,7 +342,12 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 }
 
 func (r *KataConfigOpenShiftReconciler) disablePeerPodsMiscConfigs() error {
-	ds := r.processDaemonsetForCAA()
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caaDsName,
+			Namespace: os.Getenv("PEERPODS_NAMESPACE"),
+		},
+	}
 	err := r.Client.Delete(context.TODO(), ds)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -288,28 +288,26 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 		},
 	}
 
-	// Create the CAA daemonset
-	ds = r.processDaemonsetForCAA(ds)
-	if err := r.processProviderConfigCAA(ds); err != nil {
-		r.Log.Error(err, "Failed setting cloud provider specific configuration for cloud-api-adaptor DS")
-		return err
-	}
-	r.Log.Info("Got CAA ds manifest", "ds", ds)
-
-	if err := controllerutil.SetControllerReference(r.kataConfig, ds, r.Scheme); err != nil {
-		r.Log.Error(err, "Failed setting ControllerReference for cloud-api-adaptor DS")
-		return err
-	}
-
-	err := r.Client.Update(context.TODO(), ds)
-	if err != nil && k8serrors.IsNotFound(err) {
-		r.Log.Error(err, "cloud-api-adaptor daemonset doesn't exist. Creating")
-		err = r.Client.Create(context.TODO(), ds)
-		if err != nil {
-			r.Log.Error(err, "failed to create cloud-api-adaptor daemonset")
+	result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, ds, func() error {
+		// Create the CAA daemonset
+		ds = r.processDaemonsetForCAA(ds)
+		if err := r.processProviderConfigCAA(ds); err != nil {
+			r.Log.Error(err, "Failed setting cloud provider specific configuration for cloud-api-adaptor DS")
 			return err
 		}
+		r.Log.Info("Got CAA ds manifest", "ds", ds)
+
+		if err := controllerutil.SetControllerReference(r.kataConfig, ds, r.Scheme); err != nil {
+			r.Log.Error(err, "Failed setting ControllerReference for cloud-api-adaptor DS")
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		r.Log.Error(err, "failed to reconcile cloud-api-adaptor daemonset")
+		return err
 	}
+	r.Log.Info("Reconciled CAA daemonset", "result", result)
 
 	// Create the mutating webhook deployment
 	err = r.createMutatingWebhookDeployment()

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -43,7 +43,7 @@ func MountProgagationRef(mode corev1.MountPropagationMode) *corev1.MountPropagat
 	return &mode
 }
 
-func (r *KataConfigOpenShiftReconciler) configureCAA(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
+func (r *KataConfigOpenShiftReconciler) configureCAA(ds *appsv1.DaemonSet, cmVersion string) *appsv1.DaemonSet {
 	var (
 		runPrivileged                = true
 		runAsUser              int64 = 0
@@ -51,6 +51,7 @@ func (r *KataConfigOpenShiftReconciler) configureCAA(ds *appsv1.DaemonSet) *apps
 		sshSecretOptional            = true
 		authJsonSecretOptional       = true
 		nodeSelector                 = r.getNodeSelectorAsMap()
+		peerPodCMVersionKey          = fmt.Sprintf("%s/version", peerpodsCMName)
 	)
 
 	dsLabelSelectors := map[string]string{
@@ -83,6 +84,9 @@ func (r *KataConfigOpenShiftReconciler) configureCAA(ds *appsv1.DaemonSet) *apps
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: dsLabelSelectors,
+				Annotations: map[string]string{
+					peerPodCMVersionKey: cmVersion,
+				},
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: "default",
@@ -288,11 +292,24 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 		},
 	}
 
+	cmVersion, found, err := r.getConfigMapVersion(peerpodsCMName, OperatorNamespace)
+	if err != nil {
+		r.Log.Error(err, "Failed getting configmap resource version", "name", peerpodsCMName)
+		return err
+	}
+
+	if !found {
+		err = fmt.Errorf("peer pod configmap %s missing", peerpodsCMName)
+		r.Log.Error(err, "Failed to reload CAA")
+		return err
+
+	}
+
 	result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, ds, func() error {
 		var err error
 
 		// Create the CAA daemonset
-		ds = r.configureCAA(ds)
+		ds = r.configureCAA(ds, cmVersion)
 
 		ds, err = r.configureCAAProvider(ds)
 		if err != nil {

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -43,7 +43,7 @@ func MountProgagationRef(mode corev1.MountPropagationMode) *corev1.MountPropagat
 	return &mode
 }
 
-func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
+func (r *KataConfigOpenShiftReconciler) configureCAA(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
 	var (
 		runPrivileged                = true
 		runAsUser              int64 = 0
@@ -195,11 +195,11 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCAA(ds *appsv1.Daemon
 
 // Handles provider specific parts of the CAA Ds
 // Modifies the DaemonSet if needed
-func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.DaemonSet) error {
+func (r *KataConfigOpenShiftReconciler) configureCAAProvider(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	r.Log.Info("Getting cloud provider from infra")
 	provider, err := getCloudProviderFromInfra(r.Client)
 	if err != nil {
-		return fmt.Errorf("failed to get cloud provider from infra: %w", err)
+		return nil, fmt.Errorf("failed to get cloud provider from infra: %w", err)
 	}
 
 	switch provider {
@@ -235,7 +235,7 @@ func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.Daem
 			}
 		}
 
-		return nil
+		return ds, nil
 	case AzureProvider:
 		// Only add bound-sa-token volume for Azure federated identity if using STS flow
 		// Check for all STS environment variables (set during OLM installation)
@@ -273,9 +273,9 @@ func (r *KataConfigOpenShiftReconciler) processProviderConfigCAA(ds *appsv1.Daem
 			}
 		}
 
-		return nil
+		return ds, nil
 	default:
-		return nil
+		return ds, nil
 	}
 }
 
@@ -289,9 +289,13 @@ func (r *KataConfigOpenShiftReconciler) enablePeerPodsMiscConfigs() error {
 	}
 
 	result, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, ds, func() error {
+		var err error
+
 		// Create the CAA daemonset
-		ds = r.processDaemonsetForCAA(ds)
-		if err := r.processProviderConfigCAA(ds); err != nil {
+		ds = r.configureCAA(ds)
+
+		ds, err = r.configureCAAProvider(ds)
+		if err != nil {
 			r.Log.Error(err, "Failed setting cloud provider specific configuration for cloud-api-adaptor DS")
 			return err
 		}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -186,7 +186,9 @@ func getCloudProviderFromInfra(c client.Client) (string, error) {
 
 // Method to check if the configMap is relevant for the operator
 func isConfigMapRelevant(configMapName string) bool {
-	return configMapName == FeatureGatesCM || configMapName == KataAddonConfigMapName
+	return configMapName == FeatureGatesCM ||
+		configMapName == KataAddonConfigMapName ||
+		configMapName == peerpodsCMName
 }
 
 // Method to get cluster id from ClusterVersion object
@@ -357,4 +359,20 @@ func (r *KataConfigOpenShiftReconciler) createAuthJsonSecret() error {
 	}
 
 	return err
+}
+
+func (r *KataConfigOpenShiftReconciler) getConfigMapVersion(name, namespace string) (string, bool, error) {
+	cm := &corev1.ConfigMap{}
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, cm)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", false, nil // ConfigMap doesn't exist yet
+		}
+		return "", false, err
+	}
+
+	return cm.GetResourceVersion(), true, nil
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
The operator does not trigger a CAA DaemonSet rollout when `peer-pods-cm` ConfigMap is updated. When an end user modifies configuration values (e.g., `PEERPODS_LIMIT_PER_NODE`), the CAA pods continue running with stale configuration. Users are forced to manually trigger a rollout, which is disruptive as it can orphan active peer-pod VMs (as described in PR #1917).

  Additionally, the previous implementation used a plain Update() call which could cause unintended DaemonSet recreation on every reconciliation, leading to peer-pod VMs losing connectivity and becoming unmanageable.

**- What I did**
1. Updated the ConfigMap event handler to watch `peer-pods-cm` for changes
2. Added a ConfigMap hash annotation to the CAA DaemonSet Pod template to trigger rolling updates when the ConfigMap changes
3. Refactored CAA DaemonSet creation to use `CreateOrUpdate()` for idempotent reconciliation


**- How to verify it**
1. Deploy the operator and create a KataConfig with peer-pods enabled
2. Verify CAA DaemonSet is running
3. Update `peer-pods-cm` ConfigMap (e.g., change `PEERPODS_LIMIT_PER_NODE`)
4. Observe that the CAA DaemonSet pods are rolled out automatically with the new configuration
5. Verify that restarting the operator does NOT cause unnecessary CAA pod rollouts


**- Description for the changelog**
Fixed automatic CAA DaemonSet rollout when peer-pods-cm ConfigMap is updated. Previously, users had to manually restart CAA pods after modifying peer-pods configuration. The operator now watches peer-pods-cm and triggers a rolling update using a ConfigMap hash annotation, ensuring configuration changes are applied without manual intervention.


Fixes: rhjira#[KATA-4899](https://redhat.atlassian.net/browse/KATA-4899)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced DaemonSet configuration management with improved version tracking via ConfigMap annotations.
  * Strengthened error handling and validation for missing configuration dependencies.
  * Optimized DaemonSet reconciliation process for more reliable configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->