### PR TITLE
airgap: add ImageSetConfiguration

### DIFF
--- a/docs/disconnected/README.md
+++ b/docs/disconnected/README.md
@@ -1,0 +1,35 @@
+# Disconnected Installation
+
+This directory contains `ImageSetConfiguration` files for mirroring the
+Sandbox Containers operator in disconnected (air-gapped) environments using `oc-mirror`.
+
+## What is covered
+
+Each `imageset-config-<ocp-version>.yaml` file mirrors:
+
+- The Sandbox Containers operator from the Red Hat operator catalog, including the
+  catalog index, operator bundle, and operator controller image.
+- The KBS operand image, listed as `relatedImages` in the operator bundle
+  and automatically picked up by `oc-mirror`.
+
+One file is provided per supported OCP version.
+
+## Usage
+
+1. Select the file matching your OCP version, e.g. `imageset-config-4.19.yaml`.
+
+2. Run `oc-mirror` to mirror all images to your internal registry:
+
+   ```bash
+   oc-mirror --config imageset-config-4.19.yaml --workspace file://oc-workspace docker://<your-registry> --v2
+   ```
+
+3. Apply the generated IDMS (ImageDigestMirrorSet) / ICSP (ImageContentSourcePolicy)
+   and CatalogSource / ClusterCatalog manifests to your cluster. These remap image references from upstream
+   registries to your internal mirror:
+
+   ```bash
+   oc apply -f oc-mirror-workspace/working-dir/cluster-resource/
+   ```
+
+4. Install the operator using the mirrored catalog as the source.

--- a/docs/disconnected/imageset-config-4.18.yaml
+++ b/docs/disconnected/imageset-config-4.18.yaml
@@ -1,0 +1,12 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.18.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    packages:
+    - name: sandboxed-containers-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.19.yaml
+++ b/docs/disconnected/imageset-config-4.19.yaml
@@ -1,0 +1,12 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.19.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
+    packages:
+    - name: sandboxed-containers-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.20.yaml
+++ b/docs/disconnected/imageset-config-4.20.yaml
@@ -1,0 +1,12 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.20.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
+    packages:
+    - name: sandboxed-containers-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.21.yaml
+++ b/docs/disconnected/imageset-config-4.21.yaml
@@ -1,0 +1,12 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.21.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.21
+    packages:
+    - name: sandboxed-containers-operator
+      channels:
+      - name: stable


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
To install OSC in disconnected environments, users need an ImageSetConfiguration for oc-mirror and all operand images listed in the bundle. This PR adds both.

**- What I did**
Add imageset-config files for OCP 4.17-4.21 and a README under docs/disconnected/.

**- How to verify it**
Follow the README.md under docs/disconnected on a air-gapped environment.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add imageset-config files for OCP 4.17-4.21 and a README under docs/disconnected/. This is an initial attempt to provide a supported way to mirror the OSC operator in air-gapped environments using oc-mirror.