### PR TITLE
qgs: Add Unix domain socket

### DIFF
--- a/scripts/install-helpers/baremetal-coco/install.sh
+++ b/scripts/install-helpers/baremetal-coco/install.sh
@@ -466,6 +466,12 @@ function set_kernel_params_for_kata_agent() {
     kata_override="[hypervisor.qemu]
 kernel_params=\"$kernel_params\""
 
+    if [ $tee_type = "tdx" ]; then
+      echo "Adding TDX quote generation service socket port 0"
+      kata_override="$kata_override
+tdx_quote_generation_service_socket_port=0"
+    fi
+
     # Create base64 encoding of the drop-in to be used as source
     source=$(echo "$kata_override" | base64 -w0) || return 1
 

--- a/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
+++ b/scripts/install-helpers/baremetal-coco/intel-dcap/qgs.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tdx-qgs-sa
+  namespace: intel-dcap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: use-privileged-scc
+  namespace: intel-dcap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: tdx-qgs-sa
+    namespace: intel-dcap
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -19,6 +39,7 @@ spec:
         intel.feature.node.kubernetes.io/tdx: 'true'
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: tdx-qgs-sa
       initContainers:
         - name: platform-registration
           image: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:308d66da94d3116cc16530a4a2cd60a995458f331e1cb3487c6ea3fdae60545b
@@ -48,7 +69,7 @@ spec:
         - name: tdx-qgs
           image: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:308d66da94d3116cc16530a4a2cd60a995458f331e1cb3487c6ea3fdae60545b
           args:
-            - -p=4050
+            - -p=0
             - -n=4
           securityContext:
             readOnlyRootFilesystem: true
@@ -72,6 +93,8 @@ spec:
             - name: qcnl-config
               mountPath: /run/dcap/
               readOnly: true
+            - name: qgs-socket
+              mountPath: /var/run/tdx-qgs
       volumes:
         - name: dcap-qcnl-cache
           emptyDir:
@@ -85,3 +108,7 @@ spec:
         - name: efivars
           hostPath:
             path: /sys/firmware/efi/efivars/
+        - name: qgs-socket
+          hostPath:
+            path: /var/run/tdx-qgs
+            type: DirectoryOrCreate


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

Changed vSOCK port 4050 to unix domain socket (port 0) for QGS.

**- What I did**

Altered QGS yaml to use unix domain socket. 

**- How to verify it**

Deploy TDX with QGS (kata version must be greater than 3.22.0) 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed vSOCK port 4050 to unix domain socket (port 0) for QGS.