### PR TITLE
runtimeclass: remove GPU runtime classes on s390x

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -2345,16 +2346,21 @@ func (r *KataConfigOpenShiftReconciler) postKataInstallation() (*ctrl.Result, er
 	}
 
 	// creating kata-nvidia-gpu runtime class if node labels exist
-	err = r.createRuntimeClass(
-		kataNvidiaGPURuntimeClassName,
-		kataNvidiaGPURuntimeClassCpuOverhead,
-		kataNvidiaGPURuntimeClassMemOverhead,
-		"",                            /* nil extended resource overhead */
-		kataNvidiaGPURuntimeClassName, /* reused for handler */
-		nvidiaGPUNodeLabels)
+	// Skip GPU runtime classes on s390x architecture as NVIDIA GPUs are not supported
+	if goruntime.GOARCH != "s390x" {
+		err = r.createRuntimeClass(
+			kataNvidiaGPURuntimeClassName,
+			kataNvidiaGPURuntimeClassCpuOverhead,
+			kataNvidiaGPURuntimeClassMemOverhead,
+			"",                            /* nil extended resource overhead */
+			kataNvidiaGPURuntimeClassName, /* reused for handler */
+			nvidiaGPUNodeLabels)
 
-	if err != nil {
-		return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		if err != nil {
+			return &ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		}
+	} else {
+		r.Log.Info("Skipping kata-nvidia-gpu runtime class creation on s390x architecture")
 	}
 
 	r.Log.Info("create Scc")


### PR DESCRIPTION
Skip creation of kata-nvidia-gpu runtime class on s390x (IBM Z) systems where NVIDIA GPU support is not available. Uses runtime.GOARCH for architecture detection, consistent with existing checks in the codebase.

The kata-cc-nvidia-gpu runtime class is already filtered on s390x through existing TEE type logic (only created for Intel TDX or AMD SNP, never for IBM SE).

Fixes: https://redhat.atlassian.net/browse/KATA-4801

