### PR TITLE
claude: narrow osc-user-guide skill trigger to explicit doc requests

### DIFF
--- a/.claude/skills/osc-user-guide/SKILL.md
+++ b/.claude/skills/osc-user-guide/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: osc-user-guide
-description: Provides comprehensive guidance on OpenShift Sandboxed Containers (OSC) by reading official Red Hat documentation. Use when questions involve OSC installation, KataConfig configuration, node setup, bare-metal or cloud deployments, PeerPods, confidential containers, TEE, Trustee, attestation, or troubleshooting.
+description: >-
+  Provides comprehensive guidance on OpenShift Sandboxed Containers (OSC) by reading official
+  Red Hat documentation. ONLY trigger when the user explicitly asks to consult the user guide,
+  official docs, release notes, or says "use the user guide". Do NOT trigger for general code
+  questions, source code inspection, or tasks answerable from the repository itself.
 ---
 
 # OSC User Guide Reader


### PR DESCRIPTION
The skill was triggering too broadly on general OSC questions that should be answered from the repository source code. Now it only triggers when the user explicitly asks for the user guide, official docs, or release notes.

---

This change addresses @ldoktor 's  https://github.com/openshift/sandboxed-containers-operator/pull/1813#pullrequestreview-4126790192 . I asked the same question and it didn't trigger this skill, which is the outcome expected, then I activated it by explicitly mentioning the user guide:

