### PR TITLE
controller: fix non-targeted nodes appearing in waitingToUninstall status

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -1903,8 +1903,30 @@ func (r *KataConfigOpenShiftReconciler) updateStatus() error {
 		return len(nodes.Items)
 	}()
 
+	// Pre-compute cluster-level attributes outside the node loop for performance.
+	// isConvergedCluster is a cluster attribute, not a node-level attribute.
+	isConvergedCluster, err := r.checkConvergedCluster()
+	if err != nil {
+		return fmt.Errorf("failed to check if cluster is converged: %w", err)
+	}
+
+	// Build the effective KataConfig node selector once for the entire reconciliation.
+	kataNodeSelector, err := r.getKataConfigNodeSelectorAsSelector()
+	if err != nil {
+		return fmt.Errorf("failed to build KataConfig node selector: %w", err)
+	}
+
 	for _, node := range nodeList.Items {
-		e := r.putNodeOnStatusList(&node)
+		// On non-converged clusters, skip nodes that don't match the selector AND
+		// never had kata-oc label (i.e., were never targeted for Kata installation).
+		// Include nodes with kata-oc label even if they no longer match the selector,
+		// as they may be uninstalling Kata and should appear in status lists.
+		_, hasKataLabel := node.Labels["node-role.kubernetes.io/kata-oc"]
+		if !isConvergedCluster && !kataNodeSelector.Matches(labels.Set(node.Labels)) && !hasKataLabel {
+			continue
+		}
+
+		e := r.putNodeOnStatusList(&node, isConvergedCluster)
 		if e != nil {
 			err = e
 		}
@@ -1953,12 +1975,7 @@ func isNodeFailedToUninstall(nodeMcoState string, nodeCurrMc string, nodeTargetM
 	return nodeMcoState == NodeDegraded && !isKataEnabledOnNode
 }
 
-func (r *KataConfigOpenShiftReconciler) putNodeOnStatusList(node *corev1.Node) error {
-
-	isConvergedCluster, err := r.checkConvergedCluster()
-	if err != nil {
-		return err
-	}
+func (r *KataConfigOpenShiftReconciler) putNodeOnStatusList(node *corev1.Node, isConvergedCluster bool) error {
 
 	targetMcpName := func() string {
 		if isConvergedCluster {


### PR DESCRIPTION
Addressing issue reported in : #[KATA-4768](https://redhat.atlassian.net/browse/KATA-4768)

**- Description of the problem which is fixed/What is the use case**

The updateStatus() function processes all worker nodes and incorrectly marks regular workers as "waitingToUninstall" when they have any MachineConfig drift, even though Kata was never installed on them.

The root cause is in putNodeOnStatusList() which evaluates all workers. When a non-kata node has nodeCurrMc != nodeTargetMc (common during cluster updates), the isNodeWaitingToUninstall() predicate returns true because:
- nodeMcoState == NodeDone (MCO finished processing)
- nodeCurrMc != nodeTargetMc (any MC drift)
- !isKataEnabledOnNode (true for non-kata labeled nodes)

**- What I did**

This fix adds an early-return check to skip nodes that don't match the configured kataConfigPoolSelector on non-converged clusters. This ensures only nodes that are actually targeted by the KataConfig (regardless of the specific selector used) are tracked in status lists, supporting both default and custom node selectors.

**- How to verify it**

Reproducer steps in https://redhat.atlassian.net/browse/KATA-4768

**- Description for the changelog**
This fix adds an early-return check to skip nodes that don't match the configured kataConfigPoolSelector on non-converged clusters