### PR TITLE
runtimeclass: skip kata-cc-nvidia-gpu creation for IBM SE

### DIFF
--- a/controllers/confidential_handler.go
+++ b/controllers/confidential_handler.go
@@ -320,17 +320,19 @@ func (r *KataConfigOpenShiftReconciler) handleConfidentialBaremetal(state Featur
 			maps.Copy(additionalLabels, amdSNPNodeLabels)
 		}
 
-		// Create kata-cc-nvidia-gpu runtime class restricted to the detected GPU TEE subset
-		err = r.createRuntimeClass(
-			kataNvidiaGPUCCRuntimeClassName,
-			kataNvidiaGPUCCRuntimeClassCpuOverhead,
-			kataNvidiaGPUCCRuntimeClassMemOverhead,
-			kataCCRuntimeClassExtResOverhead,
-			handler,
-			additionalLabels)
-		if err != nil {
-			r.Log.Error(err, "aborting, failed to create runtimeclass")
-			return err
+		// Create kata-cc-nvidia-gpu runtime class only for Intel TDX and AMD SNP
+		if hasIntelTDX || hasAmdSNP {
+			err = r.createRuntimeClass(
+				kataNvidiaGPUCCRuntimeClassName,
+				kataNvidiaGPUCCRuntimeClassCpuOverhead,
+				kataNvidiaGPUCCRuntimeClassMemOverhead,
+				kataCCRuntimeClassExtResOverhead,
+				handler,
+				additionalLabels)
+			if err != nil {
+				r.Log.Error(err, "aborting, failed to create runtimeclass")
+				return err
+			}
 		}
 
 	} else {


### PR DESCRIPTION
Skip creation of kata-cc-nvidia-gpu runtime class for IBM SE (s390x) systems where NVIDIA GPU confidential computing is not supported.

This change adds an explicit conditional check (hasIntelTDX || hasAmdSNP) around the GPU runtime class creation to ensure it's never created on IBM SE deployments, even if the logic changes in the future.

Fixes: https://redhat.atlassian.net/browse/KATA-4801

Follow up of https://github.com/openshift/sandboxed-containers-operator/pull/1961