```
❯ what kata version does osc 1.11 use?                                                                                                            
                                       
● Let me check the repository for the Kata version used in OSC 1.11.                                                                              
                                                                                                                                                  
  Searched for 1 pattern (ctrl+o to expand)                                                                                                       
                                                      
● Bash(git tag -l '*1.11*' | head -20)                                                                                                            
  ⎿  v1.11.0                          
     v1.11.1                                                                                                                                      
                                                                                                                                                  
● Let me check the FBC catalog entries for OSC 1.11 to find the Kata version reference.                                                           
                                                                                                                                                  
● Bash(git show v1.11.0:Makefile 2>/dev/null | grep -i 'kata\|KATA' | head -20)                                                                   
  ⎿  (No output)                                                                                                                                  
                                                                                                                                                  
● Bash(git show v1.11.0:versions.yaml 2>/dev/null || git show v1.11.0:config/manager/manager.yaml 2>/dev/null | head -40)                         
  ⎿  apiVersion: v1                                                                                                                               
     kind: Namespace                                                                                                                              
     metadata:                                                                                                                                    
     … +37 lines (ctrl+o to expand)                                                                                                               
                                                                                                                                                  
● Bash(git show v1.11.0:go.mod 2>/dev/null | grep -i kata | head -10)
  ⎿  (No output)                                                                                                                                  
                                                                                                                                                  
● Bash(git log v1.11.0 --oneline -20 | head -20)       
  ⎿  cb3c7960 Merge pull request #1429 from littlejawa/update_bundle_in_fbcs                                                                      
     f738bc75 Release 1.11: update the catalogs with the latest bundle reference                                                                  
     8c99c3e1 chore(deps): update osc-monitor to 96955b2
     … +17 lines (ctrl+o to expand)                                                                                                               
                                                                                                                                                  
● Bash(git show v1.11.0:config/peerpods/podvm/cloud-api-adaptor 2>/dev/null | head -5; echo "---"; git ls-tree v1.11.0 config/peerpods/podvm/
      2>/dev/null)                                                                                                                                
  ⎿  ---                                                                                                                                          
     100644 blob a07f6c27fd60e7933c6e1fe38a508a0f57462001       config/peerpods/podvm/Dockerfile.podvm-builder
     100644 blob a3c1062655205105ac0cb360a91a46a7a3323366       config/peerpods/podvm/Dockerfile.podvm-oci                                        
     … +17 lines (ctrl+o to expand)
                                                                                                                                                  
● Let me check the FBC catalog and the kata-containers submodule version.                                                                
                                                                                                                                                  
● Bash(git show v1.11.0:fbc/v4.18/catalog/sandboxed-containers-operator/catalog.json 2>/dev/null | python3 -c "                                   
      import sys, json…)                                                                                                                          
  ⎿  (No output)                                                                                                                                  
                                                                                                                                                  
● Bash(cd config/peerpods/podvm/cloud-api-adaptor && git log --oneline 4594d6f0951e1ad1fc63bfa751dfe4863a40e551 -1 2>/dev/null; echo "---"; git   
      ls-tree 4594d6f0951e1ad…)                                                                                                                   
  ⎿  4594d6f0 Merge pull request #251 from littlejawa/set_cpe_label_for_1.11                                                                      
     ---                                                                                                                                          
     160000 commit ea4138b669ba066512eaa2d2ee901bd1fcd9a65c     podvm-payload/kata-containers                                                     
                                                                                                                                                  
● Bash(cd config/peerpods/podvm/cloud-api-adaptor && git log --oneline ea4138b669ba066512eaa2d2ee901bd1fcd9a65c -1 2>/dev/null; echo "---"; git
      show ea4138b669ba066512…)                                                                                                                   
  ⎿  /bin/bash: line 1: cd: config/peerpods/podvm/cloud-api-adaptor: No such file or directory
     ---                                                                                                                                          
                                                                                                                                                  
● Bash(cd /home/wmoschet/src/github.com/openshift/sandboxed-containers-operator && git -C config/peerpods/podvm/cloud-api-adaptor log --oneline   
      ea4138b669ba -1 2>/dev/…)                                                                                                                   
  ⎿  ---submodule---                                                                                                                              
     ea4138b66 Merge pull request #149 from c3d/merge-3.21                                                                                        
     ---direct tag check---                                                                                                                       
     … +2 lines (ctrl+o to expand)                                                                                                                
                                                                                                                                                  
● OSC 1.11 uses Kata Containers 3.21.0 (specifically commit ea4138b66 — "Merge pull request #149 from c3d/merge-3.21" — pinned in the             
  podvm-payload/kata-containers submodule at the v1.11.0 tag).                                                                                    
                                                                                                                                                  
✻ Cogitated for 52s                                                                                                                               
                                                                                                                                                  
※ recap: You asked what Kata version OSC 1.11 uses. The answer is Kata Containers 3.21.0, confirmed from the submodule pin at the v1.11.0 tag. No 
  pending action unless you have a follow-up question. (disable recaps in /config)                                                                
                                                                                                                                                  
❯ does there such as information in the user guide?                                                                                               
                                                                                                                                                  
● Skill(osc-user-guide)                                                                                                                           
  ⎿  Successfully loaded skill                                                                                                                    
                               
● Let me download the OSC 1.11 user guide PDFs and check for version information.                                                                 
                                                                                   
● Bash(bash /home/wmoschet/src/github.com/openshift/sandboxed-containers-operator/.claude/skills/osc-user-guide/download-pdfs.sh 1.11)            
  ⎿  OSC 1.11 User Guide PDFs                                                                                                                     
     ========================                                                                                                                     
     … +9 lines (ctrl+o to expand)                                                                                                                
  ⎿  (timeout 2m)                                                                                                                                 
                                                                                                                                                  
● The release notes PDF is the most likely place for version info. Let me check it first.                                                         
                                                                                                                                                  
  Read 1 file (ctrl+o to expand)                                                                                                                  
                                                                                                                                                  
● No, the OSC 1.11 user guide does not include the Kata Containers version.                                                                       
                                                                                                                                                  
  I checked all four available guides for OSC 1.11 — the Release Notes (which I just read in full) cover new features, bug fixes, tech previews,  
  and known issues, but never mention the underlying Kata Containers version (3.21.0). The other guides (Deploying OSC, Deploying Confidential    
  Containers, Deploying Trustee) are operational/how-to docs and don't include component version mappings either.                                 
                                                                                                                                                  
  The only way to determine the Kata version is from the source — specifically the podvm-payload/kata-containers submodule pinned at the git tag, 
  as we did earlier.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined activation criteria for the user guide skill to trigger only when explicitly requested, improving relevance and reducing unnecessary activations for general code questions or repository tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->