### PR TITLE
claude: add a skill that automates managing the pull requests from Konflux

### DIFF
--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -85,9 +85,14 @@ Output: JSON with {success, repo, pr, label}
 ## check-pipeline-status.sh
 Check Konflux pipeline status.
 ```bash
-./check-pipeline-status.sh --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID]
+# For on-push (default)
+./check-pipeline-status.sh --component COMPONENT_NAME
+
+# For on-pull-request (--pr-id REQUIRED)
+./check-pipeline-status.sh --component COMPONENT_NAME --type on-pull-request --pr-id PR_ID
 ```
 Output: JSON with {component, pipeline_type, latest, all_runs}
+Note: --pr-id is mandatory for on-pull-request to avoid matching runs from different PRs
 
 ## get-nudge-prs.sh
 Find nudge PRs for a component.

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -1,0 +1,296 @@
+---
+name: process-konflux-prs
+description: Look at pull requests created by the Konflux bot and manage them, optimizing their merge to avoid repetitive builds.
+allowed-tools:
+  - Bash(scripts/process-konflux-prs/list-prs.sh*)
+  - Bash(scripts/process-konflux-prs/get-pr-status.sh*)
+  - Bash(scripts/process-konflux-prs/get-pr-components.sh*)
+  - Bash(scripts/process-konflux-prs/label-pr.sh*)
+  - Bash(scripts/process-konflux-prs/check-pipeline-status.sh*)
+  - Bash(scripts/process-konflux-prs/get-nudge-prs.sh*)
+  - Bash(scripts/process-konflux-prs/get-component-info.sh*)
+---
+
+Process the pull requests from Mintmaker and Konflux
+
+# Implementation Requirements
+
+**CRITICAL**: Always query fresh data. Never use PR numbers from previous runs or earlier in the conversation.
+
+When implementing this skill:
+
+1. **Always start fresh**: Use `list-prs.sh` at the beginning of execution to get current PRs
+2. **Process only discovered PRs**: Only process PR numbers returned from `list-prs.sh`
+3. **Never hardcode PR numbers**: Do not use PR numbers from memory, previous runs, or earlier conversation turns
+4. **Verify state before processing**: Use `get-pr-status.sh` to verify PR state before taking action
+
+Example correct workflow:
+```bash
+# CORRECT: Discover PRs dynamically
+prs=$(./scripts/process-konflux-prs/list-prs.sh --mintmaker)
+for pr in $(echo "$prs" | jq -c '.[]'); do
+  repo=$(echo "$pr" | jq -r '.repo')
+  number=$(echo "$pr" | jq -r '.number')
+  # Process each discovered PR
+done
+
+# WRONG: Using hardcoded or remembered PR numbers
+for pr_num in 2147 2146 2144 2143; do  # ❌ Never do this
+  # ...
+done
+```
+
+**IMPORTANT**: Do not perform active polling/wait loops when executing.
+This skill is intended to be run on a regular basis. Each time it runs, it should
+evaluate the status of all PRs, and try to move them forward according to the
+workflow. If the workflow states that you "need to wait" for something (like:
+wait for the completion of checks), this skill should actually let the PR untouched,
+and on next run, look at the status again.
+The labels we put on the PRs are used to keep some state information without the
+need to maintain any local status.
+
+# Available Helper Scripts
+
+All scripts are located in `scripts/process-konflux-prs/` and output JSON.
+
+## list-prs.sh
+List Konflux PRs from repositories.
+```bash
+./list-prs.sh [--mintmaker|--nudge] [--repo REPO_NAME]
+```
+Output: JSON array with {number, title, url, repo, type}
+
+## get-pr-status.sh
+Get PR status including checks and labels.
+```bash
+./get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
+```
+Output: JSON with {number, title, state, labels, checks, has_ok_to_test, has_lgtm, all_checks_passed, pending_checks}
+
+## get-pr-components.sh
+Identify components that will be rebuilt (excludes enterprise-contract validation checks).
+```bash
+./get-pr-components.sh --repo REPO_NAME --pr PR_NUMBER
+```
+Output: JSON array of component names
+
+## label-pr.sh
+Add a label to a PR.
+```bash
+./label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
+```
+Labels: "ok-to-test" or "lgtm"
+Output: JSON with {success, repo, pr, label}
+
+## check-pipeline-status.sh
+Check Konflux pipeline status.
+```bash
+./check-pipeline-status.sh --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID]
+```
+Output: JSON with {component, pipeline_type, latest, all_runs}
+
+## get-nudge-prs.sh
+Find nudge PRs for a component.
+```bash
+./get-nudge-prs.sh --component COMPONENT_NAME
+```
+Output: JSON array of nudge PRs
+
+## get-component-info.sh
+Get component metadata.
+```bash
+./get-component-info.sh [--component COMPONENT_NAME]
+```
+Output: JSON with {name, repository, build_time_minutes, nudges}
+
+# Usage
+
+Without any parameter, the command will list the PRs from the different repositories,
+and state for each PR which images will be rebuilt if the PR is merged. It will
+also provide the suggested action for each PR.
+See [Status output format](#status-output-format) for details.
+
+With the --label parameter, the command will only perform the "labelling" steps,
+and not merge any PR.
+
+With the --dry-run parameter, the command will show the commands it would execute,
+but will not label nor merge any PR.
+
+At this point, this skill is considered to be "in development" and should NEVER
+merge any PR.
+
+# Workflow definition
+
+We receive two types of pull requests from Konflux:
+
+- Mintmaker PRs: update of dependencies
+- Nudge PRs: updated reference to a newly built image from our own pipelines
+
+The first type comes on a regular basis from Mintmaker.
+The other comes from merging pull requests: each PR we merge will generate the
+build of (at least) one image. When an image is rebuilt, its reference is updated
+on some other component(s) automatically, with a nudge PR.
+See the [list of components](#list-of-components) for our nudge relationship.
+
+The workflow requires to process Mintmaker PRs first, then Nudge PRs.
+The processing of each PR is done in two steps: labelling, and merging.
+
+## Labelling
+
+Using labels allows to mark the progression of PRs towards merging, making it
+possible to run the command multiple time, and continue the processing without
+having to keep a separate status.
+It also allows developers to mark the PRs themselves, and have this automated
+process take their labels into account.
+
+We're using two labels:
+- `ok-to-test` is used to make our automated tests run on the PR.
+- `lgtm` is used to mark the PR as ready to merge.
+
+The rule typically is:
+
+- if a PR don't have "ok-to-test", set the "ok-to-test" label
+- if a PR has "ok-to-test" AND all the checks are passing, set the "lgtm" label
+
+Labelling can be done in parallel for all PRs from all repositories, as there
+is no conflict with "on-pull-request" pipelines running in parallel.
+
+Note that Nudge PRs in the osc repository are configured to auto-merge when
+the tests are passing. Setting the "ok-to-test" label on those PRs is then the
+only required labelling. But it means we have to look for the merge pipeline
+when the PR auto-merges, and make sure it succeeds (see [merging](#merging)).
+
+## Merging
+
+PRs are ready to merge when they have the label "lgtm" and all the checks are
+passing.
+
+We need to be careful when merging a PR: each time we merge a PR, we need to verify
+that the on-push pipelines (triggered when we merge) are successful before merging
+another PR that rebuilds the same component.
+
+The checks that run on the pull request itself include Konflux pipeline builds.
+The same pipelines will run on-push when the PR is merged. It is then possible
+to know, before the PR is merged, which component it will rebuild.
+Use `get-pr-components.sh` to identify which components will be rebuilt.
+
+The build pipelines themselves can be monitored from the Konflux cluster, using
+`check-pipeline-status.sh`.
+Then when we merge a PR, we can monitor which on-push pipelines are triggered, and
+wait for their completion before merging another PR for the same component.
+
+When the on-push pipeline is successful, a Nudge PR can be created.
+If the Nudge PR already exists, it is updated every time the same component is rebuilt.
+We then let the Nudge PRs opened as long as we are processing Mintmaker PRs, and
+process the Nudge PRs as a second step, to avoid unnecessary rebuilds.
+Use `get-component-info.sh` to see which components are nudged when a component is rebuilt.
+
+Verifying that the nudge PR is created or updated is part of how we verify that
+a Mintmaker PR was successfully merged. If the on-push pipeline failed, or if the
+expected Nudge PR update doesn't come, we consider the merge as failed, report it,
+and stop processing any other PR related to the same component.
+
+# List of repositories
+
+| Repo name         | URL                                                           |
+| ----------------- | ------------------------------------------------------------- |
+| kata-containers   | `https://github.com/openshift/kata-containers`                |
+| cloud-api-adaptor | `https://github.com/openshift/cloud-api-adaptor`              |
+| compute-artifacts | `https://github.com/openshift/confidential-compute-artifacts` |
+| podvm-scripts     | `https://github.com/confidential-devhub/coco-podvm-scripts`   |
+| osc               | `https://github.com/openshift/sandboxed-containers-operator`  |
+
+# Mintmaker PRs filter
+
+Implemented in `list-prs.sh --mintmaker`:
+- status is "open"
+- author is the "app/red-hat-konflux" bot
+- title starts with one of the following:
+  - "chore(deps): update konflux references"
+  - "chore(deps): update registry.access.redhat.com/ubi9/ubi"
+  - "chore(deps): update registry.access.redhat.com/ubi9/go-toolset"
+  - "chore(deps): update registry.access.redhat.com/ubi10/ubi"
+  - "chore(deps): update registry.access.redhat.com/ubi10/go-toolset"
+
+# Nudge PRs filter
+
+Implemented in `list-prs.sh --nudge`:
+- status is "open"
+- author is the "app/red-hat-konflux" bot
+- label "konflux-nudge" is set
+- title does NOT start with "chore(deps): update osc-operator-bundle"
+
+# List of components
+
+The following table shows the list of components, the repository they are built from,
+an estimation of the time to build the image, and the component(s) that is updated
+by a Nudge PR when they are rebuilt.
+
+Available via `get-component-info.sh`.
+
+| Component             | Repository        | Approx. build time | Nudged component(s)                                   |
+| --------------------- | ----------------- | ------------------ | ----------------------------------------------------- |
+| osc-monitor           | kata-containers   | 10 min             | osc-operator-bundle                                   |
+| osc-caa               | cloud-api-adaptor | 15 min             | osc-operator-bundle                                   |
+| osc-caa-webhook       | cloud-api-adaptor | 10 min             | osc-operator-bundle                                   |
+| osc-podvm-payload     | cloud-api-adaptor | 45 min             | osc-operator-bundle, osc-dm-verity-image, osc-initrds |
+| osc-pccs              | compute-artifacts |  8 min             | osc-operator-bundle                                   |
+| osc-tdx-qgs           | compute-artifacts |  8 min             | osc-operator-bundle                                   |
+| osc-storage-helper    | compute-artifacts |  8 min             | osc-operator-bundle                                   |
+| osc-operator          | osc               | 12 min             | osc-operator-bundle                                   |
+| osc-operator-bundle   | osc               |  3 min             | osc-test-fbc                                          |
+| osc-podvm-builder     | osc               | 10 min             | osc-operator-bundle                                   |
+| osc-must-gather       | osc               | 10 min             | osc-operator-bundle                                   |
+| osc-dm-verity-image   | podvm-scripts     | 50 min             | osc-operator-bundle                                   |
+| build-dm-verity-image | podvm-scripts     |  2 min             | osc-dm-verity-image                                   |
+| osc-initrds           | compute-artifacts | 15 min             |                                                       |
+| osc-test-fbc          | osc               | 15 min             |                                                       |
+
+Note about the osc-test-fbc component:
+This is the file-based catalog that we use for testing. It is updated when the
+bundle is rebuilt.
+As the bundle gets rebuilt every time any other image is rebuilt, we want to keep
+the Nudge PR for the osc-test-fbc opened as long as there are updates going on.
+That's why this process should ignore the Nudge PR with title like:
+"chore(deps): update osc-operator-bundle"
+as these are the PRs that update the catalog.
+Merging this PR should only be done manually, when we are ready to start testing
+the whole set of images.
+
+# Konflux cluster access
+
+Access to Konflux is granted with a token, generated from a dedicated service account,
+with limited access. The token will be provided when setting up the automated process.
+
+Scripts should not use the "oc project" command, as there are limitations
+for the service account here. Instead, they should specify the target namespace on
+every command (default: ose-osc-tenant).
+
+# GitHub access
+
+A dedicated token should be provided to access GitHub via `gh auth login`.
+
+# How to identify the pipelineruns for a given PR
+
+The pipelines running on the PR can be identified as checks with a name that matches the following pattern:
+"Red Hat Konflux / {component-name}-on-pull-request"
+
+**Important:** Enterprise contract checks (validation checks) should be excluded. They follow a different pattern and do not represent component builds.
+
+Multiple component build checks can exist for a given PR, depending on which files are modified by the PR.
+The details of the check will show the exact pipelinerun ID, with format {component-name}-on-pull-request-{alphanumeric ID}.
+When the PR is merged, a similar pipelinerun will start, with pattern:
+{component-name}-on-push-{other alphanumeric ID}
+
+# Status output format
+
+When run with the "--status" parameter, the result should be displayed on the
+terminal (if available) and saved under the local folder as a markdown file with
+a timestamp in the filename for easy filtering (like: "YYYYMMDD-Konflux-PR-status.md").
+
+The output for each PR should include:
+
+- PR Number (with link to the PR on GitHub)
+- Rebuilt component(s)
+- Current status
+- Recommended action

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -511,6 +511,8 @@ Implemented in `list-prs.sh --mintmaker`:
   - starts with `"chore(deps): update registry.access.redhat.com/ubi9/"` (any ubi9 image)
   - starts with `"chore(deps): update registry.access.redhat.com/ubi10/"` (any ubi10 image)
   - starts with `"Update registry.access.redhat.com/ubi9/"` or `"Update registry.access.redhat.com/ubi10/"`
+  - starts with `"chore(deps): update registry.redhat.io/rhel9/rhel-bootc"` (rhel-bootc image)
+  - starts with `"Update registry.redhat.io/rhel9/rhel-bootc"`
 
 # Nudge PRs filter
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -282,11 +282,12 @@ them from the processing set.
 
 **Known skip patterns:**
 
-- **go-toolset major-version-only tag**: title contains `ubi9/go-toolset` AND the tag
-  is a bare major version (e.g. `v9`, `v10`) with no Go version number.
-  Detection: title matches `ubi9/go-toolset` AND ends with `tag to v<N>` where `<N>`
-  is a single integer (no dots). Example: `"Update ubi9/go-toolset Docker tag to v9"`.
-  *Why*: we pin `ubi9/go-toolset` to the Go version tag (e.g. `v1.26.4-...`), not the
+- **go-toolset major-version-only tag**: title contains `ubi9/go-toolset` or
+  `ubi10/go-toolset` AND the tag is a bare major version (e.g. `v9`, `v10`) with no
+  Go version number.
+  Detection: title matches `ubi[0-9]+/go-toolset` AND ends with `tag to v<N>` where
+  `<N>` is a single integer (no dots). Example: `"Update ubi9/go-toolset Docker tag to v9"`.
+  *Why*: we pin `go-toolset` to the Go version tag (e.g. `v1.26.4-...`), not the
   image's own major version. A separate PR with the correct Go version tag will arrive.
 
 For each PR matching a skip pattern:

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -10,6 +10,7 @@ allowed-tools:
   - Bash(scripts/process-konflux-prs/merge-pr.sh*)
   - Bash(scripts/process-konflux-prs/skip-pr.sh*)
   - Bash(scripts/process-konflux-prs/check-pipeline-status.sh*)
+  - Bash(scripts/process-konflux-prs/check-merge-safety.sh*)
   - Bash(scripts/process-konflux-prs/get-nudge-prs.sh*)
   - Bash(scripts/process-konflux-prs/get-component-info.sh*)
 ---
@@ -200,6 +201,18 @@ Check Konflux pipeline status.
 Output: JSON with {component, pipeline_type, latest, all_runs}
 Note: --pr-id is mandatory for on-pull-request to avoid matching runs from different PRs
 
+## check-merge-safety.sh
+Check whether it is safe to merge a PR by verifying no on-push pipeline is running
+for any of its components. Wraps `check-pipeline-status.sh` over a component list.
+```bash
+./scripts/process-konflux-prs/check-merge-safety.sh --components "comp1 comp2 ..."
+```
+Output: JSON `{safe_to_merge: bool, blocking: [{component, pipeline, reason}]}`
+- `safe_to_merge`: true when no component has a running on-push pipeline
+- `blocking`: list of components currently blocked (empty when safe)
+
+**Use this instead of a manual loop over `check-pipeline-status.sh` before each merge.**
+
 ## get-nudge-prs.sh
 Find nudge PRs for a component.
 ```bash
@@ -314,14 +327,13 @@ After all labelling is complete, merge PRs that were **already ready before this
 - Do NOT merge a PR that received `lgtm` during this run's Phase A — the same
   snapshot principle applies: lgtm was just set, so this is its first eligible run,
   not a confirmed-ready state from a prior run.
-- **Pre-merge pipeline check**: Before merging a PR, for each component in the
-  snapshot's `components` array, call:
+- **Pre-merge pipeline check**: Before merging a PR, call:
   ```bash
-  ./scripts/process-konflux-prs/check-pipeline-status.sh --component COMPONENT_NAME
+  ./scripts/process-konflux-prs/check-merge-safety.sh --components "comp1 comp2 ..."
   ```
-  (defaults to `--type on-push`). If `latest` is non-null AND `latest.completionTime`
-  is null, an on-push pipeline for that component is still running. **Skip this PR**
-  and report it as "blocked by running on-push pipeline". Do NOT merge it.
+  using the snapshot's `components` array. If `safe_to_merge` is `false`, **skip this
+  PR** and report it as "blocked by running on-push pipeline" (include the `blocking`
+  list in the report). Do NOT merge it.
 - Merge PRs one at a time using `merge-pr.sh`. After each merge, note which
   components will be rebuilt (from the snapshot's `components` field).
 - Within a single run, do NOT merge two PRs that rebuild the same component —

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -28,7 +28,7 @@ Process the pull requests from Mintmaker and Konflux
   Do NOT touch Nudge PRs.
 - **`--nudge`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
   [Step 2 - Nudge PR processing](#step-2---nudge-pr-processing)). Do NOT touch Mintmaker PRs.
-  Do NOT merge.
+  Merges non-osc nudge PRs when checks pass (osc nudge PRs auto-merge on their own).
 - **`--dry-run`**: Show what would be done. Do NOT label or merge. Can be combined with
   `--mintmaker` or `--nudge` to preview that specific step.
 
@@ -360,6 +360,20 @@ will trigger a rebuild of the same source component. If a Mintmaker PR would
 rebuild component C, and a Nudge PR carries an updated reference for C, merging
 the Nudge PR now would be immediately obsoleted by the Mintmaker rebuild.
 
+### Why the hold-back strategy is needed
+
+When multiple Nudge PRs all target the same downstream component (e.g.
+`osc-operator-bundle`), merging them triggers one on-push pipeline per merge.
+These pipelines run concurrently on their respective HEADs. Because each pipeline
+builds and publishes independently, the one that **finishes last** wins — regardless
+of merge order. If the last-finishing pipeline was triggered by the first merge, it
+produces an image that is missing all the updates from later merges.
+
+The fix: hold one PR back and only merge it once all other on-push pipelines for
+that component group have completed. Its merge then triggers a single, uncontested
+final pipeline that builds from HEAD containing all previous merges, producing a
+complete image with all component updates.
+
 ### Step 2 algorithm
 
 **Phase A — Build the "Mintmaker-blocked" component set**
@@ -368,26 +382,65 @@ the Nudge PR now would be immediately obsoleted by the Mintmaker rebuild.
 2. Union the `components` arrays from all entries into a single set:
    `mintmaker_rebuilding_components`.
 
-**Phase B — Filter and process Nudge PRs**
+**Phase B — Filter, group, and label Nudge PRs**
 
 1. Call `snapshot-prs.sh --nudge` to get all open Nudge PRs with their status.
+   Record the result as the **initial snapshot** (fixed for this run).
 2. For each Nudge PR, identify the **source component** — the component whose
    reference was updated — by matching known component names against the PR title.
-   (Nudge PR titles contain the source component name, e.g.
-   "chore(deps): update osc-monitor …".)
-   Use `get-component-info.sh` (no args) to get the full list of component names
-   to match against.
-3. If the source component is in `mintmaker_rebuilding_components`: **skip** this
-   Nudge PR and note it as "blocked by open Mintmaker PR". Do NOT label it.
-4. If the source component is NOT in `mintmaker_rebuilding_components`: apply the
-   labelling rules above to this Nudge PR.
+   Use `get-component-info.sh` (no args) to get the full list of component names.
+3. Remove PRs whose source component is in `mintmaker_rebuilding_components` from
+   the working set. Note them as "blocked by open Mintmaker PR". Do NOT label them.
+4. **Group** the remaining PRs by their `components` array (exact match on the set
+   of components they will rebuild — same components = same group).
+5. For each group:
 
-**Phase C — Report**
+   **Group has multiple open PRs:**
+   - Identify PRs with `has_ok_to_test: false` (not yet labeled).
+   - If **2 or more** PRs have `has_ok_to_test: false`: apply `ok-to-test` to all
+     except the **lowest-numbered** one. The lowest-numbered becomes the **held-back
+     PR** for this group. Do NOT label it this run.
+   - If **exactly one** PR has `has_ok_to_test: false` and the rest have
+     `has_ok_to_test: true` (still open, not yet merged): the held-back PR is waiting
+     for its peers to merge first. Do NOT label it — leave it for the next run.
+   - If **all** PRs have `has_ok_to_test: true`: all are in flight; nothing to label.
 
-Show two groups:
-- Nudge PRs processed (with actions taken or their current label/check status).
-- Nudge PRs skipped (with the reason: which open Mintmaker PR blocks them and
-  which component it will rebuild).
+   **Group has exactly one open PR** (all peers have merged — they are no longer in
+   the snapshot):
+   - This is either a standalone PR or the held-back PR whose peers have all merged.
+   - Call `check-merge-safety.sh --components "<components>"`.
+   - If `safe_to_merge: true`: apply standard labelling rules — `ok-to-test` if not
+     set; `lgtm` if `ok-to-test` is already set and checks pass (for non-osc repos;
+     see Phase C).
+   - If `safe_to_merge: false`: **do not label**. Report as "waiting for on-push
+     pipelines to complete" and include the `blocking` list. Revisit next run.
+
+**Phase C — Merge non-osc Nudge PRs**
+
+Nudge PRs in the osc repository auto-merge once checks pass. Nudge PRs in other
+repositories (compute-artifacts, podvm-scripts) do not auto-merge and require
+explicit merging.
+
+For each non-osc Nudge PR where the **initial snapshot** shows `has_ok_to_test: true`
+AND `build_checks_passed: true` AND `pending_checks: 0` AND the PR is **not currently
+designated as held-back** (i.e., it is not the sole unlabeled PR in a multi-PR group):
+
+- Call `check-merge-safety.sh --components "<components>"`. If `safe_to_merge` is
+  `false`, skip and report as "blocked by running on-push pipeline".
+- Apply `lgtm` label.
+- Merge using `merge-pr.sh`. Within a single run, do NOT merge two PRs that rebuild
+  the same component — the second must wait for the next run.
+
+**Phase D — Report**
+
+Report four groups:
+- **Labeled this run**: Nudge PRs that received `ok-to-test` or `lgtm`.
+- **Merged this run**: non-osc Nudge PRs successfully merged.
+- **Held back**: PRs designated as held-back (waiting for group peers to merge or
+  for pipelines to clear). For each, show which peers are still open or which
+  pipelines are blocking.
+- **Skipped**: PRs blocked by an open Mintmaker PR, by still-running on-push
+  pipelines, or with pending/failed checks. Include the reason for each.
 
 ## Merging
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -19,8 +19,16 @@ Process the pull requests from Mintmaker and Konflux
 
 - **No parameter**: ONLY list PRs. For each PR, show which images will be rebuilt and the
   suggested action (see [Status output format](#status-output-format)). Do NOT label or merge.
-- **`--label`**: ONLY perform labelling steps. Do NOT merge.
-- **`--dry-run`**: Show what would be done. Do NOT label or merge.
+- **`--step1`**: Process Mintmaker PRs ONLY. Apply labels (ok-to-test, lgtm). Do NOT touch
+  Nudge PRs. Do NOT merge.
+- **`--step2`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
+  [Step 2 - Nudge PR processing](#step-2---nudge-pr-processing)). Do NOT touch Mintmaker PRs.
+  Do NOT merge.
+- **`--dry-run`**: Show what would be done. Do NOT label or merge. Can be combined with
+  `--step1` or `--step2` to preview that specific step.
+
+`--step1` and `--step2` are mutually exclusive. If neither is given, only list/status output
+is produced.
 
 **This skill is in development and must NEVER merge any PR.**
 
@@ -177,58 +185,110 @@ Output: JSON with {name, repository, build_time_minutes, nudges}
 
 We receive two types of pull requests from Konflux:
 
-- Mintmaker PRs: update of dependencies
-- Nudge PRs: updated reference to a newly built image from our own pipelines
+- **Mintmaker PRs**: dependency updates (base images, konflux references).
+- **Nudge PRs**: updated reference to a newly built image from our own pipelines.
 
 The first type comes on a regular basis from Mintmaker.
-The other comes from merging pull requests: each PR we merge will generate the
-build of (at least) one image. When an image is rebuilt, its reference is updated
-on some other component(s) automatically, with a nudge PR.
-See the [list of components](#list-of-components) for our nudge relationship.
+The second is triggered automatically when a PR is merged: each merge builds (at
+least) one image, which then causes Konflux to open or update a Nudge PR in the
+downstream component(s).
+See the [list of components](#list-of-components) for nudge relationships.
 
-The workflow requires to process Mintmaker PRs first, then Nudge PRs.
-The processing of each PR is done in two steps: labelling, and merging.
+**The workflow is two separate steps, run independently:**
 
-## Labelling
+1. **Step 1 — Mintmaker PRs** (`--step1`): label and advance Mintmaker PRs.
+2. **Step 2 — Nudge PRs** (`--step2`): label and advance Nudge PRs, but ONLY
+   those that are safe to process (see below).
 
-**Only performed when `--label` parameter is passed. Skip entirely otherwise.**
+Merging Mintmaker PRs triggers component rebuilds, which in turn refresh the
+existing Nudge PRs. Processing a Nudge PR before the corresponding Mintmaker PRs
+are done would merge a stale image reference that gets immediately superseded.
+Steps 1 and 2 must therefore stay separate.
 
-Using labels allows to mark the progression of PRs towards merging, making it
-possible to run the command multiple time, and continue the processing without
-having to keep a separate status.
-It also allows developers to mark the PRs themselves, and have this automated
-process take their labels into account.
+## Labelling rules (applies to both steps)
 
-We're using two labels:
+Using labels marks the progression of PRs towards merging, so the command can be
+re-run without keeping external state. Developers can also set labels manually and
+this process will respect them.
 
-- `ok-to-test` is used to make our automated tests run on the PR.
-- `lgtm` is used to mark the PR as ready to merge.
+Labels used:
 
-The rule typically is:
+- `ok-to-test`: triggers automated CI on the PR.
+- `lgtm`: marks the PR as ready to merge.
 
-- if a PR doesn't have "ok-to-test", set the "ok-to-test" label **and post a
-  `/ok-to-test` comment**. Some bots monitoring PRs only react to maintainer
-  comments, not to label additions alone, so both actions are required.
-- if a PR has "ok-to-test" AND `build_checks_passed` is true AND `pending_checks` is 0,
-  set the "lgtm" label. (`build_checks_passed` excludes enterprise-contract checks that
-  return `NEUTRAL` — do not use `all_checks_passed` as it gives false negatives.)
+Rules:
+
+- If a PR does NOT have `ok-to-test`, set it **and** post a `/ok-to-test` comment.
+  Some bots only react to maintainer comments, not label additions alone.
+- If a PR has `ok-to-test` AND `build_checks_passed` is `true` AND `pending_checks`
+  is `0`, set `lgtm`. (`build_checks_passed` excludes enterprise-contract checks
+  that return `NEUTRAL` — do NOT use `all_checks_passed`.)
 
 Labelling can be done in parallel for all PRs from all repositories, as there
-is no conflict with "on-pull-request" pipelines running in parallel.
+is no conflict between "on-pull-request" pipelines running concurrently.
 
 Note that Nudge PRs in the osc repository are configured to auto-merge when
-the tests are passing. Setting the "ok-to-test" label on those PRs is then the
-only required labelling. But it means we have to look for the merge pipeline
-when the PR auto-merges, and make sure it succeeds (see [merging](#merging)).
+tests pass. Setting `ok-to-test` on those PRs is therefore the only required
+label. Track the merge pipeline when the PR auto-merges to confirm success
+(see [merging](#merging)).
+
+## Step 1 - Mintmaker PR processing
+
+**Only executed when `--step1` is passed.**
+
+1. Call `list-prs.sh --mintmaker` to discover open Mintmaker PRs.
+2. For each Mintmaker PR, apply labelling rules above.
+3. Report which PRs received labels and which are still waiting for checks.
+
+Do NOT touch Nudge PRs during Step 1.
+
+## Step 2 - Nudge PR processing
+
+**Only executed when `--step2` is passed.**
+
+Nudge PRs must only be processed when we are certain that no open Mintmaker PR
+will trigger a rebuild of the same source component. If a Mintmaker PR would
+rebuild component C, and a Nudge PR carries an updated reference for C, merging
+the Nudge PR now would be immediately obsoleted by the Mintmaker rebuild.
+
+### Step 2 algorithm
+
+**Phase A — Build the "Mintmaker-blocked" component set**
+
+1. Call `list-prs.sh --mintmaker` to get all open Mintmaker PRs.
+2. For each Mintmaker PR, call `get-pr-status.sh` and collect its `components`
+   array (the components that will be rebuilt when that PR is merged).
+3. Union all these component arrays into a single set:
+   `mintmaker_rebuilding_components`.
+
+**Phase B — Filter and process Nudge PRs**
+
+1. Call `list-prs.sh --nudge` to get all open Nudge PRs.
+2. For each Nudge PR, identify the **source component** — the component whose
+   reference was updated — by matching known component names against the PR title.
+   (Nudge PR titles contain the source component name, e.g.
+   "chore(deps): update osc-monitor …".)
+   Use `get-component-info.sh` (no args) to get the full list of component names
+   to match against.
+3. If the source component is in `mintmaker_rebuilding_components`: **skip** this
+   Nudge PR and note it as "blocked by open Mintmaker PR". Do NOT label it.
+4. If the source component is NOT in `mintmaker_rebuilding_components`: apply the
+   labelling rules above to this Nudge PR.
+
+**Phase C — Report**
+
+Show two groups:
+- Nudge PRs processed (with actions taken or their current label/check status).
+- Nudge PRs skipped (with the reason: which open Mintmaker PR blocks them and
+  which component it will rebuild).
 
 ## Merging
 
-PRs are ready to merge when they have the label "lgtm" and all the checks are
-passing.
+PRs are ready to merge when they have `lgtm` and all checks are passing.
 
-We need to be careful when merging a PR: each time we merge a PR, we need to verify
-that the on-push pipelines (triggered when we merge) are successful before merging
-another PR that rebuilds the same component.
+We need to be careful when merging a PR: each merge triggers on-push pipelines
+that rebuild the component. A second PR for the same component must not be merged
+until those pipelines succeed.
 
 The checks that run on the pull request itself include Konflux pipeline builds.
 The same pipelines will run on-push when the PR is merged. It is then possible
@@ -242,7 +302,7 @@ wait for their completion before merging another PR for the same component.
 
 When the on-push pipeline is successful, a Nudge PR can be created.
 If the Nudge PR already exists, it is updated every time the same component is rebuilt.
-We then let the Nudge PRs opened as long as we are processing Mintmaker PRs, and
+We then let the Nudge PRs open as long as we are processing Mintmaker PRs, and
 process the Nudge PRs as a second step, to avoid unnecessary rebuilds.
 Use `get-component-info.sh` to see which components are nudged when a component is rebuilt.
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -218,11 +218,17 @@ Labels used:
 
 Rules:
 
-- If a PR does NOT have `ok-to-test`, set it **and** post a `/ok-to-test` comment.
-  Some bots only react to maintainer comments, not label additions alone.
-- If a PR has `ok-to-test` AND `build_checks_passed` is `true` AND `pending_checks`
-  is `0`, set `lgtm`. (`build_checks_passed` excludes enterprise-contract checks
-  that return `NEUTRAL` — do NOT use `all_checks_passed`.)
+Both rules are evaluated against the **state returned by `get-pr-status.sh` at the
+start of this run** — the snapshot is fixed before any labels are applied. Applying
+`ok-to-test` in this run does NOT qualify the same PR for `lgtm` in the same run,
+because `ok-to-test` triggers new CI pipelines whose results are not yet known.
+
+- If `has_ok_to_test` is `false` in the snapshot, set `ok-to-test` **and** post a
+  `/ok-to-test` comment. Some bots only react to maintainer comments, not label
+  additions alone. Stop here for this PR — do NOT also set `lgtm`.
+- If `has_ok_to_test` is `true` in the snapshot AND `build_checks_passed` is `true`
+  AND `pending_checks` is `0`, set `lgtm`. (`build_checks_passed` excludes
+  enterprise-contract checks that return `NEUTRAL` — do NOT use `all_checks_passed`.)
 
 Labelling can be done in parallel for all PRs from all repositories, as there
 is no conflict between "on-pull-request" pipelines running concurrently.
@@ -327,13 +333,12 @@ Implemented in `list-prs.sh --mintmaker`:
 
 - status is "open"
 - author is the "app/red-hat-konflux" bot
-- title starts with one of the following:
+- title matches one of the following patterns (note: generalised to avoid missing new image types):
 
-  - "chore(deps): update konflux references"
-  - "chore(deps): update registry.access.redhat.com/ubi9/ubi"
-  - "chore(deps): update registry.access.redhat.com/ubi9/go-toolset"
-  - "chore(deps): update registry.access.redhat.com/ubi10/ubi"
-  - "chore(deps): update registry.access.redhat.com/ubi10/go-toolset"
+  - starts with `"chore(deps): update konflux references"` or `"Update Konflux references"`
+  - starts with `"chore(deps): update registry.access.redhat.com/ubi9/"` (any ubi9 image)
+  - starts with `"chore(deps): update registry.access.redhat.com/ubi10/"` (any ubi10 image)
+  - starts with `"Update registry.access.redhat.com/ubi9/"` or `"Update registry.access.redhat.com/ubi10/"`
 
 # Nudge PRs filter
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -15,6 +15,15 @@ Process the pull requests from Mintmaker and Konflux
 
 # Implementation Requirements
 
+**CRITICAL: Parameter-gated behavior**: The command behavior is strictly controlled by parameters:
+
+- **No parameter**: ONLY list PRs. For each PR, show which images will be rebuilt and the
+  suggested action (see [Status output format](#status-output-format)). Do NOT label or merge.
+- **`--label`**: ONLY perform labelling steps. Do NOT merge.
+- **`--dry-run`**: Show what would be done. Do NOT label or merge.
+
+**This skill is in development and must NEVER merge any PR.**
+
 **CRITICAL**: Always query fresh data. Never use PR numbers from previous runs or earlier in the conversation.
 
 When implementing this skill:
@@ -108,22 +117,6 @@ Get component metadata.
 ```
 Output: JSON with {name, repository, build_time_minutes, nudges}
 
-# Usage
-
-Without any parameter, the command will list the PRs from the different repositories,
-and state for each PR which images will be rebuilt if the PR is merged. It will
-also provide the suggested action for each PR.
-See [Status output format](#status-output-format) for details.
-
-With the --label parameter, the command will only perform the "labelling" steps,
-and not merge any PR.
-
-With the --dry-run parameter, the command will show the commands it would execute,
-but will not label nor merge any PR.
-
-At this point, this skill is considered to be "in development" and should NEVER
-merge any PR.
-
 # Workflow definition
 
 We receive two types of pull requests from Konflux:
@@ -142,6 +135,8 @@ The processing of each PR is done in two steps: labelling, and merging.
 
 ## Labelling
 
+**Only performed when `--label` parameter is passed. Skip entirely otherwise.**
+
 Using labels allows to mark the progression of PRs towards merging, making it
 possible to run the command multiple time, and continue the processing without
 having to keep a separate status.
@@ -149,6 +144,7 @@ It also allows developers to mark the PRs themselves, and have this automated
 process take their labels into account.
 
 We're using two labels:
+
 - `ok-to-test` is used to make our automated tests run on the PR.
 - `lgtm` is used to mark the PR as ready to merge.
 
@@ -208,9 +204,11 @@ and stop processing any other PR related to the same component.
 # Mintmaker PRs filter
 
 Implemented in `list-prs.sh --mintmaker`:
+
 - status is "open"
 - author is the "app/red-hat-konflux" bot
 - title starts with one of the following:
+
   - "chore(deps): update konflux references"
   - "chore(deps): update registry.access.redhat.com/ubi9/ubi"
   - "chore(deps): update registry.access.redhat.com/ubi9/go-toolset"
@@ -220,6 +218,7 @@ Implemented in `list-prs.sh --mintmaker`:
 # Nudge PRs filter
 
 Implemented in `list-prs.sh --nudge`:
+
 - status is "open"
 - author is the "app/red-hat-konflux" bot
 - label "konflux-nudge" is set

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -89,7 +89,8 @@ Add a label to a PR.
 ./label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
 ```
 Labels: "ok-to-test" or "lgtm"
-Output: JSON with {success, repo, pr, label}
+Output: JSON with {success, repo, pr, label, comment}
+Note: when label is "ok-to-test", also posts a `/ok-to-test` comment; `comment` indicates whether it succeeded.
 
 ## check-pipeline-status.sh
 Check Konflux pipeline status.
@@ -150,7 +151,9 @@ We're using two labels:
 
 The rule typically is:
 
-- if a PR don't have "ok-to-test", set the "ok-to-test" label
+- if a PR doesn't have "ok-to-test", set the "ok-to-test" label **and post a
+  `/ok-to-test` comment**. Some bots monitoring PRs only react to maintainer
+  comments, not to label additions alone, so both actions are required.
 - if a PR has "ok-to-test" AND all the checks are passing, set the "lgtm" label
 
 Labelling can be done in parallel for all PRs from all repositories, as there

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -2,17 +2,18 @@
 name: process-konflux-prs
 description: Look at pull requests created by the Konflux bot and manage them, optimizing their merge to avoid repetitive builds.
 allowed-tools:
-  - Bash(scripts/process-konflux-prs/snapshot-prs.sh*)
-  - Bash(scripts/process-konflux-prs/list-prs.sh*)
-  - Bash(scripts/process-konflux-prs/get-pr-status.sh*)
-  - Bash(scripts/process-konflux-prs/get-pr-components.sh*)
-  - Bash(scripts/process-konflux-prs/label-pr.sh*)
-  - Bash(scripts/process-konflux-prs/merge-pr.sh*)
-  - Bash(scripts/process-konflux-prs/skip-pr.sh*)
-  - Bash(scripts/process-konflux-prs/check-pipeline-status.sh*)
-  - Bash(scripts/process-konflux-prs/check-merge-safety.sh*)
-  - Bash(scripts/process-konflux-prs/get-nudge-prs.sh*)
-  - Bash(scripts/process-konflux-prs/get-component-info.sh*)
+  - Bash(scripts/process-konflux-prs/snapshot-prs.sh *)
+  - Bash(scripts/process-konflux-prs/list-prs.sh *)
+  - Bash(scripts/process-konflux-prs/get-pr-status.sh *)
+  - Bash(scripts/process-konflux-prs/get-pr-components.sh *)
+  - Bash(scripts/process-konflux-prs/label-pr.sh *)
+  - Bash(scripts/process-konflux-prs/merge-pr.sh *)
+  - Bash(scripts/process-konflux-prs/skip-pr.sh *)
+  - Bash(scripts/process-konflux-prs/check-pipeline-status.sh *)
+  - Bash(scripts/process-konflux-prs/check-merge-safety.sh *)
+  - Bash(scripts/process-konflux-prs/get-nudge-prs.sh *)
+  - Bash(scripts/process-konflux-prs/get-component-info.sh)
+  - Bash(scripts/process-konflux-prs/get-component-info.sh *)
 ---
 
 Process the pull requests from Mintmaker and Konflux
@@ -584,7 +585,7 @@ When the PR is merged, a similar pipelinerun will start, with pattern:
 
 # Status output format
 
-When run with the "--status" parameter, the result should be displayed on the
+When run with no parameter (list-only mode), the result should be displayed on the
 terminal (if available) and saved under the local folder as a markdown file with
 a timestamp in the filename for easy filtering (like: "YYYYMMDD-Konflux-PR-status.md").
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -399,14 +399,17 @@ complete image with all component updates.
 5. For each group:
 
    **Group has multiple open PRs:**
+   The **held-back PR** for a multi-PR group is always the **lowest-numbered open PR**,
+   regardless of its label state. It is kept last so that its on-push pipeline runs
+   uncontested after all peers have merged.
    - Identify PRs with `has_ok_to_test: false` (not yet labeled).
    - If **2 or more** PRs have `has_ok_to_test: false`: apply `ok-to-test` to all
-     except the **lowest-numbered** one. The lowest-numbered becomes the **held-back
-     PR** for this group. Do NOT label it this run.
+     except the lowest-numbered (the held-back PR). Do NOT label the held-back PR.
    - If **exactly one** PR has `has_ok_to_test: false` and the rest have
-     `has_ok_to_test: true` (still open, not yet merged): the held-back PR is waiting
-     for its peers to merge first. Do NOT label it — leave it for the next run.
+     `has_ok_to_test: true` (still open, not yet merged): that sole unlabeled PR is
+     the held-back PR waiting for its peers to merge first. Do NOT label it.
    - If **all** PRs have `has_ok_to_test: true`: all are in flight; nothing to label.
+     The lowest-numbered is still implicitly the held-back PR (Phase C will not merge it).
 
    **Group has exactly one open PR** (all peers have merged — they are no longer in
    the snapshot):
@@ -425,15 +428,25 @@ All other PRs require explicit merging:
 - PRs from non-osc repositories (compute-artifacts, podvm-scripts).
 - osc PRs with `base_branch != "devel"` (e.g. targeting `osc-release-v1.12`).
 
-For each such PR where the **initial snapshot** shows `has_ok_to_test: true`
-AND `build_checks_passed: true` AND `pending_checks: 0` AND the PR is **not currently
-designated as held-back** (i.e., it is not the sole unlabeled PR in a multi-PR group):
+For each group that requires explicit merging, process as follows:
 
-- Call `check-merge-safety.sh --components "<components>"`. If `safe_to_merge` is
-  `false`, skip and report as "blocked by running on-push pipeline".
-- Apply `lgtm` label.
-- Merge using `merge-pr.sh`. Within a single run, do NOT merge two PRs that rebuild
-  the same component — the second must wait for the next run.
+**Single-PR group** (solo or held-back PR whose peers have all merged): merge it if
+`has_ok_to_test: true` AND `build_checks_passed: true` AND `pending_checks: 0` AND
+`check-merge-safety` passes.
+
+**Multi-PR group**: the held-back PR is the **lowest-numbered open PR** in the group.
+For all other PRs where the **initial snapshot** shows `has_ok_to_test: true`
+AND `build_checks_passed: true` AND `pending_checks: 0`:
+- Call `check-merge-safety.sh --components "<components>"` **once** before merging
+  any PR in the group. If `safe_to_merge` is `false`, skip the entire group and report
+  as "blocked by running on-push pipeline".
+- Apply `lgtm` and merge **all** eligible PRs in this single run. Merging multiple PRs
+  from the same group in one run is intentional: their on-push pipelines will race, but
+  the held-back PR's final pipeline (merged in a later run once all pipelines complete)
+  produces the definitive image containing all component updates.
+- The held-back PR (lowest-numbered) is NOT merged this run. It is processed in a
+  subsequent run once all peers have merged and check-merge-safety passes (Phase B
+  solo-group path).
 
 **Phase D — Report**
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -266,6 +266,14 @@ After all labelling is complete, merge PRs that were **already ready before this
 - Do NOT merge a PR that received `lgtm` during this run's Phase A — the same
   snapshot principle applies: lgtm was just set, so this is its first eligible run,
   not a confirmed-ready state from a prior run.
+- **Pre-merge pipeline check**: Before merging a PR, for each component in the
+  snapshot's `components` array, call:
+  ```bash
+  ./scripts/process-konflux-prs/check-pipeline-status.sh --component COMPONENT_NAME
+  ```
+  (defaults to `--type on-push`). If `latest` is non-null AND `latest.completionTime`
+  is null, an on-push pipeline for that component is still running. **Skip this PR**
+  and report it as "blocked by running on-push pipeline". Do NOT merge it.
 - Merge PRs one at a time using `merge-pr.sh`. After each merge, note which
   components will be rebuilt (from the snapshot's `components` field).
 - Within a single run, do NOT merge two PRs that rebuild the same component —
@@ -278,7 +286,7 @@ After all labelling is complete, merge PRs that were **already ready before this
 Report three groups:
 - PRs labelled in this run (ok-to-test or lgtm added).
 - PRs merged in this run.
-- PRs waiting (checks pending, build failed, or blocked by a same-component merge).
+- PRs waiting (checks pending, build failed, blocked by a running on-push pipeline, or blocked by a same-component merge in this run).
 
 Do NOT touch Nudge PRs during Step 1.
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -6,6 +6,7 @@ allowed-tools:
   - Bash(scripts/process-konflux-prs/get-pr-status.sh*)
   - Bash(scripts/process-konflux-prs/get-pr-components.sh*)
   - Bash(scripts/process-konflux-prs/label-pr.sh*)
+  - Bash(scripts/process-konflux-prs/merge-pr.sh*)
   - Bash(scripts/process-konflux-prs/check-pipeline-status.sh*)
   - Bash(scripts/process-konflux-prs/get-nudge-prs.sh*)
   - Bash(scripts/process-konflux-prs/get-component-info.sh*)
@@ -19,8 +20,9 @@ Process the pull requests from Mintmaker and Konflux
 
 - **No parameter**: ONLY list PRs. For each PR, show which images will be rebuilt and the
   suggested action (see [Status output format](#status-output-format)). Do NOT label or merge.
-- **`--mintmaker`**: Process Mintmaker PRs ONLY. Apply labels (ok-to-test, lgtm). Do NOT touch
-  Nudge PRs. Do NOT merge.
+- **`--mintmaker`**: Process Mintmaker PRs ONLY. Apply labels (ok-to-test, lgtm), then merge
+  PRs that are ready (see [Step 1 - Mintmaker PR processing](#step-1---mintmaker-pr-processing)).
+  Do NOT touch Nudge PRs.
 - **`--nudge`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
   [Step 2 - Nudge PR processing](#step-2---nudge-pr-processing)). Do NOT touch Mintmaker PRs.
   Do NOT merge.
@@ -29,8 +31,6 @@ Process the pull requests from Mintmaker and Konflux
 
 `--mintmaker` and `--nudge` are mutually exclusive. If neither is given, only list/status output
 is produced.
-
-**This skill is in development and must NEVER merge any PR.**
 
 **CRITICAL**: Always query fresh data. Never use PR numbers from previous runs or earlier in the conversation.
 
@@ -155,6 +155,14 @@ Labels: "ok-to-test" or "lgtm"
 Output: JSON with {success, repo, pr, label, comment}
 Note: when label is "ok-to-test", also posts a `/ok-to-test` comment; `comment` indicates whether it succeeded.
 
+## merge-pr.sh
+Merge a PR using the merge (non-squash) strategy.
+```bash
+./scripts/process-konflux-prs/merge-pr.sh --repo REPO_NAME --pr PR_NUMBER
+```
+Output: JSON with {success, repo, pr, message}
+Note: deletes the source branch after merging.
+
 ## check-pipeline-status.sh
 Check Konflux pipeline status.
 ```bash
@@ -242,9 +250,35 @@ label. Track the merge pipeline when the PR auto-merges to confirm success
 
 **Only executed when `--mintmaker` is passed.**
 
+### Phase A — Labelling
+
 1. Call `list-prs.sh --mintmaker` to discover open Mintmaker PRs.
-2. For each Mintmaker PR, apply labelling rules above.
-3. Report which PRs received labels and which are still waiting for checks.
+2. Fetch status for all PRs with `get-pr-status.sh` and record the **initial snapshot**
+   (this snapshot is fixed; it must not be refreshed during the same run).
+3. For each Mintmaker PR, apply labelling rules above.
+
+### Phase B — Merging
+
+After all labelling is complete, merge PRs that were **already ready before this run**:
+
+- A PR is eligible to merge if, in the **initial snapshot**: `has_lgtm` is `true`
+  AND `build_checks_passed` is `true` AND `pending_checks` is `0`.
+- Do NOT merge a PR that received `lgtm` during this run's Phase A — the same
+  snapshot principle applies: lgtm was just set, so this is its first eligible run,
+  not a confirmed-ready state from a prior run.
+- Merge PRs one at a time using `merge-pr.sh`. After each merge, note which
+  components will be rebuilt (from the snapshot's `components` field).
+- Within a single run, do NOT merge two PRs that rebuild the same component —
+  the second one must wait for the on-push pipeline triggered by the first to complete.
+  Leave it for the next run.
+- Use `merge-pr.sh --repo REPO_NAME --pr PR_NUMBER` to merge.
+
+### Phase C — Report
+
+Report three groups:
+- PRs labelled in this run (ok-to-test or lgtm added).
+- PRs merged in this run.
+- PRs waiting (checks pending, build failed, or blocked by a same-component merge).
 
 Do NOT touch Nudge PRs during Step 1.
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -28,7 +28,7 @@ Process the pull requests from Mintmaker and Konflux
   Do NOT touch Nudge PRs.
 - **`--nudge`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
   [Step 2 - Nudge PR processing](#step-2---nudge-pr-processing)). Do NOT touch Mintmaker PRs.
-  Merges non-osc nudge PRs when checks pass (osc nudge PRs auto-merge on their own).
+  Merges nudge PRs that do not auto-merge (non-osc repos, and osc PRs not targeting `devel`).
 - **`--dry-run`**: Show what would be done. Do NOT label or merge. Can be combined with
   `--mintmaker` or `--nudge` to preview that specific step.
 
@@ -132,6 +132,7 @@ Output: JSON array of status objects, one per PR:
 ```json
 [{
   "repo": "osc", "pr": 1234, "title": "…",
+  "base_branch": "devel",
   "components": ["osc-operator"],
   "build_checks_passed": true,
   "build_checks_failed": [],
@@ -279,10 +280,12 @@ because `ok-to-test` triggers new CI pipelines whose results are not yet known.
 Labelling can be done in parallel for all PRs from all repositories, as there
 is no conflict between "on-pull-request" pipelines running concurrently.
 
-Note that Nudge PRs in the osc repository are configured to auto-merge when
-tests pass. Setting `ok-to-test` on those PRs is therefore the only required
-label. Track the merge pipeline when the PR auto-merges to confirm success
-(see [merging](#merging)).
+Note that Nudge PRs in the osc repository targeting the **`devel` branch** are
+configured to auto-merge when tests pass. Setting `ok-to-test` on those PRs is
+therefore the only required label. Nudge PRs in osc targeting any other branch
+(e.g. `osc-release-v1.12`) do NOT auto-merge and must be treated the same as
+PRs from non-osc repositories (explicit lgtm + merge). Track the merge pipeline
+when a PR auto-merges to confirm success (see [merging](#merging)).
 
 ## Step 1 - Mintmaker PR processing
 
@@ -415,13 +418,14 @@ complete image with all component updates.
    - If `safe_to_merge: false`: **do not label**. Report as "waiting for on-push
      pipelines to complete" and include the `blocking` list. Revisit next run.
 
-**Phase C — Merge non-osc Nudge PRs**
+**Phase C — Merge PRs that do not auto-merge**
 
-Nudge PRs in the osc repository auto-merge once checks pass. Nudge PRs in other
-repositories (compute-artifacts, podvm-scripts) do not auto-merge and require
-explicit merging.
+Only osc Nudge PRs with `base_branch == "devel"` auto-merge when tests pass.
+All other PRs require explicit merging:
+- PRs from non-osc repositories (compute-artifacts, podvm-scripts).
+- osc PRs with `base_branch != "devel"` (e.g. targeting `osc-release-v1.12`).
 
-For each non-osc Nudge PR where the **initial snapshot** shows `has_ok_to_test: true`
+For each such PR where the **initial snapshot** shows `has_ok_to_test: true`
 AND `build_checks_passed: true` AND `pending_checks: 0` AND the PR is **not currently
 designated as held-back** (i.e., it is not the sole unlabeled PR in a multi-PR group):
 

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -116,6 +116,19 @@ Enterprise-contract checks legitimately return `NEUTRAL` and are excluded from
 `build_checks_passed`. If `pending_checks > 0`, checks are still running — wait for
 the next run.
 
+## label-pr.sh output and error handling
+
+`label-pr.sh` outputs a single JSON object. Do **not** try to parse anything else
+from its output — the underlying `gh` command occasionally prints extra text to
+stdout that is now suppressed, but if a future version leaks text before the JSON,
+a display-layer `jq` parse error does **not** mean the label was not applied.
+
+**When a batch labeling loop produces jq parse errors:**
+1. Do NOT re-run `label-pr.sh` for the same PR — the label may already be set.
+2. Continue to the next phase (e.g. apply `lgtm` after the `ok-to-test` batch).
+3. If verification is needed, use `get-pr-status.sh` to check the current label
+   state — never infer failure from display-layer errors alone.
+
 ## get-pr-components.sh
 Identify components that will be rebuilt (excludes enterprise-contract validation checks).
 ```bash

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -33,9 +33,12 @@ When implementing this skill:
 3. **Never hardcode PR numbers**: Do not use PR numbers from memory, previous runs, or earlier conversation turns
 4. **Verify state before processing**: Use `get-pr-status.sh` to verify PR state before taking action
 
+All scripts must be called from the **repository root** using the full relative path
+`./scripts/process-konflux-prs/<script>.sh`. Never `cd` into the scripts directory.
+
 Example correct workflow:
 ```bash
-# CORRECT: Discover PRs dynamically
+# CORRECT: call from repo root, discover PRs dynamically
 prs=$(./scripts/process-konflux-prs/list-prs.sh --mintmaker)
 for pr in $(echo "$prs" | jq -c '.[]'); do
   repo=$(echo "$pr" | jq -r '.repo')
@@ -46,6 +49,21 @@ done
 # WRONG: Using hardcoded or remembered PR numbers
 for pr_num in 2147 2146 2144 2143; do  # ❌ Never do this
   # ...
+done
+```
+
+**Efficiency**: fetch status for all PRs in a **single bash loop** rather than one tool
+call per PR. For N PRs, one loop invocation avoids N round-trips:
+
+```bash
+# Fetch status + components for every PR in one bash call
+mintmaker_prs=$(./scripts/process-konflux-prs/list-prs.sh --mintmaker)
+echo "$mintmaker_prs" | jq -c '.[]' | while read -r pr; do
+  repo=$(echo "$pr" | jq -r '.repo')
+  number=$(echo "$pr" | jq -r '.number')
+  status=$(./scripts/process-konflux-prs/get-pr-status.sh --repo "$repo" --pr "$number" 2>/dev/null)
+  echo "$status" | jq --arg repo "$repo" \
+    '{repo: $repo, pr: .number, components, build_checks_passed, build_checks_failed, pending_checks, has_ok_to_test, has_lgtm}'
 done
 ```
 
@@ -65,28 +83,52 @@ All scripts are located in `scripts/process-konflux-prs/` and output JSON.
 ## list-prs.sh
 List Konflux PRs from repositories.
 ```bash
-./list-prs.sh [--mintmaker|--nudge] [--repo REPO_NAME]
+./scripts/process-konflux-prs/list-prs.sh [--mintmaker|--nudge] [--repo REPO_NAME]
 ```
-Output: JSON array with {number, title, url, repo, type}
+Output: JSON array with `{number, title, url, repo, type}`
 
 ## get-pr-status.sh
-Get PR status including checks and labels.
+Get PR status including checks, labels, and rebuilt components — **one call replaces a
+separate `get-pr-components.sh` call**.
 ```bash
-./get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
+./scripts/process-konflux-prs/get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
 ```
-Output: JSON with {number, title, state, labels, checks, has_ok_to_test, has_lgtm, all_checks_passed, pending_checks}
+Output: JSON object — exact shape:
+```json
+{
+  "number": 1234,
+  "title": "chore(deps): update …",
+  "state": "OPEN",
+  "labels": ["ok-to-test"],          // array of strings, NOT objects
+  "has_ok_to_test": true,
+  "has_lgtm": false,
+  "components": ["osc-operator"],    // rebuilt components (from build pipeline checks)
+  "build_checks_passed": true,       // true only when all build pipeline checks are SUCCESS
+                                     // enterprise-contract checks (conclusion=NEUTRAL) excluded
+  "build_checks_failed": [],         // names of build checks with FAILURE conclusion
+  "pending_checks": 0,               // integer count of IN_PROGRESS/QUEUED checks
+  "checks": [...]                    // raw checks array, null entries filtered
+}
+```
+
+**Use `build_checks_passed` (not `all_checks_passed`) to determine if a PR is ready.**
+Enterprise-contract checks legitimately return `NEUTRAL` and are excluded from
+`build_checks_passed`. If `pending_checks > 0`, checks are still running — wait for
+the next run.
 
 ## get-pr-components.sh
 Identify components that will be rebuilt (excludes enterprise-contract validation checks).
 ```bash
-./get-pr-components.sh --repo REPO_NAME --pr PR_NUMBER
+./scripts/process-konflux-prs/get-pr-components.sh --repo REPO_NAME --pr PR_NUMBER
 ```
-Output: JSON array of component names
+Output: JSON array of component names.
+**Note:** `get-pr-status.sh` already returns `components` — prefer using that to avoid
+a redundant GitHub API call.
 
 ## label-pr.sh
 Add a label to a PR.
 ```bash
-./label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
+./scripts/process-konflux-prs/label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
 ```
 Labels: "ok-to-test" or "lgtm"
 Output: JSON with {success, repo, pr, label, comment}
@@ -96,10 +138,10 @@ Note: when label is "ok-to-test", also posts a `/ok-to-test` comment; `comment` 
 Check Konflux pipeline status.
 ```bash
 # For on-push (default)
-./check-pipeline-status.sh --component COMPONENT_NAME
+./scripts/process-konflux-prs/check-pipeline-status.sh --component COMPONENT_NAME
 
 # For on-pull-request (--pr-id REQUIRED)
-./check-pipeline-status.sh --component COMPONENT_NAME --type on-pull-request --pr-id PR_ID
+./scripts/process-konflux-prs/check-pipeline-status.sh --component COMPONENT_NAME --type on-pull-request --pr-id PR_ID
 ```
 Output: JSON with {component, pipeline_type, latest, all_runs}
 Note: --pr-id is mandatory for on-pull-request to avoid matching runs from different PRs
@@ -107,14 +149,14 @@ Note: --pr-id is mandatory for on-pull-request to avoid matching runs from diffe
 ## get-nudge-prs.sh
 Find nudge PRs for a component.
 ```bash
-./get-nudge-prs.sh --component COMPONENT_NAME
+./scripts/process-konflux-prs/get-nudge-prs.sh --component COMPONENT_NAME
 ```
 Output: JSON array of nudge PRs
 
 ## get-component-info.sh
 Get component metadata.
 ```bash
-./get-component-info.sh [--component COMPONENT_NAME]
+./scripts/process-konflux-prs/get-component-info.sh [--component COMPONENT_NAME]
 ```
 Output: JSON with {name, repository, build_time_minutes, nudges}
 
@@ -154,7 +196,9 @@ The rule typically is:
 - if a PR doesn't have "ok-to-test", set the "ok-to-test" label **and post a
   `/ok-to-test` comment**. Some bots monitoring PRs only react to maintainer
   comments, not to label additions alone, so both actions are required.
-- if a PR has "ok-to-test" AND all the checks are passing, set the "lgtm" label
+- if a PR has "ok-to-test" AND `build_checks_passed` is true AND `pending_checks` is 0,
+  set the "lgtm" label. (`build_checks_passed` excludes enterprise-contract checks that
+  return `NEUTRAL` — do not use `all_checks_passed` as it gives false negatives.)
 
 Labelling can be done in parallel for all PRs from all repositories, as there
 is no conflict with "on-pull-request" pipelines running in parallel.

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -19,15 +19,15 @@ Process the pull requests from Mintmaker and Konflux
 
 - **No parameter**: ONLY list PRs. For each PR, show which images will be rebuilt and the
   suggested action (see [Status output format](#status-output-format)). Do NOT label or merge.
-- **`--step1`**: Process Mintmaker PRs ONLY. Apply labels (ok-to-test, lgtm). Do NOT touch
+- **`--mintmaker`**: Process Mintmaker PRs ONLY. Apply labels (ok-to-test, lgtm). Do NOT touch
   Nudge PRs. Do NOT merge.
-- **`--step2`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
+- **`--nudge`**: Process Nudge PRs ONLY, with the Mintmaker safeguard (see
   [Step 2 - Nudge PR processing](#step-2---nudge-pr-processing)). Do NOT touch Mintmaker PRs.
   Do NOT merge.
 - **`--dry-run`**: Show what would be done. Do NOT label or merge. Can be combined with
-  `--step1` or `--step2` to preview that specific step.
+  `--mintmaker` or `--nudge` to preview that specific step.
 
-`--step1` and `--step2` are mutually exclusive. If neither is given, only list/status output
+`--mintmaker` and `--nudge` are mutually exclusive. If neither is given, only list/status output
 is produced.
 
 **This skill is in development and must NEVER merge any PR.**
@@ -196,8 +196,8 @@ See the [list of components](#list-of-components) for nudge relationships.
 
 **The workflow is two separate steps, run independently:**
 
-1. **Step 1 — Mintmaker PRs** (`--step1`): label and advance Mintmaker PRs.
-2. **Step 2 — Nudge PRs** (`--step2`): label and advance Nudge PRs, but ONLY
+1. **Step 1 — Mintmaker PRs** (`--mintmaker`): label and advance Mintmaker PRs.
+2. **Step 2 — Nudge PRs** (`--nudge`): label and advance Nudge PRs, but ONLY
    those that are safe to process (see below).
 
 Merging Mintmaker PRs triggers component rebuilds, which in turn refresh the
@@ -240,7 +240,7 @@ label. Track the merge pipeline when the PR auto-merges to confirm success
 
 ## Step 1 - Mintmaker PR processing
 
-**Only executed when `--step1` is passed.**
+**Only executed when `--mintmaker` is passed.**
 
 1. Call `list-prs.sh --mintmaker` to discover open Mintmaker PRs.
 2. For each Mintmaker PR, apply labelling rules above.
@@ -250,7 +250,7 @@ Do NOT touch Nudge PRs during Step 1.
 
 ## Step 2 - Nudge PR processing
 
-**Only executed when `--step2` is passed.**
+**Only executed when `--nudge` is passed.**
 
 Nudge PRs must only be processed when we are certain that no open Mintmaker PR
 will trigger a rebuild of the same source component. If a Mintmaker PR would

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -8,6 +8,7 @@ allowed-tools:
   - Bash(scripts/process-konflux-prs/get-pr-components.sh*)
   - Bash(scripts/process-konflux-prs/label-pr.sh*)
   - Bash(scripts/process-konflux-prs/merge-pr.sh*)
+  - Bash(scripts/process-konflux-prs/skip-pr.sh*)
   - Bash(scripts/process-konflux-prs/check-pipeline-status.sh*)
   - Bash(scripts/process-konflux-prs/get-nudge-prs.sh*)
   - Bash(scripts/process-konflux-prs/get-component-info.sh*)
@@ -171,6 +172,14 @@ Labels: "ok-to-test" or "lgtm"
 Output: JSON with {success, repo, pr, label, comment}
 Note: when label is "ok-to-test", also posts a `/ok-to-test` comment; `comment` indicates whether it succeeded.
 
+## skip-pr.sh
+Mark a PR as intentionally skipped: adds the `mintmaker-skip` label and posts an
+explanatory comment. The label prevents re-posting on subsequent runs.
+```bash
+./scripts/process-konflux-prs/skip-pr.sh --repo REPO_NAME --pr PR_NUMBER --reason "reason"
+```
+Output: JSON with {success, repo, pr, message}
+
 ## merge-pr.sh
 Merge a PR using the merge (non-squash) strategy.
 ```bash
@@ -266,12 +275,34 @@ label. Track the merge pipeline when the PR auto-merges to confirm success
 
 **Only executed when `--mintmaker` is passed.**
 
+### Phase 0 — Skip filter
+
+Before labelling or merging, identify PRs that match a known skip pattern and remove
+them from the processing set.
+
+**Known skip patterns:**
+
+- **go-toolset major-version-only tag**: title contains `ubi9/go-toolset` AND the tag
+  is a bare major version (e.g. `v9`, `v10`) with no Go version number.
+  Detection: title matches `ubi9/go-toolset` AND ends with `tag to v<N>` where `<N>`
+  is a single integer (no dots). Example: `"Update ubi9/go-toolset Docker tag to v9"`.
+  *Why*: we pin `ubi9/go-toolset` to the Go version tag (e.g. `v1.26.4-...`), not the
+  image's own major version. A separate PR with the correct Go version tag will arrive.
+
+For each PR matching a skip pattern:
+- If `has_mintmaker_skip` is `false` in the snapshot: call `skip-pr.sh` with an
+  appropriate `--reason` explaining the skip. This posts a comment and adds the
+  `mintmaker-skip` label so subsequent runs skip it silently.
+- Remove the PR from the snapshot used in Phase A and Phase B (do not label or merge it,
+  regardless of `has_mintmaker_skip`).
+
 ### Phase A — Labelling
 
 1. Call `snapshot-prs.sh --mintmaker` to discover open Mintmaker PRs and fetch their
    status in one pass. Record the result as the **initial snapshot** (this snapshot is
    fixed; it must not be refreshed during the same run).
-2. For each entry in the snapshot, apply labelling rules above.
+2. Run Phase 0 to remove skip-pattern PRs from the snapshot.
+3. For each remaining entry in the snapshot, apply labelling rules above.
 
 ### Phase B — Merging
 
@@ -299,7 +330,8 @@ After all labelling is complete, merge PRs that were **already ready before this
 
 ### Phase C — Report
 
-Report three groups:
+Report four groups:
+- PRs skipped this run (matched a skip pattern; `skip-pr.sh` called for first-time skips).
 - PRs labelled in this run (ok-to-test or lgtm added).
 - PRs merged in this run.
 - PRs waiting (checks pending, build failed, blocked by a running on-push pipeline, or blocked by a same-component merge in this run).

--- a/.claude/commands/process-konflux-prs.md
+++ b/.claude/commands/process-konflux-prs.md
@@ -2,6 +2,7 @@
 name: process-konflux-prs
 description: Look at pull requests created by the Konflux bot and manage them, optimizing their merge to avoid repetitive builds.
 allowed-tools:
+  - Bash(scripts/process-konflux-prs/snapshot-prs.sh*)
   - Bash(scripts/process-konflux-prs/list-prs.sh*)
   - Bash(scripts/process-konflux-prs/get-pr-status.sh*)
   - Bash(scripts/process-konflux-prs/get-pr-components.sh*)
@@ -60,20 +61,15 @@ for pr_num in 2147 2146 2144 2143; do  # ❌ Never do this
 done
 ```
 
-**Efficiency**: fetch status for all PRs in a **single bash loop** rather than one tool
-call per PR. For N PRs, one loop invocation avoids N round-trips:
+**Efficiency**: use `snapshot-prs.sh` to discover PRs and fetch all their statuses in a
+single script invocation:
 
 ```bash
-# Fetch status + components for every PR in one bash call
-mintmaker_prs=$(./scripts/process-konflux-prs/list-prs.sh --mintmaker)
-echo "$mintmaker_prs" | jq -c '.[]' | while read -r pr; do
-  repo=$(echo "$pr" | jq -r '.repo')
-  number=$(echo "$pr" | jq -r '.number')
-  status=$(./scripts/process-konflux-prs/get-pr-status.sh --repo "$repo" --pr "$number" 2>/dev/null)
-  echo "$status" | jq --arg repo "$repo" \
-    '{repo: $repo, pr: .number, components, build_checks_passed, build_checks_failed, pending_checks, has_ok_to_test, has_lgtm}'
-done
+snapshot=$(./scripts/process-konflux-prs/snapshot-prs.sh --mintmaker)
 ```
+
+Do NOT call `list-prs.sh` followed by a `get-pr-status.sh` loop — `snapshot-prs.sh`
+already does both.
 
 **IMPORTANT**: Do not perform active polling/wait loops when executing.
 This skill is intended to be run on a regular basis. Each time it runs, it should
@@ -123,6 +119,26 @@ Output: JSON object — exact shape:
 Enterprise-contract checks legitimately return `NEUTRAL` and are excluded from
 `build_checks_passed`. If `pending_checks > 0`, checks are still running — wait for
 the next run.
+
+## snapshot-prs.sh
+Discover PRs and fetch their status in one pass — replaces a `list-prs.sh` call followed
+by a `get-pr-status.sh` loop.
+```bash
+./scripts/process-konflux-prs/snapshot-prs.sh --mintmaker|--nudge [--repo REPO_NAME]
+```
+Output: JSON array of status objects, one per PR:
+```json
+[{
+  "repo": "osc", "pr": 1234, "title": "…",
+  "components": ["osc-operator"],
+  "build_checks_passed": true,
+  "build_checks_failed": [],
+  "pending_checks": 0,
+  "has_ok_to_test": true,
+  "has_lgtm": false
+}]
+```
+**Use this instead of calling `list-prs.sh` then looping over `get-pr-status.sh`.**
 
 ## label-pr.sh output and error handling
 
@@ -252,10 +268,10 @@ label. Track the merge pipeline when the PR auto-merges to confirm success
 
 ### Phase A — Labelling
 
-1. Call `list-prs.sh --mintmaker` to discover open Mintmaker PRs.
-2. Fetch status for all PRs with `get-pr-status.sh` and record the **initial snapshot**
-   (this snapshot is fixed; it must not be refreshed during the same run).
-3. For each Mintmaker PR, apply labelling rules above.
+1. Call `snapshot-prs.sh --mintmaker` to discover open Mintmaker PRs and fetch their
+   status in one pass. Record the result as the **initial snapshot** (this snapshot is
+   fixed; it must not be refreshed during the same run).
+2. For each entry in the snapshot, apply labelling rules above.
 
 ### Phase B — Merging
 
@@ -303,15 +319,13 @@ the Nudge PR now would be immediately obsoleted by the Mintmaker rebuild.
 
 **Phase A — Build the "Mintmaker-blocked" component set**
 
-1. Call `list-prs.sh --mintmaker` to get all open Mintmaker PRs.
-2. For each Mintmaker PR, call `get-pr-status.sh` and collect its `components`
-   array (the components that will be rebuilt when that PR is merged).
-3. Union all these component arrays into a single set:
+1. Call `snapshot-prs.sh --mintmaker` to get all open Mintmaker PRs with their status.
+2. Union the `components` arrays from all entries into a single set:
    `mintmaker_rebuilding_components`.
 
 **Phase B — Filter and process Nudge PRs**
 
-1. Call `list-prs.sh --nudge` to get all open Nudge PRs.
+1. Call `snapshot-prs.sh --nudge` to get all open Nudge PRs with their status.
 2. For each Nudge PR, identify the **source component** — the component whose
    reference was updated — by matching known component names against the PR title.
    (Nudge PR titles contain the source component name, e.g.

--- a/scripts/process-konflux-prs/README.md
+++ b/scripts/process-konflux-prs/README.md
@@ -1,0 +1,229 @@
+# Process Konflux PRs - Helper Scripts
+
+This directory contains independent scripts that provide base functionalities for managing Konflux PRs. These scripts are designed to be called by the `process-konflux-prs` skill, but can also be used standalone.
+
+## Scripts Overview
+
+### 1. list-prs.sh
+List Konflux PRs from all repositories.
+
+**Usage:**
+```bash
+./list-prs.sh [--mintmaker|--nudge] [--repo REPO_NAME]
+```
+
+**Options:**
+- `--mintmaker`: Filter for Mintmaker PRs only
+- `--nudge`: Filter for Nudge PRs only
+- `--repo REPO_NAME`: Filter for a specific repository
+
+**Output:** JSON array of PRs with number, title, url, repo, and type.
+
+**Example:**
+```bash
+# List all Konflux PRs
+./list-prs.sh
+
+# List only Mintmaker PRs
+./list-prs.sh --mintmaker
+
+# List Nudge PRs from the osc repository
+./list-prs.sh --nudge --repo osc
+```
+
+### 2. get-pr-status.sh
+Get the status of a specific PR including checks, labels, and merge state.
+
+**Usage:**
+```bash
+./get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
+```
+
+**Options:**
+- `--repo REPO_NAME`: Repository name (kata-containers, cloud-api-adaptor, compute-artifacts, podvm-scripts, osc)
+- `--pr PR_NUMBER`: Pull request number
+
+**Output:** JSON with PR details including:
+- `number`, `title`, `state`
+- `labels`: Array of label names
+- `checks`: Array of status checks with name, status, conclusion, details_url
+- `has_ok_to_test`: Boolean indicating if "ok-to-test" label is present
+- `has_lgtm`: Boolean indicating if "lgtm" label is present
+- `all_checks_passed`: Boolean indicating if all checks have passed
+- `pending_checks`: Count of checks still in progress
+
+**Example:**
+```bash
+./get-pr-status.sh --repo osc --pr 2147
+```
+
+### 3. get-pr-components.sh
+Identify which components will be rebuilt by a PR based on its Konflux checks.
+
+**Usage:**
+```bash
+./get-pr-components.sh --repo REPO_NAME --pr PR_NUMBER
+```
+
+**Options:**
+- `--repo REPO_NAME`: Repository name
+- `--pr PR_NUMBER`: Pull request number
+
+**Output:** JSON array of component names that will be rebuilt.
+
+**Note:** This script filters out enterprise-contract validation checks, which are not component builds. It only returns actual component builds that match the pattern "{component-name}-on-pull-request".
+
+**Example:**
+```bash
+./get-pr-components.sh --repo cloud-api-adaptor --pr 1234
+# Output: ["osc-caa", "osc-caa-webhook"]
+```
+
+### 4. label-pr.sh
+Add a label to a PR.
+
+**Usage:**
+```bash
+./label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
+```
+
+**Options:**
+- `--repo REPO_NAME`: Repository name
+- `--pr PR_NUMBER`: Pull request number
+- `--label LABEL_NAME`: Label to add (must be "ok-to-test" or "lgtm")
+
+**Output:** JSON with success status.
+
+**Example:**
+```bash
+./label-pr.sh --repo osc --pr 2147 --label ok-to-test
+```
+
+### 5. check-pipeline-status.sh
+Check the status of Konflux pipelines for a component.
+
+**Usage:**
+```bash
+./check-pipeline-status.sh --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID] [--namespace NAMESPACE]
+```
+
+**Options:**
+- `--component COMPONENT_NAME`: Component name (e.g., osc-operator, osc-caa)
+- `--type TYPE`: Pipeline type (on-pull-request or on-push, default: on-push)
+- `--pr-id PR_ID`: PR identifier for on-pull-request pipelines
+- `--namespace NAMESPACE`: Konflux namespace (default: ose-osc-tenant)
+
+**Output:** JSON with pipeline status including latest run and all matching runs.
+
+**Example:**
+```bash
+# Check on-push pipeline for osc-operator
+./check-pipeline-status.sh --component osc-operator
+
+# Check on-pull-request pipeline
+./check-pipeline-status.sh --component osc-caa --type on-pull-request --pr-id abc123
+```
+
+### 6. get-nudge-prs.sh
+Find nudge PRs for a given component.
+
+**Usage:**
+```bash
+./get-nudge-prs.sh --component COMPONENT_NAME
+```
+
+**Options:**
+- `--component COMPONENT_NAME`: Component name (e.g., osc-operator-bundle, osc-dm-verity-image)
+
+**Output:** JSON array of nudge PRs that update the specified component.
+
+**Important:** Nudge PR titles mention the **source** component (what was rebuilt), not the **target** component (what is being updated). This script handles that automatically by:
+1. Finding all components that nudge the target component
+2. Searching for nudge PRs with titles mentioning those source components
+
+**Example:**
+```bash
+./get-nudge-prs.sh --component osc-operator-bundle
+# Finds PRs with titles like "chore(deps): update osc-operator" (source component)
+# which update osc-operator-bundle (target component)
+```
+
+### 7. get-component-info.sh
+Get metadata about components (build time, dependencies).
+
+**Usage:**
+```bash
+./get-component-info.sh [--component COMPONENT_NAME]
+```
+
+**Options:**
+- `--component COMPONENT_NAME`: Get info for a specific component (optional)
+
+**Output:** JSON with component metadata including repository, build time, and nudged components.
+
+**Example:**
+```bash
+# Get all components info
+./get-component-info.sh
+
+# Get specific component info
+./get-component-info.sh --component osc-operator
+```
+
+## Repository Mapping
+
+The scripts recognize these repository names:
+- `kata-containers` → `https://github.com/openshift/kata-containers`
+- `cloud-api-adaptor` → `https://github.com/openshift/cloud-api-adaptor`
+- `compute-artifacts` → `https://github.com/openshift/confidential-compute-artifacts`
+- `podvm-scripts` → `https://github.com/confidential-devhub/coco-podvm-scripts`
+- `osc` → `https://github.com/openshift/sandboxed-containers-operator`
+
+## Implementation Notes
+
+- The Konflux bot appears as `app/red-hat-konflux` in GitHub (not just `red-hat-konflux`)
+- All PR queries filter by `--author "app/red-hat-konflux"`
+- Enterprise contract checks are excluded from component detection as they are validation checks, not component builds
+- Only checks matching the pattern "Red Hat Konflux / {component-name}-on-pull-request" are considered component builds
+
+## Prerequisites
+
+All scripts require:
+- `gh` (GitHub CLI) - authenticated and configured
+- `jq` - for JSON processing
+
+Scripts that interact with Konflux also require:
+- `oc` (OpenShift CLI) - logged into Konflux cluster
+- `tkn` (Tekton CLI) - for pipeline operations
+
+## Environment Variables
+
+- `GITHUB_TOKEN`: GitHub personal access token (can be set via `gh auth login`)
+- Konflux access: Configure via `oc login` with appropriate service account token
+
+## Integration with process-konflux-prs Skill
+
+These scripts are designed to be called by the `process-konflux-prs` skill.
+The skill's allowed-tools section should be updated to reference these scripts
+instead of individual `gh`, `oc`, and `tkn` commands.
+
+This provides:
+1. **Better isolation**: The skill can only execute these specific scripts
+2. **Easier testing**: Each script can be tested independently
+3. **Better maintainability**: Script logic is separated from skill orchestration
+4. **Consistent output**: All scripts output JSON for easy parsing
+
+## Testing
+
+Test each script individually before using them in the skill:
+
+```bash
+# Test listing PRs
+./list-prs.sh --mintmaker
+
+# Test getting PR status (replace with actual PR number)
+./get-pr-status.sh --repo osc --pr 2147
+
+# Test component info
+./get-component-info.sh
+```

--- a/scripts/process-konflux-prs/README.md
+++ b/scripts/process-konflux-prs/README.md
@@ -104,13 +104,17 @@ Check the status of Konflux pipelines for a component.
 
 **Usage:**
 ```bash
-./check-pipeline-status.sh --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID] [--namespace NAMESPACE]
+# For on-push pipelines (default)
+./check-pipeline-status.sh --component COMPONENT_NAME [--namespace NAMESPACE]
+
+# For on-pull-request pipelines (--pr-id is REQUIRED)
+./check-pipeline-status.sh --component COMPONENT_NAME --type on-pull-request --pr-id PR_ID [--namespace NAMESPACE]
 ```
 
 **Options:**
 - `--component COMPONENT_NAME`: Component name (e.g., osc-operator, osc-caa)
 - `--type TYPE`: Pipeline type (on-pull-request or on-push, default: on-push)
-- `--pr-id PR_ID`: PR identifier for on-pull-request pipelines
+- `--pr-id PR_ID`: PR identifier (REQUIRED for on-pull-request, must match the suffix in the pipelinerun name)
 - `--namespace NAMESPACE`: Konflux namespace (default: ose-osc-tenant)
 
 **Output:** JSON with pipeline status including latest run and all matching runs.
@@ -120,7 +124,7 @@ Check the status of Konflux pipelines for a component.
 # Check on-push pipeline for osc-operator
 ./check-pipeline-status.sh --component osc-operator
 
-# Check on-pull-request pipeline
+# Check on-pull-request pipeline (--pr-id is mandatory to avoid matching runs from different PRs)
 ./check-pipeline-status.sh --component osc-caa --type on-pull-request --pr-id abc123
 ```
 

--- a/scripts/process-konflux-prs/README.md
+++ b/scripts/process-konflux-prs/README.md
@@ -49,7 +49,7 @@ Get the status of a specific PR including checks, labels, and merge state.
 - `checks`: Array of status checks with name, status, conclusion, details_url
 - `has_ok_to_test`: Boolean indicating if "ok-to-test" label is present
 - `has_lgtm`: Boolean indicating if "lgtm" label is present
-- `all_checks_passed`: Boolean indicating if all checks have passed
+- `build_checks_passed`: Boolean indicating if all build checks have passed
 - `pending_checks`: Count of checks still in progress
 
 **Example:**
@@ -71,7 +71,7 @@ Identify which components will be rebuilt by a PR based on its Konflux checks.
 
 **Output:** JSON array of component names that will be rebuilt.
 
-**Note:** This script filters out enterprise-contract validation checks, which are not component builds. It only returns actual component builds that match the pattern "{component-name}-on-pull-request".
+**Note:** This script filters out enterprise-contract validation checks, which are not component builds. It only returns actual component builds that match the pattern "Red Hat Konflux / {component-name}-on-pull-request".
 
 **Example:**
 ```bash

--- a/scripts/process-konflux-prs/check-merge-safety.sh
+++ b/scripts/process-konflux-prs/check-merge-safety.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Check whether it is safe to merge a PR by verifying that no on-push pipeline
+# is currently running for any of the components it would rebuild.
+#
+# Usage: ./check-merge-safety.sh --components "comp1 comp2 ..." [--namespace NAMESPACE]
+#
+# Output: JSON {safe_to_merge: bool, blocking: [{component, pipeline, reason}]}
+#   safe_to_merge: true when no on-push pipeline is running for any component
+#   blocking:      list of components with a running pipeline (empty when safe)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+COMPONENTS=()
+NAMESPACE_ARG=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --components)
+            IFS=' ' read -ra COMPONENTS <<< "$2"
+            shift 2
+            ;;
+        --namespace)
+            NAMESPACE_ARG="--namespace $2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --components 'comp1 comp2 ...' [--namespace NAMESPACE]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ${#COMPONENTS[@]} -eq 0 ]]; then
+    echo "Usage: $0 --components 'comp1 comp2 ...'" >&2
+    exit 1
+fi
+
+blocking='[]'
+for component in "${COMPONENTS[@]}"; do
+    result=$("$SCRIPT_DIR/check-pipeline-status.sh" --component "$component" $NAMESPACE_ARG)
+    latest=$(echo "$result" | jq '.latest')
+    completion=$(echo "$result" | jq -r '.latest.completionTime // "null"')
+
+    # A pipeline is running when latest is non-null and has no completionTime
+    if [[ "$latest" != "null" && "$completion" == "null" ]]; then
+        reason=$(echo "$result" | jq -r '.latest.reason // "Running"')
+        pipeline=$(echo "$result" | jq -r '.latest.name // "unknown"')
+        entry=$(jq -n \
+            --arg component "$component" \
+            --arg pipeline "$pipeline" \
+            --arg reason "$reason" \
+            '{component: $component, pipeline: $pipeline, reason: $reason}')
+        blocking=$(echo "$blocking" | jq --argjson e "$entry" '. + [$e]')
+    fi
+done
+
+count=$(echo "$blocking" | jq 'length')
+safe_to_merge=true
+[[ "$count" -gt 0 ]] && safe_to_merge=false
+
+jq -n \
+    --argjson safe_to_merge "$safe_to_merge" \
+    --argjson blocking "$blocking" \
+    '{safe_to_merge: $safe_to_merge, blocking: $blocking}'

--- a/scripts/process-konflux-prs/check-merge-safety.sh
+++ b/scripts/process-konflux-prs/check-merge-safety.sh
@@ -39,7 +39,13 @@ fi
 
 blocking='[]'
 for component in "${COMPONENTS[@]}"; do
-    result=$("$SCRIPT_DIR/check-pipeline-status.sh" --component "$component" $NAMESPACE_ARG)
+    if ! result=$("$SCRIPT_DIR/check-pipeline-status.sh" --component "$component" $NAMESPACE_ARG 2>&1); then
+        echo "Warning: failed to check pipeline status for $component: $result" >&2
+        entry=$(jq -n --arg component "$component" \
+            '{component: $component, pipeline: "unknown", reason: "status check failed"}')
+        blocking=$(echo "$blocking" | jq --argjson e "$entry" '. + [$e]')
+        continue
+    fi
     latest=$(echo "$result" | jq '.latest')
     completion=$(echo "$result" | jq -r '.latest.completionTime // "null"')
 

--- a/scripts/process-konflux-prs/check-pipeline-status.sh
+++ b/scripts/process-konflux-prs/check-pipeline-status.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Check the status of Konflux pipelines for a component
+# Usage: ./check-pipeline-status.sh --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID]
+#
+# Outputs JSON with pipeline status
+
+set -euo pipefail
+
+COMPONENT=""
+PIPELINE_TYPE="on-push"
+PR_ID=""
+NAMESPACE="ose-osc-tenant"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --component)
+            COMPONENT="$2"
+            shift 2
+            ;;
+        --type)
+            PIPELINE_TYPE="$2"
+            shift 2
+            ;;
+        --pr-id)
+            PR_ID="$2"
+            shift 2
+            ;;
+        --namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID] [--namespace NAMESPACE]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$COMPONENT" ]]; then
+    echo "Usage: $0 --component COMPONENT_NAME [--type on-pull-request|on-push] [--pr-id PR_ID] [--namespace NAMESPACE]" >&2
+    exit 1
+fi
+
+# Construct pipeline name pattern
+if [[ "$PIPELINE_TYPE" == "on-pull-request" && -n "$PR_ID" ]]; then
+    PATTERN="${COMPONENT}-on-pull-request-${PR_ID}"
+else
+    PATTERN="${COMPONENT}-${PIPELINE_TYPE}"
+fi
+
+# List pipeline runs
+pipelineruns=$(tkn pipelinerun list \
+    --namespace "$NAMESPACE" \
+    --output json 2>/dev/null || echo '{"items":[]}')
+
+# Filter for matching pipeline runs
+matching_runs=$(echo "$pipelineruns" | jq --arg pattern "$PATTERN" '
+    [.items[] |
+     select(.metadata.generateName != null) |
+     select(.metadata.generateName | type == "string") |
+     select(.metadata.generateName | startswith($pattern)) |
+     {
+        name: .metadata.name,
+        status: (.status.conditions[0].status // "Unknown"),
+        reason: (.status.conditions[0].reason // "Unknown"),
+        startTime: .status.startTime,
+        completionTime: .status.completionTime
+     }] |
+    sort_by(.startTime) |
+    reverse
+')
+
+# Get most recent run
+latest_run=$(echo "$matching_runs" | jq '.[0] // null')
+
+result=$(jq -n \
+    --arg component "$COMPONENT" \
+    --arg type "$PIPELINE_TYPE" \
+    --argjson latest "$latest_run" \
+    --argjson all "$matching_runs" \
+    '{
+        component: $component,
+        pipeline_type: $type,
+        latest: $latest,
+        all_runs: $all
+    }')
+
+echo "$result" | jq '.'

--- a/scripts/process-konflux-prs/check-pipeline-status.sh
+++ b/scripts/process-konflux-prs/check-pipeline-status.sh
@@ -42,8 +42,15 @@ if [[ -z "$COMPONENT" ]]; then
     exit 1
 fi
 
+# Validate PR_ID is provided for on-pull-request type
+if [[ "$PIPELINE_TYPE" == "on-pull-request" && -z "$PR_ID" ]]; then
+    echo "Error: --pr-id is required when --type is on-pull-request" >&2
+    echo "Usage: $0 --component COMPONENT_NAME --type on-pull-request --pr-id PR_ID [--namespace NAMESPACE]" >&2
+    exit 1
+fi
+
 # Construct pipeline name pattern
-if [[ "$PIPELINE_TYPE" == "on-pull-request" && -n "$PR_ID" ]]; then
+if [[ "$PIPELINE_TYPE" == "on-pull-request" ]]; then
     PATTERN="${COMPONENT}-on-pull-request-${PR_ID}"
 else
     PATTERN="${COMPONENT}-${PIPELINE_TYPE}"

--- a/scripts/process-konflux-prs/check-pipeline-status.sh
+++ b/scripts/process-konflux-prs/check-pipeline-status.sh
@@ -63,7 +63,7 @@ pipelineruns=$(tkn pipelinerun list \
 
 # Filter for matching pipeline runs
 matching_runs=$(echo "$pipelineruns" | jq --arg pattern "$PATTERN" '
-    [.items[] |
+    [(.items // [])[] |
      select(.metadata.generateName != null) |
      select(.metadata.generateName | type == "string") |
      select(.metadata.generateName | startswith($pattern)) |

--- a/scripts/process-konflux-prs/get-component-info.sh
+++ b/scripts/process-konflux-prs/get-component-info.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Get information about a component (build time, nudged components)
+# Usage: ./get-component-info.sh [--component COMPONENT_NAME]
+#
+# Outputs JSON with component metadata or all components if no name specified
+
+set -euo pipefail
+
+COMPONENT=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --component)
+            COMPONENT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--component COMPONENT_NAME]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Component metadata (from the skill documentation)
+components_json='[
+  {
+    "name": "osc-monitor",
+    "repository": "kata-containers",
+    "build_time_minutes": 10,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-caa",
+    "repository": "cloud-api-adaptor",
+    "build_time_minutes": 15,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-caa-webhook",
+    "repository": "cloud-api-adaptor",
+    "build_time_minutes": 10,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-podvm-payload",
+    "repository": "cloud-api-adaptor",
+    "build_time_minutes": 45,
+    "nudges": ["osc-operator-bundle", "osc-dm-verity-image", "osc-initrds"]
+  },
+  {
+    "name": "osc-pccs",
+    "repository": "compute-artifacts",
+    "build_time_minutes": 8,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-tdx-qgs",
+    "repository": "compute-artifacts",
+    "build_time_minutes": 8,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-storage-helper",
+    "repository": "compute-artifacts",
+    "build_time_minutes": 8,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-operator",
+    "repository": "osc",
+    "build_time_minutes": 12,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-operator-bundle",
+    "repository": "osc",
+    "build_time_minutes": 3,
+    "nudges": ["osc-test-fbc"]
+  },
+  {
+    "name": "osc-podvm-builder",
+    "repository": "osc",
+    "build_time_minutes": 10,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-must-gather",
+    "repository": "osc",
+    "build_time_minutes": 10,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "osc-dm-verity-image",
+    "repository": "podvm-scripts",
+    "build_time_minutes": 50,
+    "nudges": ["osc-operator-bundle"]
+  },
+  {
+    "name": "build-dm-verity-image",
+    "repository": "podvm-scripts",
+    "build_time_minutes": 2,
+    "nudges": ["osc-dm-verity-image"]
+  },
+  {
+    "name": "osc-initrds",
+    "repository": "compute-artifacts",
+    "build_time_minutes": 15,
+    "nudges": []
+  },
+  {
+    "name": "osc-test-fbc",
+    "repository": "osc",
+    "build_time_minutes": 15,
+    "nudges": []
+  }
+]'
+
+if [[ -z "$COMPONENT" ]]; then
+    # Return all components
+    echo "$components_json" | jq '.'
+else
+    # Return specific component
+    echo "$components_json" | jq --arg name "$COMPONENT" '.[] | select(.name == $name)'
+fi

--- a/scripts/process-konflux-prs/get-nudge-prs.sh
+++ b/scripts/process-konflux-prs/get-nudge-prs.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Find nudge PRs for a given component
+# Usage: ./get-nudge-prs.sh --component COMPONENT_NAME
+#
+# Outputs JSON array of nudge PRs that update the given component
+# Note: Nudge PR titles mention the SOURCE component (what was rebuilt),
+#       not the TARGET component (what is being updated)
+
+set -euo pipefail
+
+COMPONENT=""
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --component)
+            COMPONENT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --component COMPONENT_NAME" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$COMPONENT" ]]; then
+    echo "Usage: $0 --component COMPONENT_NAME" >&2
+    exit 1
+fi
+
+# Get all components and find which ones nudge the target component
+components_info=$("$SCRIPT_DIR/get-component-info.sh")
+
+# Find source components that nudge our target component
+source_components=$(echo "$components_info" | jq -r --arg target "$COMPONENT" '
+    [.[] | select(.nudges[] == $target) | .name] | .[]
+')
+
+# If no components nudge this one, return empty
+if [[ -z "$source_components" ]]; then
+    echo "[]" | jq '.'
+    exit 0
+fi
+
+# Find which repository should have the nudge PR
+# (The repository of the target component)
+target_repo=$(echo "$components_info" | jq -r --arg target "$COMPONENT" '
+    .[] | select(.name == $target) | .repository
+')
+
+if [[ -z "$target_repo" || "$target_repo" == "null" ]]; then
+    echo "[]" | jq '.'
+    exit 0
+fi
+
+# Map repo name to URL
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+repo_url="${REPOS[$target_repo]}"
+
+# Get all nudge PRs from the target repository
+prs=$(gh pr list \
+    --repo "$repo_url" \
+    --state open \
+    --author "app/red-hat-konflux" \
+    --label "konflux-nudge" \
+    --json number,title,url,updatedAt \
+    --limit 50)
+
+# Filter for PRs that mention any of the source components
+# Nudge PR titles are like "chore(deps): update {source-component}"
+all_matching_prs='[]'
+
+while IFS= read -r source_component; do
+    [[ -z "$source_component" ]] && continue
+
+    matching=$(echo "$prs" | jq --arg component "$source_component" '
+        [.[] |
+         select(.title | contains($component))]
+    ')
+
+    all_matching_prs=$(echo "$all_matching_prs" "$matching" | jq -s 'add | unique_by(.number) | sort_by(.updatedAt) | reverse')
+done <<< "$source_components"
+
+echo "$all_matching_prs" | jq '.'

--- a/scripts/process-konflux-prs/get-pr-components.sh
+++ b/scripts/process-konflux-prs/get-pr-components.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Identify which components will be rebuilt by a PR
+# Usage: ./get-pr-components.sh --repo REPO_NAME --pr PR_NUMBER
+#
+# Outputs JSON array of components that will be rebuilt
+
+set -euo pipefail
+
+REPO_URL=""
+PR_NUMBER=""
+
+# Repository mapping
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)
+            if [[ -n "${REPOS[$2]:-}" ]]; then
+                REPO_URL="${REPOS[$2]}"
+            else
+                echo "Unknown repository: $2" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_URL" || -z "$PR_NUMBER" ]]; then
+    echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+    exit 1
+fi
+
+# Get PR status checks
+pr_data=$(gh pr view "$PR_NUMBER" \
+    --repo "$REPO_URL" \
+    --json statusCheckRollup)
+
+# Extract component names from Konflux checks
+# Pattern: "Red Hat Konflux / {component-name}-on-pull-request"
+# Exclude: enterprise-contract checks (validation, not component builds)
+components=$(echo "$pr_data" | jq -r '
+    [.statusCheckRollup[] |
+     select(.name != null) |
+     select(.name | type == "string") |
+     select(.name | startswith("Red Hat Konflux / ")) |
+     select(.name | contains("enterprise-contract") | not) |
+     select(.name | contains("-on-pull-request")) |
+     .name |
+     sub("Red Hat Konflux / "; "") |
+     sub("-on-pull-request.*"; "")] |
+    unique |
+    sort
+')
+
+echo "$components" | jq '.'

--- a/scripts/process-konflux-prs/get-pr-components.sh
+++ b/scripts/process-konflux-prs/get-pr-components.sh
@@ -54,8 +54,9 @@ pr_data=$(gh pr view "$PR_NUMBER" \
 # Extract component names from Konflux checks
 # Pattern: "Red Hat Konflux / {component-name}-on-pull-request"
 # Exclude: enterprise-contract checks (validation, not component builds)
+# Note: statusCheckRollup can be null for fresh PRs without checks
 components=$(echo "$pr_data" | jq -r '
-    [.statusCheckRollup[] |
+    [(.statusCheckRollup // [])[] |
      select(.name != null) |
      select(.name | type == "string") |
      select(.name | startswith("Red Hat Konflux / ")) |

--- a/scripts/process-konflux-prs/get-pr-status.sh
+++ b/scripts/process-konflux-prs/get-pr-status.sh
@@ -52,7 +52,8 @@ pr_data=$(gh pr view "$PR_NUMBER" \
     --json number,title,state,labels,statusCheckRollup)
 
 # Extract status checks
-checks=$(echo "$pr_data" | jq '[.statusCheckRollup[] | {
+# Note: statusCheckRollup can be null for fresh PRs without checks
+checks=$(echo "$pr_data" | jq '[(.statusCheckRollup // [])[] | {
     name: .name,
     status: .status,
     conclusion: .conclusion,
@@ -60,7 +61,8 @@ checks=$(echo "$pr_data" | jq '[.statusCheckRollup[] | {
 }]')
 
 # Extract labels
-labels=$(echo "$pr_data" | jq '[.labels[].name]')
+# Note: labels can be null for PRs without labels
+labels=$(echo "$pr_data" | jq '[(.labels // [])[].name]')
 
 # Build result
 result=$(echo "$pr_data" | jq \

--- a/scripts/process-konflux-prs/get-pr-status.sh
+++ b/scripts/process-konflux-prs/get-pr-status.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Get PR status including checks, labels, and merge state
+# Usage: ./get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
+#
+# Outputs JSON with: number, title, labels, checks (name, status, conclusion, details_url)
+
+set -euo pipefail
+
+REPO_URL=""
+PR_NUMBER=""
+
+# Repository mapping
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)
+            if [[ -n "${REPOS[$2]:-}" ]]; then
+                REPO_URL="${REPOS[$2]}"
+            else
+                echo "Unknown repository: $2" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_URL" || -z "$PR_NUMBER" ]]; then
+    echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+    exit 1
+fi
+
+# Get PR details
+pr_data=$(gh pr view "$PR_NUMBER" \
+    --repo "$REPO_URL" \
+    --json number,title,state,labels,statusCheckRollup)
+
+# Extract status checks
+checks=$(echo "$pr_data" | jq '[.statusCheckRollup[] | {
+    name: .name,
+    status: .status,
+    conclusion: .conclusion,
+    details_url: .detailsUrl
+}]')
+
+# Extract labels
+labels=$(echo "$pr_data" | jq '[.labels[].name]')
+
+# Build result
+result=$(echo "$pr_data" | jq \
+    --argjson checks "$checks" \
+    --argjson labels "$labels" \
+    '{
+        number: .number,
+        title: .title,
+        state: .state,
+        labels: $labels,
+        checks: $checks,
+        has_ok_to_test: ($labels | any(. == "ok-to-test")),
+        has_lgtm: ($labels | any(. == "lgtm")),
+        all_checks_passed: ([$checks[] | select(.conclusion != "SUCCESS")] | length == 0),
+        pending_checks: ([$checks[] | select(.status == "IN_PROGRESS" or .status == "PENDING")] | length)
+    }')
+
+echo "$result" | jq '.'

--- a/scripts/process-konflux-prs/get-pr-status.sh
+++ b/scripts/process-konflux-prs/get-pr-status.sh
@@ -31,6 +31,7 @@ declare -A REPOS=(
 while [[ $# -gt 0 ]]; do
     case $1 in
         --repo)
+            [[ $# -ge 2 ]] || { echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2; exit 1; }
             if [[ -n "${REPOS[$2]:-}" ]]; then
                 REPO_URL="${REPOS[$2]}"
             else
@@ -40,6 +41,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --pr)
+            [[ $# -ge 2 ]] || { echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2; exit 1; }
             PR_NUMBER="$2"
             shift 2
             ;;
@@ -77,6 +79,7 @@ labels=$(echo "$pr_data" | jq '[(.labels // [])[].name]')
 # Enterprise-contract checks (containing "enterprise-contract") are excluded —
 # they return NEUTRAL when not required, which is not a failure.
 build_checks=$(echo "$checks" | jq '[.[] |
+    select(.name | startswith("Red Hat Konflux / ")) |
     select(.name | test("-on-pull-request")) |
     select(.name | contains("enterprise-contract") | not)]')
 

--- a/scripts/process-konflux-prs/get-pr-status.sh
+++ b/scripts/process-konflux-prs/get-pr-status.sh
@@ -58,7 +58,7 @@ fi
 # Get PR details
 pr_data=$(gh pr view "$PR_NUMBER" \
     --repo "$REPO_URL" \
-    --json number,title,state,labels,statusCheckRollup)
+    --json number,title,state,labels,statusCheckRollup,baseRefName)
 
 # All checks, with null entries filtered out
 checks=$(echo "$pr_data" | jq '[(.statusCheckRollup // [])[] |
@@ -88,6 +88,7 @@ echo "$pr_data" | jq \
         number: .number,
         title: .title,
         state: .state,
+        base_branch: .baseRefName,
         labels: $labels,
         has_ok_to_test: ($labels | any(. == "ok-to-test")),
         has_lgtm: ($labels | any(. == "lgtm")),

--- a/scripts/process-konflux-prs/get-pr-status.sh
+++ b/scripts/process-konflux-prs/get-pr-status.sh
@@ -2,7 +2,16 @@
 # Get PR status including checks, labels, and merge state
 # Usage: ./get-pr-status.sh --repo REPO_NAME --pr PR_NUMBER
 #
-# Outputs JSON with: number, title, labels, checks (name, status, conclusion, details_url)
+# Outputs JSON with:
+#   number, title, state
+#   labels: array of strings (e.g. ["ok-to-test", "lgtm"])
+#   has_ok_to_test, has_lgtm: booleans
+#   components: array of component names that will be rebuilt (from build pipeline checks)
+#   build_checks_passed: true only when all build pipeline checks completed with SUCCESS
+#                        (enterprise-contract checks with NEUTRAL conclusion are excluded)
+#   build_checks_failed: array of names of build checks that failed (FAILURE conclusion)
+#   pending_checks: integer count of checks still IN_PROGRESS, QUEUED, or PENDING
+#   checks: raw array of all checks (name, status, conclusion, details_url); nulls filtered out
 
 set -euo pipefail
 
@@ -51,33 +60,47 @@ pr_data=$(gh pr view "$PR_NUMBER" \
     --repo "$REPO_URL" \
     --json number,title,state,labels,statusCheckRollup)
 
-# Extract status checks
-# Note: statusCheckRollup can be null for fresh PRs without checks
-checks=$(echo "$pr_data" | jq '[(.statusCheckRollup // [])[] | {
-    name: .name,
-    status: .status,
-    conclusion: .conclusion,
-    details_url: .detailsUrl
-}]')
+# All checks, with null entries filtered out
+checks=$(echo "$pr_data" | jq '[(.statusCheckRollup // [])[] |
+    select(.name != null) |
+    {
+        name: .name,
+        status: .status,
+        conclusion: (.conclusion // ""),
+        details_url: .detailsUrl
+    }]')
 
-# Extract labels
-# Note: labels can be null for PRs without labels
+# Labels: array of strings
 labels=$(echo "$pr_data" | jq '[(.labels // [])[].name]')
 
-# Build result
-result=$(echo "$pr_data" | jq \
+# Build pipeline checks only: "Red Hat Konflux / {component}-on-pull-request[…]"
+# Enterprise-contract checks (containing "enterprise-contract") are excluded —
+# they return NEUTRAL when not required, which is not a failure.
+build_checks=$(echo "$checks" | jq '[.[] |
+    select(.name | test("-on-pull-request")) |
+    select(.name | contains("enterprise-contract") | not)]')
+
+echo "$pr_data" | jq \
     --argjson checks "$checks" \
     --argjson labels "$labels" \
+    --argjson build_checks "$build_checks" \
     '{
         number: .number,
         title: .title,
         state: .state,
         labels: $labels,
-        checks: $checks,
         has_ok_to_test: ($labels | any(. == "ok-to-test")),
         has_lgtm: ($labels | any(. == "lgtm")),
-        all_checks_passed: ([$checks[] | select(.conclusion != "SUCCESS")] | length == 0),
-        pending_checks: ([$checks[] | select(.status == "IN_PROGRESS" or .status == "PENDING")] | length)
-    }')
-
-echo "$result" | jq '.'
+        components: ($build_checks | [.[].name |
+            sub("Red Hat Konflux / "; "") |
+            sub("-on-pull-request.*"; "")] | sort | unique),
+        build_checks_passed: ($build_checks | length > 0 and
+            (map(.conclusion == "SUCCESS") | all)),
+        build_checks_failed: [$build_checks[] |
+            select(.conclusion == "FAILURE") | .name],
+        pending_checks: ([$checks[] |
+            select(.status == "IN_PROGRESS" or
+                   .status == "QUEUED" or
+                   .status == "PENDING")] | length),
+        checks: $checks
+    }'

--- a/scripts/process-konflux-prs/label-pr.sh
+++ b/scripts/process-konflux-prs/label-pr.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Add a label to a PR
+# Usage: ./label-pr.sh --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME
+#
+# Returns: success/failure status
+
+set -euo pipefail
+
+REPO_URL=""
+PR_NUMBER=""
+LABEL=""
+
+# Repository mapping
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)
+            if [[ -n "${REPOS[$2]:-}" ]]; then
+                REPO_URL="${REPOS[$2]}"
+            else
+                echo "Unknown repository: $2" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        --label)
+            LABEL="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_URL" || -z "$PR_NUMBER" || -z "$LABEL" ]]; then
+    echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME" >&2
+    exit 1
+fi
+
+# Validate label
+if [[ "$LABEL" != "ok-to-test" && "$LABEL" != "lgtm" ]]; then
+    echo "Error: Label must be 'ok-to-test' or 'lgtm'" >&2
+    exit 1
+fi
+
+# Add label
+if gh pr edit "$PR_NUMBER" \
+    --repo "$REPO_URL" \
+    --add-label "$LABEL"; then
+    echo "{\"success\": true, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\"}" | jq '.'
+else
+    echo "{\"success\": false, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\"}" | jq '.'
+    exit 1
+fi

--- a/scripts/process-konflux-prs/label-pr.sh
+++ b/scripts/process-konflux-prs/label-pr.sh
@@ -23,6 +23,7 @@ declare -A REPOS=(
 while [[ $# -gt 0 ]]; do
     case $1 in
         --repo)
+            [[ $# -ge 2 ]] || { echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME" >&2; exit 1; }
             if [[ -n "${REPOS[$2]:-}" ]]; then
                 REPO_URL="${REPOS[$2]}"
             else
@@ -32,10 +33,12 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --pr)
+            [[ $# -ge 2 ]] || { echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME" >&2; exit 1; }
             PR_NUMBER="$2"
             shift 2
             ;;
         --label)
+            [[ $# -ge 2 ]] || { echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --label LABEL_NAME" >&2; exit 1; }
             LABEL="$2"
             shift 2
             ;;

--- a/scripts/process-konflux-prs/label-pr.sh
+++ b/scripts/process-konflux-prs/label-pr.sh
@@ -58,9 +58,11 @@ if [[ "$LABEL" != "ok-to-test" && "$LABEL" != "lgtm" ]]; then
 fi
 
 # Add label
+# Redirect stdout to /dev/null: gh prints the PR URL on success, which would
+# make the script output non-JSON and break callers that parse our JSON output.
 if gh pr edit "$PR_NUMBER" \
     --repo "$REPO_URL" \
-    --add-label "$LABEL"; then
+    --add-label "$LABEL" >/dev/null; then
 
     COMMENT_POSTED=false
     # When adding ok-to-test, also post the /ok-to-test comment. Some bots
@@ -68,7 +70,7 @@ if gh pr edit "$PR_NUMBER" \
     if [[ "$LABEL" == "ok-to-test" ]]; then
         if gh pr comment "$PR_NUMBER" \
             --repo "$REPO_URL" \
-            --body "/ok-to-test"; then
+            --body "/ok-to-test" >/dev/null; then
             COMMENT_POSTED=true
         fi
     fi

--- a/scripts/process-konflux-prs/label-pr.sh
+++ b/scripts/process-konflux-prs/label-pr.sh
@@ -61,8 +61,20 @@ fi
 if gh pr edit "$PR_NUMBER" \
     --repo "$REPO_URL" \
     --add-label "$LABEL"; then
-    echo "{\"success\": true, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\"}" | jq '.'
+
+    COMMENT_POSTED=false
+    # When adding ok-to-test, also post the /ok-to-test comment. Some bots
+    # monitoring PRs only react to maintainer comments, not to label additions.
+    if [[ "$LABEL" == "ok-to-test" ]]; then
+        if gh pr comment "$PR_NUMBER" \
+            --repo "$REPO_URL" \
+            --body "/ok-to-test"; then
+            COMMENT_POSTED=true
+        fi
+    fi
+
+    echo "{\"success\": true, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\", \"comment\": $COMMENT_POSTED}" | jq '.'
 else
-    echo "{\"success\": false, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\"}" | jq '.'
+    echo "{\"success\": false, \"repo\": \"$(basename "$REPO_URL")\", \"pr\": $PR_NUMBER, \"label\": \"$LABEL\", \"comment\": false}" | jq '.'
     exit 1
 fi

--- a/scripts/process-konflux-prs/list-prs.sh
+++ b/scripts/process-konflux-prs/list-prs.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# List Konflux PRs from repositories
+# Usage: ./list-prs.sh [--mintmaker|--nudge] [--repo REPO_NAME]
+#
+# Outputs JSON array of PRs with: number, title, url, repo, type (mintmaker/nudge)
+
+set -euo pipefail
+
+PR_TYPE=""
+REPO_FILTER=""
+
+# Repository mapping
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --mintmaker)
+            PR_TYPE="mintmaker"
+            shift
+            ;;
+        --nudge)
+            PR_TYPE="nudge"
+            shift
+            ;;
+        --repo)
+            REPO_FILTER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--mintmaker|--nudge] [--repo REPO_NAME]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Mintmaker title prefixes
+MINTMAKER_PREFIXES=(
+    "chore(deps): update konflux references"
+    "chore(deps): update registry.access.redhat.com/ubi9/ubi"
+    "chore(deps): update registry.access.redhat.com/ubi9/go-toolset"
+    "chore(deps): update registry.access.redhat.com/ubi10/ubi"
+    "chore(deps): update registry.access.redhat.com/ubi10/go-toolset"
+)
+
+is_mintmaker_pr() {
+    local title="$1"
+    for prefix in "${MINTMAKER_PREFIXES[@]}"; do
+        if [[ "$title" == "$prefix"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Process each repository
+all_prs='[]'
+
+for repo_name in "${!REPOS[@]}"; do
+    # Skip if repo filter is set and doesn't match
+    if [[ -n "$REPO_FILTER" && "$REPO_FILTER" != "$repo_name" ]]; then
+        continue
+    fi
+
+    repo_url="${REPOS[$repo_name]}"
+
+    # Get open PRs from red-hat-konflux bot
+    prs=$(gh pr list \
+        --repo "$repo_url" \
+        --state open \
+        --author "app/red-hat-konflux" \
+        --json number,title,url,labels \
+        --limit 100)
+
+    # Filter and classify PRs
+    while IFS= read -r pr; do
+        number=$(echo "$pr" | jq -r '.number')
+        title=$(echo "$pr" | jq -r '.title')
+        url=$(echo "$pr" | jq -r '.url')
+        labels=$(echo "$pr" | jq -r '.labels[].name')
+
+        # Skip empty results
+        [[ "$number" == "null" ]] && continue
+
+        # Determine PR type
+        pr_type=""
+
+        # Check if it's a Nudge PR
+        if echo "$labels" | grep -q "konflux-nudge"; then
+            # Skip bundle update PRs
+            if [[ "$title" != "chore(deps): update osc-operator-bundle"* ]]; then
+                pr_type="nudge"
+            fi
+        # Check if it's a Mintmaker PR
+        elif is_mintmaker_pr "$title"; then
+            pr_type="mintmaker"
+        fi
+
+        # Skip if type doesn't match filter
+        if [[ -n "$PR_TYPE" && "$pr_type" != "$PR_TYPE" ]]; then
+            continue
+        fi
+
+        # Skip if no type identified
+        [[ -z "$pr_type" ]] && continue
+
+        # Add to results
+        pr_json=$(jq -n \
+            --argjson number "$number" \
+            --arg title "$title" \
+            --arg url "$url" \
+            --arg repo "$repo_name" \
+            --arg type "$pr_type" \
+            '{number: $number, title: $title, url: $url, repo: $repo, type: $type}')
+
+        all_prs=$(echo "$all_prs" | jq --argjson pr "$pr_json" '. + [$pr]')
+    done < <(echo "$prs" | jq -c '.[]')
+done
+
+echo "$all_prs" | jq '.'

--- a/scripts/process-konflux-prs/list-prs.sh
+++ b/scripts/process-konflux-prs/list-prs.sh
@@ -49,6 +49,15 @@ MINTMAKER_PREFIXES=(
     "chore(deps): update registry.access.redhat.com/ubi10/go-toolset"
 )
 
+# Validate repo filter if provided
+if [[ -n "$REPO_FILTER" ]]; then
+    if [[ -z "${REPOS[$REPO_FILTER]:-}" ]]; then
+        echo "Error: Unknown repository '$REPO_FILTER'" >&2
+        echo "Valid repositories: ${!REPOS[*]}" >&2
+        exit 1
+    fi
+fi
+
 is_mintmaker_pr() {
     local title="$1"
     for prefix in "${MINTMAKER_PREFIXES[@]}"; do

--- a/scripts/process-konflux-prs/list-prs.sh
+++ b/scripts/process-konflux-prs/list-prs.sh
@@ -40,15 +40,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Mintmaker title prefixes
-MINTMAKER_PREFIXES=(
-    "chore(deps): update konflux references"
-    "chore(deps): update registry.access.redhat.com/ubi9/ubi"
-    "chore(deps): update registry.access.redhat.com/ubi9/go-toolset"
-    "chore(deps): update registry.access.redhat.com/ubi10/ubi"
-    "chore(deps): update registry.access.redhat.com/ubi10/go-toolset"
-)
-
 # Validate repo filter if provided
 if [[ -n "$REPO_FILTER" ]]; then
     if [[ -z "${REPOS[$REPO_FILTER]:-}" ]]; then
@@ -60,11 +51,13 @@ fi
 
 is_mintmaker_pr() {
     local title="$1"
-    for prefix in "${MINTMAKER_PREFIXES[@]}"; do
-        if [[ "$title" == "$prefix"* ]]; then
-            return 0
-        fi
-    done
+    # Match any Red Hat UBI base image update (ubi9/* or ubi10/*) or Konflux references update
+    [[ "$title" == "chore(deps): update konflux references"* ]] && return 0
+    [[ "$title" == "Update Konflux references"* ]] && return 0
+    [[ "$title" == "chore(deps): update registry.access.redhat.com/ubi9"* ]] && return 0
+    [[ "$title" == "chore(deps): update registry.access.redhat.com/ubi10"* ]] && return 0
+    [[ "$title" == "Update registry.access.redhat.com/ubi9"* ]] && return 0
+    [[ "$title" == "Update registry.access.redhat.com/ubi10"* ]] && return 0
     return 1
 }
 

--- a/scripts/process-konflux-prs/list-prs.sh
+++ b/scripts/process-konflux-prs/list-prs.sh
@@ -56,8 +56,10 @@ is_mintmaker_pr() {
     [[ "$title" == "Update Konflux references"* ]] && return 0
     [[ "$title" == "chore(deps): update registry.access.redhat.com/ubi9"* ]] && return 0
     [[ "$title" == "chore(deps): update registry.access.redhat.com/ubi10"* ]] && return 0
+    [[ "$title" == "chore(deps): update registry.redhat.io/rhel9/rhel-bootc"* ]] && return 0
     [[ "$title" == "Update registry.access.redhat.com/ubi9"* ]] && return 0
     [[ "$title" == "Update registry.access.redhat.com/ubi10"* ]] && return 0
+    [[ "$title" == "Update registry.redhat.io/rhel9/rhel-bootc"* ]] && return 0
     return 1
 }
 

--- a/scripts/process-konflux-prs/merge-pr.sh
+++ b/scripts/process-konflux-prs/merge-pr.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Merge a PR using squash strategy
+# Usage: ./merge-pr.sh --repo REPO_NAME --pr PR_NUMBER
+#
+# Returns JSON: {success, repo, pr, message}
+
+set -euo pipefail
+
+REPO_URL=""
+PR_NUMBER=""
+
+# Repository mapping
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)
+            if [[ -n "${REPOS[$2]:-}" ]]; then
+                REPO_URL="${REPOS[$2]}"
+            else
+                echo "Unknown repository: $2" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_URL" || -z "$PR_NUMBER" ]]; then
+    echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER" >&2
+    exit 1
+fi
+
+REPO_NAME=$(basename "$REPO_URL")
+
+if gh pr merge "$PR_NUMBER" \
+    --repo "$REPO_URL" \
+    --merge \
+    --delete-branch 2>/dev/null; then
+    echo "{\"success\": true, \"repo\": \"$REPO_NAME\", \"pr\": $PR_NUMBER, \"message\": \"merged\"}" | jq '.'
+else
+    MSG=$(gh pr view "$PR_NUMBER" --repo "$REPO_URL" --json state,mergeStateStatus \
+        --jq '"state=\(.state) mergeStateStatus=\(.mergeStateStatus)"' 2>/dev/null || echo "unknown")
+    echo "{\"success\": false, \"repo\": \"$REPO_NAME\", \"pr\": $PR_NUMBER, \"message\": \"$MSG\"}" | jq '.'
+    exit 1
+fi

--- a/scripts/process-konflux-prs/skip-pr.sh
+++ b/scripts/process-konflux-prs/skip-pr.sh
@@ -53,6 +53,13 @@ fi
 
 REPO_NAME=$(basename "$REPO_URL")
 
+# Check whether the PR already has the mintmaker-skip label to avoid re-posting
+existing_labels=$(gh pr view "$PR_NUMBER" --repo "$REPO_URL" --json labels --jq '[.labels[].name]')
+if echo "$existing_labels" | jq -e 'any(. == "mintmaker-skip")' >/dev/null 2>&1; then
+    echo "{\"success\": true, \"repo\": \"$REPO_NAME\", \"pr\": $PR_NUMBER, \"message\": \"already skipped\"}" | jq '.'
+    exit 0
+fi
+
 # Ensure the label exists in the repository (idempotent)
 gh label create mintmaker-skip \
     --repo "$REPO_URL" \

--- a/scripts/process-konflux-prs/skip-pr.sh
+++ b/scripts/process-konflux-prs/skip-pr.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Mark a PR as intentionally skipped: post an explanatory comment and add the
+# 'mintmaker-skip' label. The label prevents re-posting the comment on subsequent runs.
+#
+# Usage: ./skip-pr.sh --repo REPO_NAME --pr PR_NUMBER --reason "reason text"
+#
+# Output: JSON {success, repo, pr, message}
+
+set -euo pipefail
+
+REPO_URL=""
+PR_NUMBER=""
+REASON=""
+
+declare -A REPOS=(
+    ["kata-containers"]="https://github.com/openshift/kata-containers"
+    ["cloud-api-adaptor"]="https://github.com/openshift/cloud-api-adaptor"
+    ["compute-artifacts"]="https://github.com/openshift/confidential-compute-artifacts"
+    ["podvm-scripts"]="https://github.com/confidential-devhub/coco-podvm-scripts"
+    ["osc"]="https://github.com/openshift/sandboxed-containers-operator"
+)
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)
+            if [[ -n "${REPOS[$2]:-}" ]]; then
+                REPO_URL="${REPOS[$2]}"
+            else
+                echo "Unknown repository: $2" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        --reason)
+            REASON="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --reason 'reason'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_URL" || -z "$PR_NUMBER" || -z "$REASON" ]]; then
+    echo "Usage: $0 --repo REPO_NAME --pr PR_NUMBER --reason 'reason'" >&2
+    exit 1
+fi
+
+REPO_NAME=$(basename "$REPO_URL")
+
+# Ensure the label exists in the repository (idempotent)
+gh label create mintmaker-skip \
+    --repo "$REPO_URL" \
+    --description "PR intentionally skipped by automated Mintmaker processing" \
+    --color "e4e669" 2>/dev/null || true
+
+gh pr edit "$PR_NUMBER" --repo "$REPO_URL" --add-label "mintmaker-skip" 2>/dev/null
+
+COMMENT="**Automated Mintmaker processing**: this PR is being skipped intentionally.
+
+${REASON}
+
+This PR will not be labelled or merged by the automated process."
+
+gh pr comment "$PR_NUMBER" --repo "$REPO_URL" --body "$COMMENT"
+
+echo "{\"success\": true, \"repo\": \"$REPO_NAME\", \"pr\": $PR_NUMBER, \"message\": \"skipped\"}" | jq '.'

--- a/scripts/process-konflux-prs/snapshot-prs.sh
+++ b/scripts/process-konflux-prs/snapshot-prs.sh
@@ -6,7 +6,7 @@
 #
 # Output: JSON array of PR status objects:
 #   [{repo, pr, title, components, build_checks_passed, build_checks_failed,
-#     pending_checks, has_ok_to_test, has_lgtm}, ...]
+#     pending_checks, has_ok_to_test, has_lgtm, has_mintmaker_skip}, ...]
 
 set -euo pipefail
 
@@ -51,7 +51,8 @@ while IFS= read -r pr; do
           build_checks_failed: (.build_checks_failed // []),
           pending_checks,
           has_ok_to_test,
-          has_lgtm}')
+          has_lgtm,
+          has_mintmaker_skip: ((.labels // []) | any(. == "mintmaker-skip"))}')
     snapshot=$(echo "$snapshot" | jq --argjson e "$entry" '. + [$e]')
 done < <(echo "$prs" | jq -c '.[]')
 

--- a/scripts/process-konflux-prs/snapshot-prs.sh
+++ b/scripts/process-konflux-prs/snapshot-prs.sh
@@ -46,6 +46,7 @@ while IFS= read -r pr; do
     status=$("$SCRIPT_DIR/get-pr-status.sh" --repo "$repo" --pr "$number" 2>/dev/null)
     entry=$(echo "$status" | jq --arg repo "$repo" \
         '{repo: $repo, pr: .number, title: .title,
+          base_branch: (.base_branch // ""),
           components: (.components // []),
           build_checks_passed,
           build_checks_failed: (.build_checks_failed // []),

--- a/scripts/process-konflux-prs/snapshot-prs.sh
+++ b/scripts/process-konflux-prs/snapshot-prs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Discover Mintmaker or Nudge PRs and fetch their status in one pass.
+# Combines list-prs.sh + get-pr-status.sh into a single snapshot.
+#
+# Usage: ./snapshot-prs.sh --mintmaker|--nudge [--repo REPO_NAME]
+#
+# Output: JSON array of PR status objects:
+#   [{repo, pr, title, components, build_checks_passed, build_checks_failed,
+#     pending_checks, has_ok_to_test, has_lgtm}, ...]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PR_TYPE=""
+REPO_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --mintmaker|--nudge)
+            PR_TYPE="$1"
+            shift
+            ;;
+        --repo)
+            REPO_FILTER="--repo $2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 --mintmaker|--nudge [--repo REPO_NAME]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$PR_TYPE" ]]; then
+    echo "Usage: $0 --mintmaker|--nudge [--repo REPO_NAME]" >&2
+    exit 1
+fi
+
+prs=$("$SCRIPT_DIR/list-prs.sh" "$PR_TYPE" $REPO_FILTER)
+
+snapshot='[]'
+while IFS= read -r pr; do
+    repo=$(echo "$pr" | jq -r '.repo')
+    number=$(echo "$pr" | jq -r '.number')
+    status=$("$SCRIPT_DIR/get-pr-status.sh" --repo "$repo" --pr "$number" 2>/dev/null)
+    entry=$(echo "$status" | jq --arg repo "$repo" \
+        '{repo: $repo, pr: .number, title: .title,
+          components: (.components // []),
+          build_checks_passed,
+          build_checks_failed: (.build_checks_failed // []),
+          pending_checks,
+          has_ok_to_test,
+          has_lgtm}')
+    snapshot=$(echo "$snapshot" | jq --argjson e "$entry" '. + [$e]')
+done < <(echo "$prs" | jq -c '.[]')
+
+echo "$snapshot" | jq '.'

--- a/scripts/process-konflux-prs/snapshot-prs.sh
+++ b/scripts/process-konflux-prs/snapshot-prs.sh
@@ -43,7 +43,10 @@ snapshot='[]'
 while IFS= read -r pr; do
     repo=$(echo "$pr" | jq -r '.repo')
     number=$(echo "$pr" | jq -r '.number')
-    status=$("$SCRIPT_DIR/get-pr-status.sh" --repo "$repo" --pr "$number" 2>/dev/null)
+    if ! status=$("$SCRIPT_DIR/get-pr-status.sh" --repo "$repo" --pr "$number" 2>&1); then
+        echo "Warning: failed to get status for $repo #$number: $status" >&2
+        continue
+    fi
     entry=$(echo "$status" | jq --arg repo "$repo" \
         '{repo: $repo, pr: .number, title: .title,
           base_branch: (.base_branch // ""),


### PR DESCRIPTION

This is a first step towards automation.
This skill describe the workflow for handling Mintmaker and Nudge PRs in an automated way, and relies on a set of scripts that performs the underlying actions, limiting the skill's execution to only the needed steps.

It is intended to run from your computer for now, with your credentials. Ideally, we'll want to give it its own tokens for github and Konflux, so that it can run independently.
The usage is to run the skill on a regular basis. It will review the PRs and make them progress towards merging, using labels to track their progress.

This commit provides the skill and scripts, but limits the behavior to "listing" and "labelling" - no merge should be done with it yet. More testing will be done, and when we're confident enough, we can add "merging" to the workflow.

Fixes: [KATA-5147](https://redhat.atlassian.net/browse/KATA-5147)