### PR TITLE
Release 1.12.1: update the version everywhere

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -259,7 +259,7 @@ spec:
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
-      value: ["latest", "1.12.0-$(tasks.clone-repository.results.commit-timestamp)"]
+      value: ["latest", "1.12.1-$(tasks.clone-repository.results.commit-timestamp)"]
     runAfter:
     - build-image-index
     taskRef:

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -294,7 +294,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: ["latest", "1.12.0-$(tasks.clone-repository.results.commit-timestamp)"]
+        value: ["latest", "1.12.1-$(tasks.clone-repository.results.commit-timestamp)"]
       runAfter:
       - build-image-index
       taskRef:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.12.0  ## OSC_VERSION
+VERSION ?= 1.12.1  ## OSC_VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
+++ b/bundle/manifests/kataconfiguration.openshift.io_kataconfigs.yaml
@@ -62,6 +62,7 @@ spec:
                 description: |-
                   CheckNodeEligibility is used to detect the node(s) eligibility to run Kata containers.
                   This is currently done through the use of the Node Feature Discovery Operator (NFD).
+                  In addition this option will also enforce runtime class creation if only if node(s) support them.
                   For more information on how the check works, please refer to the sandboxed containers documentation - https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.6/html-single/user_guide/index#about-node-eligibility-checks_about-osc
                 type: boolean
               enablePeerPods:

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-02-24T18:05:19Z"
+    createdAt: "2026-05-07T10:41:36Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -24,7 +24,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.1.0 <1.12.0'
+    olm.skipRange: '>=1.1.0 <1.12.1'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.12.0
+  name: sandboxed-containers-operator.v1.12.1
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -593,8 +593,8 @@ spec:
     name: tdx-qgs
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:c893a5e46565307f5e00644f66463cae08ce4f5c6e67fe49e7483e1988425c4d
     name: storage-helper
-  replaces: sandboxed-containers-operator.v1.11.1
-  version: 1.12.0
+  replaces: sandboxed-containers-operator.v1.12.0
+  version: 1.12.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.12.0  ## OSC_VERSION
+  newTag: v1.12.1  ## OSC_VERSION

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.1.0 <1.12.0'
+    olm.skipRange: '>=1.1.0 <1.12.1'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.12.0
+  name: sandboxed-containers-operator.v1.12.1  ## OSC_VERSION
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -364,8 +364,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  replaces: sandboxed-containers-operator.v1.11.1
-  version: 1.12.0
+  replaces: sandboxed-containers-operator.v1.12.0
+  version: 1.12.1  ## OSC_VERSION
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -9,4 +9,4 @@ kind: Kustomization
 images:
 - name: metrics-server
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.12.0  ## OSC_VERSION
+  newTag: v1.12.1  ## OSC_VERSION

--- a/config/peerpods/podvm/bootc/Containerfile.rhel
+++ b/config/peerpods/podvm/bootc/Containerfile.rhel
@@ -1,5 +1,5 @@
 # Get payload
-FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.12.0 as payload  ## OSC_VERSION
+FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.12.1 as payload  ## OSC_VERSION
 
 # Build bootc rhel podvm
 FROM registry.redhat.io/rhel9/rhel-bootc:9.7-1777449541 as podvm-bootc

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -15,7 +15,7 @@ spec:
       # /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz
       initContainers:
         - name: copy
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.12.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.12.1  ## OSC_VERSION
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -29,7 +29,7 @@ spec:
         - name: create
           # Binaries like kubectl, packer and yq are expected to be under /usr/local/bin
           # podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.1  ## OSC_VERSION
           # This image contains the following
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -21,7 +21,7 @@ spec:
           # ibmcloud-podvm-image-handler.sh script under /scripts/ibmcloud-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           # Binaries like kubectl, packer and yq under /usr/local/bin
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.1  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           env:

--- a/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: delete-gallery
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.0  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.12.1  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           envFrom:

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.12.0  ## OSC_VERSION
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.12.1  ## OSC_VERSION
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,4 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.12.0  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.12.1  ## OSC_VERSION

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -113,7 +113,7 @@ When adding a new container definition in some pod yaml, make sure to tag the `i
 field with `  ## OSC_VERSION`, e.g.
 
 ```
-image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.12.0  ## OSC_VERSION
+image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.12.1  ## OSC_VERSION
 ```
 
 Do the same when adding new `RELATED_IMAGE` entries in the environment of the controller
@@ -121,7 +121,7 @@ in `config/manager/manager.yaml`, e.g.
 
 ```
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.12.0  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.12.1  ## OSC_VERSION
 ```
 
 This is a best effort to track locations where OSC version bumps should happen.

--- a/docs/credentials-handling.md
+++ b/docs/credentials-handling.md
@@ -111,7 +111,7 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.12.0
+  startingCSV: sandboxed-containers-operator.v1.12.1
 ```
 5. Continue following the OSC installation instructions while making sure your created RG is always the one used (the one in use also above), in peer-pods-cm and in configuring the default worker subnet
 


### PR DESCRIPTION
Reference commit (1.11.1): https://github.com/openshift/sandboxed-containers-operator/pull/1454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release version to 1.12.1 across build, pipelines, and deployment configs.
  * Updated image tags and operator manifests, including upgrade metadata and skip-range adjustments.
  * Updated container images used by pod VM creation/deletion jobs and related templates.
* **Documentation**
  * Updated examples and guides to reference v1.12.1 and clarified CRD behavior for node eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->