### PR TITLE
peerpods: add AWS IRSA support for workload identity

### DIFF
--- a/config/peerpods/podvm/ami-helper.sh
+++ b/config/peerpods/podvm/ami-helper.sh
@@ -169,6 +169,26 @@ delete_bucket() {
 	aws s3api delete-bucket --bucket ${BUCKET_NAME} --region ${REGION}
 }
 
+delete_vmimport_role() {
+	echo "Delete vmimport role"
+	if ! aws iam get-role --role-name vmimport --region ${REGION} &>/dev/null; then
+		echo "vmimport role does not exist, skipping deletion"
+		return 0
+	fi
+
+	echo "Deleting inline policy from vmimport role"
+	# Ignore NoSuchEntity error to make cleanup idempotent
+	aws iam delete-role-policy --role-name vmimport --policy-name vmimport --region ${REGION} 2>/dev/null || true
+
+	echo "Deleting vmimport role"
+	if ! aws iam delete-role --role-name vmimport --region ${REGION}; then
+		echo "Error: Failed to delete vmimport role"
+		return 1
+	fi
+
+	echo "Successfully deleted vmimport role"
+}
+
 create_bucket() {
 	echo "Create s3 Bucket named ${BUCKET_NAME} at ${REGION}"
 	if [[ ${REGION} == us-east-1 ]]; then
@@ -303,7 +323,7 @@ prepare
 
 [[ $in_place ]] && extended_credentials
 
-[[ $clean_credentials ]] && clean_credentials; [[ $delete_bucket ]] && delete_bucket; [[ $clean_credentials || $delete_bucket ]] && exit 0
+[[ $delete_bucket ]] && delete_bucket && delete_vmimport_role; [[ $clean_credentials ]] && clean_credentials; [[ $clean_credentials || $delete_bucket ]] && exit 0
 
 create_bucket
 

--- a/config/peerpods/podvm/ami-helper.sh
+++ b/config/peerpods/podvm/ami-helper.sh
@@ -13,9 +13,9 @@ Usage: $(basename $0) [options]
    -c               Clean credentials and exit
    -d               Delete the bucket and exit
    -h               Print this help message
-   -i               In cluster
+   -i               Request and use extended credentials in-place for this execution
    -r <region>      Set the region (otherwise it will be fetched from the cluster)
-   -s               Skip credentials request
+   -s               Skip requesting extended credentials for operator image operations
 EOF
 }
 
@@ -25,13 +25,16 @@ while getopts ":b:cdhir:s" opt; do
 		c ) clean_credentials=true;;
 		d ) delete_bucket=true;;
 		h ) usage && exit 0;;
-		i ) in_cluster=true;;
+		i ) in_place=true;;
 		r ) REGION=$OPTARG;;
 		s ) skip_cr=true;;
 		\? ) echo "Invalid option: -$OPTARG" >&2 && usage && exit 1;;
 	esac
 done
 
+# Request extended credentials from CCO and export them to the current environment
+# for immediate use during this script execution. Used when running with -i flag
+# (typically inside cluster jobs that need elevated permissions).
 extended_credentials() {
 	echo "Creating extended credentials for IAM role management, bucket creation and operation credentials"
 
@@ -224,9 +227,12 @@ clean_credentials() {
 	oc delete credentialsrequest openshift-sandboxed-containers-aws-image -n openshift-cloud-credential-operator
 }
 
+# Request extended credentials from CCO for future operator image creation operations.
+# Creates peer-pods-image-creation-secret that will be used by automated image jobs.
+# Does NOT modify current environment - credentials are saved in secret for later use only.
 get_operation_credentials() {
 	[[ $skip_cr ]] && return
-	echo "Ask for addtional credentials"
+	echo "Ask for additional credentials"
 	oc get ns openshift-sandboxed-containers-operator >/dev/null 2>&1 || (echo "OSC namespace is missing, re-run after installting the operator" && exit 1)
 
 	cat <<EOF > "${CREDENTIALS_REQUEST_YAML_FILE}"
@@ -295,7 +301,7 @@ init
 
 prepare
 
-[[ $in_cluster ]] && extended_credentials
+[[ $in_place ]] && extended_credentials
 
 [[ $clean_credentials ]] && clean_credentials; [[ $delete_bucket ]] && delete_bucket; [[ $clean_credentials || $delete_bucket ]] && exit 0
 
@@ -303,4 +309,4 @@ create_bucket
 
 set_service_role
 
-[[ $in_cluster ]] || get_operation_credentials
+[[ $in_place ]] || get_operation_credentials

--- a/config/peerpods/podvm/ami-helper.sh
+++ b/config/peerpods/podvm/ami-helper.sh
@@ -176,9 +176,25 @@ delete_vmimport_role() {
 		return 0
 	fi
 
-	echo "Deleting inline policy from vmimport role"
-	# Ignore NoSuchEntity error to make cleanup idempotent
-	aws iam delete-role-policy --role-name vmimport --policy-name vmimport --region ${REGION} 2>/dev/null || true
+	echo "Detaching managed policies from vmimport role"
+	# List and detach any managed policies
+	managed_policies=$(aws iam list-attached-role-policies --role-name vmimport --region ${REGION} --query 'AttachedPolicies[*].PolicyArn' --output text 2>/dev/null || true)
+	if [[ -n "$managed_policies" ]]; then
+		for policy_arn in $managed_policies; do
+			echo "Detaching managed policy: $policy_arn"
+			aws iam detach-role-policy --role-name vmimport --policy-arn "$policy_arn" --region ${REGION} || true
+		done
+	fi
+
+	echo "Deleting inline policies from vmimport role"
+	# List and delete all inline policies
+	inline_policies=$(aws iam list-role-policies --role-name vmimport --region ${REGION} --query 'PolicyNames[*]' --output text 2>/dev/null || true)
+	if [[ -n "$inline_policies" ]]; then
+		for policy_name in $inline_policies; do
+			echo "Deleting inline policy: $policy_name"
+			aws iam delete-role-policy --role-name vmimport --policy-name "$policy_name" --region ${REGION} || true
+		done
+	fi
 
 	echo "Deleting vmimport role"
 	if ! aws iam delete-role --role-name vmimport --region ${REGION}; then

--- a/config/peerpods/podvm/ami-helper.sh
+++ b/config/peerpods/podvm/ami-helper.sh
@@ -71,7 +71,7 @@ spec:
       resource: "arn:aws:s3:::${BUCKET_NAME}"
     - effect: Allow
       action:
-        - s3:GetOcbject
+        - s3:GetObject
         - s3:PutObject
         - s3:DeleteObject
       resource: "arn:aws:s3:::${BUCKET_NAME}/*"
@@ -253,7 +253,7 @@ spec:
       resource: "arn:aws:s3:::${BUCKET_NAME}"
     - effect: Allow
       action:
-        - s3:GetOcbject
+        - s3:GetObject
         - s3:PutObject
         - s3:DeleteObject
       resource: "arn:aws:s3:::${BUCKET_NAME}/*"

--- a/config/peerpods/podvm/aws-podvm-image-handler.sh
+++ b/config/peerpods/podvm/aws-podvm-image-handler.sh
@@ -19,8 +19,14 @@ function verify_vars() {
     # Ensure CLOUD_PROVIDER is set to aws
     [[ -z "${CLOUD_PROVIDER}" || "${CLOUD_PROVIDER}" != "aws" ]] && error_exit "CLOUD_PROVIDER is empty or not set to aws"
 
-    [[ -z "${AWS_ACCESS_KEY_ID}" ]] && error_exit "AWS_ACCESS_KEY_ID is not set"
-    [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && error_exit "AWS_SECRET_ACCESS_KEY is not set"
+    # Check for AWS credentials - support both static credentials and IRSA
+    if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
+        echo "Verified static AWS credentials"
+    elif [[ -n "${AWS_ROLE_ARN}" && -n "${AWS_WEB_IDENTITY_TOKEN_FILE}" ]]; then
+        echo "Verified AWS IRSA (IAM Roles for Service Accounts) variables"
+    else
+        error_exit "Neither static credentials (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY) nor IRSA credentials (AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE) are set"
+    fi
 
     # Packer variables
     [[ -z "${INSTANCE_TYPE}" ]] && error_exit "INSTANCE_TYPE is not set"
@@ -200,11 +206,36 @@ function bootc_to_ami() {
     aws_ami_name="${4}"
     aws_bucket="${5}" # bucket must exist
 
-    [[ -n "$AWS_ACCESS_KEY_ID" ]] && [[ -n "$AWS_SECRET_ACCESS_KEY" ]] && [[ -n "$AWS_REGION" ]] || error_exit "bootc_to_ami failed: AWS_* keys or AWS_REGION are missing"
-    # TODO: check permissions
-    run_args="--env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY"
+    # Validate credentials - support both static and IRSA
+    # Note: IRSA check is also done earlier in create_ami_from_prebuilt_artifact() to prevent resource leaks,
+    # but kept here for consistency and future use
+    if [[ -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]]; then
+        echo "bootc_to_ami: Using static AWS credentials"
+	# TODO: pass as env file
+        run_args="--env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY"
+    elif [[ -n "$AWS_ROLE_ARN" && -n "$AWS_WEB_IDENTITY_TOKEN_FILE" ]]; then
+        error_exit "bootc_to_ami failed: IRSA are not yet supported by the Bootc Image Builder"
+	# see https://github.com/osbuild/bootc-image-builder#aws-credentials-file
+    else
+        error_exit "bootc_to_ami failed: no valid credentials are properly configured"
+    fi
+
     bib_args="--type ami --aws-ami-name ${aws_ami_name} --aws-bucket ${aws_bucket} --aws-region ${AWS_REGION}"
     bootc_image_builder_conversion "${container_image_repo_url}" "${image_tag}" "${auth_json_file}" "${run_args}" "${bib_args}"
+}
+
+# Check if peer-pods-secret is based on CCO-created secret (needs permissions extension) or otherwise (should have full permissions).
+# Returns 0 if CCO flow, 1 otherwise (should have full permissions).
+function is_cco_flow_secret() {
+    local cco_label=$(kubectl get secret peer-pods-secret \
+        -n openshift-sandboxed-containers-operator \
+        -o jsonpath='{.metadata.labels.kataconfiguration\.openshift\.io/credentials-request-based}' 2>/dev/null)
+
+    if [[ "$cco_label" == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 function prepare_for_prebuilt_artifact() {
@@ -215,17 +246,39 @@ function prepare_for_prebuilt_artifact() {
     # Update the BUCKET_NAME in the aws-podvm-image-cm configmap
     kubectl patch configmap aws-podvm-image-cm -n openshift-sandboxed-containers-operator --type merge -p "{\"data\":{\"BUCKET_NAME\":\"${BUCKET_NAME}\"}}"
 
-    echo "Calling the helper script to extend credentials, create vmimport role and a bucket"
-    /scripts/ami-helper.sh -i -b ${BUCKET_NAME} || error_exit "Failed to extend credentials, create vmimport role and a bucket using the helper script"
-
-    echo "Extending the credentials in use"
+    # Determine credential source and handle appropriately
     local extended_secret_name="peer-pods-image-creation-secret"
-    export AWS_ACCESS_KEY_ID=$(oc get secret ${extended_secret_name} -n openshift-sandboxed-containers-operator -o jsonpath='{.data.aws_access_key_id}' | base64 -d)
-    export AWS_SECRET_ACCESS_KEY=$(oc get secret ${extended_secret_name} -n openshift-sandboxed-containers-operator -o jsonpath='{.data.aws_secret_access_key}' | base64 -d)
+
+    if [[ -n "${AWS_ROLE_ARN}" && -n "${AWS_WEB_IDENTITY_TOKEN_FILE}" ]]; then
+        echo "Using IRSA credentials for image creation"
+        /scripts/ami-helper.sh -s -b ${BUCKET_NAME} || error_exit "Failed to create bucket using the helper script"
+    elif is_cco_flow_secret; then
+        echo "CCO flow detected, requesting credential extension"
+        /scripts/ami-helper.sh -i -b ${BUCKET_NAME} || error_exit "Failed to extend credentials using the helper script"
+        export AWS_ACCESS_KEY_ID=$(kubectl get secret ${extended_secret_name} -n openshift-sandboxed-containers-operator -o jsonpath='{.data.aws_access_key_id}' | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$(kubectl get secret ${extended_secret_name} -n openshift-sandboxed-containers-operator -o jsonpath='{.data.aws_secret_access_key}' | base64 -d)
+    else
+        echo "Using manual credentials (expecting s3 ${BUCKET_NAME} bucket to exist and vmimport service role to be set)"
+
+        # Validate bucket exists
+        aws s3api head-bucket --bucket ${BUCKET_NAME} --region ${AWS_REGION} 2>/dev/null || \
+            error_exit "Bucket ${BUCKET_NAME} not found or not accessible. When using manual credentials, you must create the bucket and vmimport role before image creation. Use ami-helper.sh or see docs/credentials-handling.md for details."
+
+        echo "Verified bucket ${BUCKET_NAME} is accessible"
+    fi
 }
 
 function create_ami_from_prebuilt_artifact() {
     echo "Creating AWS AMI image from prebuilt artifact"
+
+    # Get the PODVM_IMAGE_TYPE, PODVM_IMAGE_TAG and PODVM_IMAGE_SRC_PATH early
+    get_image_type_url_and_path
+
+    # Reject IRSA for bootc image type before creating any resources
+    # see https://github.com/osbuild/bootc-image-builder#aws-credentials-file
+    if [[ "${PODVM_IMAGE_TYPE}" == "bootc" && -n "${AWS_ROLE_ARN}" && -n "${AWS_WEB_IDENTITY_TOKEN_FILE}" ]]; then
+        error_exit "bootc image type with IRSA credentials is not yet supported by the Bootc Image Builder"
+    fi
 
     prepare_for_prebuilt_artifact
 
@@ -235,9 +288,6 @@ function create_ami_from_prebuilt_artifact() {
     image_repo_auth_file="/tmp/regauth/auth.json"
 
     [[ ! ${BUCKET_NAME} ]] && error_exit "BUCKET_NAME is not defined"
-
-    # Get the PODVM_IMAGE_TYPE, PODVM_IMAGE_TAG and PODVM_IMAGE_SRC_PATH
-    get_image_type_url_and_path
 
     case "${PODVM_IMAGE_TYPE}" in
     oci)
@@ -271,11 +321,16 @@ function create_ami_from_prebuilt_artifact() {
         ;;
     esac
 
-    echo "Deleting the bucket"
-    /scripts/ami-helper.sh -i -d -b ${BUCKET_NAME} || error_exit "Failed to delete the bucket using the helper script"
-
-    echo "Cleaning the credentials"
-    /scripts/ami-helper.sh -i -c || error_exit "Failed to clean the credentials using the helper script"
+    # Cleanup: delete bucket and credentials based on credential source
+    if [[ -n "${AWS_ROLE_ARN}" ]]; then
+        echo "IRSA flow: deleting bucket only (no credential cleanup needed)"
+        /scripts/ami-helper.sh -s -d -b ${BUCKET_NAME} || echo "Warning: Failed to delete bucket"
+    elif is_cco_flow_secret; then
+        echo "CCO flow: deleting bucket and cleaning extended credentials"
+        /scripts/ami-helper.sh -i -c -d -b ${BUCKET_NAME} || echo "Warning: Failed to clean up"
+    else
+        echo "Manual credentials: bucket and vmimport role were pre-created, perform manual cleanup"
+    fi
 }
 
 function upload_image_to_s3() {

--- a/controllers/credentials_controller.go
+++ b/controllers/credentials_controller.go
@@ -349,7 +349,7 @@ func (kh *KataConfigHandler) teardownPeerPodsCredentials(ctx context.Context) (b
 
 // checkAndSetupSTSWorkflow checks if STS (Security Token Service) workflow environment variables
 // are set and creates/updates the peer-pods-secret accordingly.
-// Currently supports Azure only.
+// Currently supports Azure and AWS.
 // Returns true if STS workflow is detected and secret was created/updated successfully.
 // Returns false if no STS environment variables are found or if there's an error.
 func (kh *KataConfigHandler) checkAndSetupSTSWorkflow(ctx context.Context) (bool, error) {
@@ -360,10 +360,16 @@ func (kh *KataConfigHandler) checkAndSetupSTSWorkflow(ctx context.Context) (bool
 	clientID := os.Getenv("CLIENTID")             // Azure client ID
 	tenantID := os.Getenv("TENANTID")             // Azure tenant ID
 	subscriptionID := os.Getenv("SUBSCRIPTIONID") // Azure subscription ID
+
+	// AWS
+	roleARN := os.Getenv("ROLEARN") // AWS IAM Role ARN
+
 	tokenPath := "/var/run/secrets/openshift/serviceaccount/token"
 
 	// Check if Azure STS credentials are provided
 	hasAzureSTSCreds := len(clientID) > 0 && len(tenantID) > 0 && len(subscriptionID) > 0
+	// Check if AWS STS credentials are provided
+	hasAWSSTSCreds := len(roleARN) > 0
 
 	// Label to mark this as an STS-based secret
 	labels := map[string]string{
@@ -371,12 +377,17 @@ func (kh *KataConfigHandler) checkAndSetupSTSWorkflow(ctx context.Context) (bool
 	}
 	secretData := map[string][]byte{}
 	if hasAzureSTSCreds {
-		kh.reconciler.Log.Info("STS workflow detected, creating peer-pods-secret")
+		kh.reconciler.Log.Info("Azure STS workflow detected, creating peer-pods-secret")
 		secretData["AZURE_CLIENT_ID"] = []byte(clientID)
 		secretData["AZURE_TENANT_ID"] = []byte(tenantID)
 		secretData["AZURE_SUBSCRIPTION_ID"] = []byte(subscriptionID)
 		secretData["AZURE_FEDERATED_TOKEN_FILE"] = []byte(tokenPath)
 		labels[labelSTS] = "azure"
+	} else if hasAWSSTSCreds {
+		kh.reconciler.Log.Info("AWS STS workflow detected, creating peer-pods-secret")
+		secretData["AWS_ROLE_ARN"] = []byte(roleARN)
+		secretData["AWS_WEB_IDENTITY_TOKEN_FILE"] = []byte(tokenPath)
+		labels[labelSTS] = "aws"
 	} else {
 		// No STS credentials found
 		return false, nil

--- a/controllers/image_generator.go
+++ b/controllers/image_generator.go
@@ -611,6 +611,8 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 
 	// aws Secret Keys
 	awsSecretKeys := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+	// aws Secret Keys for IRSA (IAM Roles for Service Accounts)
+	awsSecretIRSAKeys := []string{"AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"}
 	// aws ConfigMap Keys
 	awsConfigMapKeys := []string{"AWS_REGION", "AWS_SUBNET_ID", "AWS_VPC_ID", "AWS_SG_IDS", "CLOUD_PROVIDER"}
 	// azure Secret Keys
@@ -635,8 +637,9 @@ func (r *ImageGenerator) validatePeerPodsConfigs() error {
 	// Check for each cloud provider if respective ConfigMap keys are present in the peerPodsConfigMap
 	switch r.provider {
 	case "aws":
-		// Check if aws Secret Keys are present in the peerPodsSecret by calling checkKeysPresentAndNotEmpty
-		if !checkKeysPresentAndNotEmpty(peerPodsSecret.Data, awsSecretKeys) {
+		// Check if aws Secret Keys are present in the peerPodsSecret
+		// Support both static credentials and IRSA (federated tokens)
+		if !(checkKeysPresentAndNotEmpty(peerPodsSecret.Data, awsSecretKeys) || checkKeysPresentAndNotEmpty(peerPodsSecret.Data, awsSecretIRSAKeys)) {
 			return fmt.Errorf("validatePeerPodsConfigs: cannot find the required keys in peer-pods-secret Secret")
 		}
 

--- a/controllers/peerpods.go
+++ b/controllers/peerpods.go
@@ -245,41 +245,56 @@ func (r *KataConfigOpenShiftReconciler) configureCAAProvider(ds *appsv1.DaemonSe
 		// Check for all STS environment variables (set during OLM installation)
 		hasAzureSTSCreds := os.Getenv("CLIENTID") != "" && os.Getenv("TENANTID") != "" && os.Getenv("SUBSCRIPTIONID") != ""
 		if hasAzureSTSCreds {
-			r.Log.Info("STS flow detected for Azure, adding bound-sa-token volume mount")
-			boundSATokenVolume := corev1.Volume{
-				Name: "bound-sa-token",
-				VolumeSource: corev1.VolumeSource{
-					Projected: &corev1.ProjectedVolumeSource{
-						Sources: []corev1.VolumeProjection{
-							{
-								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-									Path:     "token",
-									Audience: "openshift",
-								},
-							},
-						},
-					},
-				},
-			}
+			r.addBoundSATokenVolume(ds)
+		}
 
-			boundSATokenVolumeMount := corev1.VolumeMount{
-				MountPath: "/var/run/secrets/openshift/serviceaccount",
-				Name:      "bound-sa-token",
-				ReadOnly:  true,
-			}
-
-			ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, boundSATokenVolume)
-			for i := range ds.Spec.Template.Spec.Containers {
-				container := &ds.Spec.Template.Spec.Containers[i]
-				if container.Name == "caa-pod" {
-					container.VolumeMounts = append(container.VolumeMounts, boundSATokenVolumeMount)
-				}
-			}
+		return ds, nil
+	case AWSProvider:
+		// Only add bound-sa-token volume for AWS IRSA if using STS flow
+		// Check for STS environment variable (set during OLM installation)
+		hasAWSSTSCreds := os.Getenv("ROLEARN") != ""
+		if hasAWSSTSCreds {
+			r.addBoundSATokenVolume(ds)
 		}
 
 		return ds, nil
 	default:
 		return ds, nil
+	}
+}
+
+// addBoundSATokenVolume adds bound-sa-token volume and mount to the DaemonSet for STS/workload identity flows
+func (r *KataConfigOpenShiftReconciler) addBoundSATokenVolume(ds *appsv1.DaemonSet) {
+	r.Log.Info("STS flow detected, adding bound-sa-token volume mount")
+
+	boundSATokenVolume := corev1.Volume{
+		Name: "bound-sa-token",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:     "token",
+							Audience: "openshift",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	boundSATokenVolumeMount := corev1.VolumeMount{
+		MountPath: "/var/run/secrets/openshift/serviceaccount",
+		Name:      "bound-sa-token",
+		ReadOnly:  true,
+	}
+
+	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, boundSATokenVolume)
+	for i := range ds.Spec.Template.Spec.Containers {
+		container := &ds.Spec.Template.Spec.Containers[i]
+		if container.Name == "caa-pod" {
+			container.VolumeMounts = append(container.VolumeMounts, boundSATokenVolumeMount)
+		}
 	}
 }
 

--- a/docs/credentials-handling.md
+++ b/docs/credentials-handling.md
@@ -1,29 +1,280 @@
 # Peer-Pods Credentials Handling
 
-This document describes the three credential flows available for providing cloud credentials to the OpenShift Sandboxed Containers Operator for peer-pods functionality.
+This document describes credential configuration options for the OpenShift Sandboxed Containers Operator peer-pods functionality.
 
 ## Overview
 
-The operator supports three distinct flows for obtaining cloud credentials, evaluated in priority order:
+The operator requires cloud credentials to provision and manage peer-pods workloads. Three credential flows are supported, with availability depending on cloud provider and cluster operation mode:
 
-1. **User-created secret** (highest priority)
-2. **STS workflow** (Workload identity via federated tokens)
-3. **CCO workflow** (Cloud Credential Operator - fallback)
+1. **STS workflow** (Tokenized authentication): AWS, Azure
+2. **CCO workflow** (Cloud Credential Operator): AWS, Azure, GCP
+3. **User-created secret**: All providers
 
-The credential flow selection happens automatically in `setupPeerPodsCredentials()` during KataConfig creation or update when `enablePeerPods: true`.
+The credential flow selection happens automatically during KataConfig creation when `enablePeerPods: true`, based on the existence and type of user-provided credentials.
 
-## Flow 1: User-Created Secret (Manual)
+---
 
-**Priority**: Highest
+## AWS Credentials
 
-**Supported Providers**: All
+### Option 1: Tokenized Authentication (IRSA)
 
-### Description
-Users manually create the `peer-pods-secret` in the `openshift-sandboxed-containers-operator` namespace with cloud provider credentials.
+#### Description
+Uses AWS IAM Roles for Service Accounts (IRSA) for authentication without long-lived secrets. This is the recommended option for AWS credentials. When the cluster is configured for tokenized authentication and appropriate credentials were provided during OLM installation (and the user has not provided credentials in peer-pods-secret), the operator reads environment variables set during OLM installation and creates a secret containing the provided variables and pointing to the projected volume containing the service account token.
 
-### User Guide
+Reference: [OpenShift Enhancement Proposal #1800](https://github.com/openshift/enhancements/pull/1800)
+
+#### Prerequisites
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed locally
+- AWS credentials with IAM permissions to create roles and policies (one-time setup only).
+
 #### Credentials Setup
-1. At configuration time (before deploying KataConfig), create `peer-pods-secret` with cloud credentials as follows:
+
+**Note**: This setup uses a single IAM role with two managed policies - a base policy for runtime CAA operations and an extended policy for image creation operations. The image creation policy can be detached after image creation to follow the principle of least privilege.
+
+1. Get AWS account ID and OIDC Provider
+```bash
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+OIDC_PROVIDER=$(oc get authentication cluster -ojson | jq -r .spec.serviceAccountIssuer | sed -e "s/^https:\/\///")
+```
+
+2. Create the IAM role with trust policy:
+```bash
+# Set variables
+ROLE_NAME=openshift-sandboxed-containers-role
+
+# Create trust policy document
+cat > trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:openshift-sandboxed-containers-operator:default",
+          "${OIDC_PROVIDER}:aud": "openshift"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+# Create the IAM role
+aws iam create-role \
+  --role-name $ROLE_NAME \
+  --assume-role-policy-document file://trust-policy.json
+```
+
+3. Create and attach the base policy (required for runtime CAA operations):
+```bash
+# TODO: Use a reduced custom policy with only required EC2 permissions instead of AmazonEC2FullAccess
+aws iam attach-role-policy \
+  --role-name ${ROLE_NAME} \
+  --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess
+```
+
+4. Create and attach the extended policy (required only for image creation):
+```bash
+cat > extended-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VMImportRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:PutRolePolicy",
+        "iam:GetRole",
+        "iam:ListRolePolicies",
+        "iam:DeleteRole",
+        "iam:DeleteRolePolicy"
+      ],
+      "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/vmimport"
+    },
+    {
+      "Sid": "S3BucketManagement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:GetBucketAcl"
+      ],
+      "Resource": "arn:aws:s3:::podvm-*"
+    },
+    {
+      "Sid": "S3ObjectManagement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::podvm-*/*"
+    },
+    {
+      "Sid": "S3ListAllBuckets",
+      "Effect": "Allow",
+      "Action": "s3:ListAllMyBuckets",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+aws iam create-policy \
+  --policy-name OSC-ImageCreation-Policy \
+  --policy-document file://extended-policy.json
+
+# Attach for image creation (temporary)
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/OSC-ImageCreation-Policy
+```
+
+5. Follow OSC installation instructions. At Subscription creation, provide the IAM Role ARN:
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sandboxed-containers-operator
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  config:
+    env:
+    - name: ROLEARN
+      value: arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ROLE_NAME}
+  installPlanApproval: Manual
+  channel: stable
+  name: sandboxed-containers-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: sandboxed-containers-operator.v1.12.1
+```
+
+6. Continue following the OSC installation instructions for AWS peer-pods configuration
+
+**Note**: After image creation completes, it's highly recommended to detach the extended policy for security (least privilege). The IAM role ARN remains the same when attaching/detaching policies, so no operator or configuration changes are needed. If you need to recreate images in the future, simply re-attach the extended policy temporarily, then detach it again after completion.
+
+```bash
+# Detach extended policy after image creation
+aws iam detach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/OSC-ImageCreation-Policy
+
+# Verify only base policy remains
+aws iam list-attached-role-policies --role-name $ROLE_NAME
+```
+
+#### Credentials Cleanup
+1. Detach all policies and delete the IAM role when you delete OSC:
+```bash
+# Detach policies from IRSA role
+aws iam detach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess
+
+# If still attached
+aws iam detach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/OSC-ImageCreation-Policy
+
+aws iam delete-role --role-name $ROLE_NAME
+
+# Delete the custom policy
+aws iam delete-policy --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/OSC-ImageCreation-Policy
+
+# Delete vmimport role (created during image creation)
+aws iam delete-role-policy --role-name vmimport --policy-name vmimport
+aws iam delete-role --role-name vmimport
+```
+
+#### How it works
+
+**Setup Flow:**
+1. User configures the IAM role's trust policy to trust the cluster's OIDC issuer for the `openshift-sandboxed-containers-operator:default` service account
+2. User creates role policies with EC2 permissions required by CAA and S3 and IAM permissions required for the image creation Job and attaches them to the IAM role
+3. During operator installation via OLM/web console, user provides the created AWS IAM Role ARN (ROLEARN)
+4. Setup: On KataConfig creation, the operator consumes the variable and creates `peer-pods-secret` and mounts the service account projected volume
+   with IRSA-based authentication configuration:
+   ```yaml
+   AWS_ROLE_ARN: <from-env>
+   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/openshift/serviceaccount/token
+   ```
+5. Token fetching: CAA DaemonSet and image jobs consume the signed Kubernetes token from the projected service account token file.
+6. Exchange: AWS SDK used by the jobs/CAA code sends this token to AWS STS (Security Token Service)
+7. Validation: AWS STS validates the token against the configured OIDC provider and checks if the issuer is trusted
+8. Access: If the trust is verified, AWS STS exchanges the Kubernetes token for temporary AWS credentials, which are used to perform EC2 operations allowed by the IAM role (e.g., create instances, manage volumes, etc.)
+9. After image creation use can deatch the extended role policy with the image creation permissions
+
+**Cleanup Flow:**
+1. On KataConfig deletion or `enablePeerPods: false`:
+   - Operator identifies STS secret by its label and deletes `peer-pods-secret`
+
+---
+
+### Option 2: Cloud Credential Operator (CCO)
+
+**Priority**: Third (fallback, automatic)
+
+#### Description
+Leverages OpenShift's Cloud Credential Operator to dynamically provision cloud credentials. The operator creates a CredentialsRequest, CCO provisions credentials, and the credentials controller translates them to the peer-pods format. This is the default option when the user does not provide credentials.
+
+#### Credentials Setup
+1. The peer-pods-secret will be created automatically
+
+#### Credentials Cleanup
+1. The peer-pods-secret will be deleted automatically
+
+#### How it works
+
+**Setup Flow:**
+
+1. KataConfig created with `enablePeerPods: true`
+2. **Image creation credentials:**
+    1. Image creation job executes ami-helper.sh script
+    2. ami-helper.sh creates CredentialsRequest requesting image creation permissions
+    3. CCO creates peer-pods-image-creation-secret in response to CredentialsRequest
+    4. ami-helper.sh uses the created credentials to create vmimport role and S3 bucket
+    5. ami-helper.sh updates the CredentialsRequest, switching the requested permissions from infrastructure setup permissions to image creation permissions
+    6. CCO updates peer-pods-image-creation-secret in response to the updated CredentialsRequest
+    7. Image creation job uses the updated credentials for image creation
+    8. Image creation job cleans up unused resources
+
+3. **Cloud API adaptor credentials:**
+    1. credentials-controller creates CredentialsRequest for provider
+    2. CCO creates cco-secret in response to CredentialsRequest
+    3. credentials-controller is triggered by cco-secret creation
+    4. credentials-controller translates cco-secret to peer-pods-secret
+    5. peer-pods-secret is owned by cco-secret (via OwnerReference)
+
+**Cleanup Flow:**
+1. KataConfig deleted or enablePeerPods: false
+2. credentials-controller deletes CredentialsRequest
+3. CCO deletes cco-secret
+4. Garbage Collector deletes owned peer-pods-secret
+
+#### Identification
+CCO-created secrets are identified by:
+- Label `kataconfiguration.openshift.io/credentials-request-based: true`
+- OwnerReference to the cco-secret
+
+---
+
+### Option 3: Manual Credentials
+
+#### Description
+Users manually create the `peer-pods-secret` in the `openshift-sandboxed-containers-operator` namespace with AWS credentials.
+
+#### Credentials Setup
+1. At configuration time (before deploying KataConfig), create `peer-pods-secret` with AWS credentials:
 
 ```yaml
 apiVersion: v1
@@ -33,41 +284,63 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 type: Opaque
 data:
-  # Azure example
-  AZURE_CLIENT_ID: <base64-encoded-client-id>
-  AZURE_CLIENT_SECRET: <base64-encoded-client-secret>
-  AZURE_TENANT_ID: <base64-encoded-tenant-id>
-  AZURE_SUBSCRIPTION_ID: <base64-encoded-subscription-id>
+  AWS_ACCESS_KEY_ID: <base64-encoded-access-key-id>
+  AWS_SECRET_ACCESS_KEY: <base64-encoded-secret-access-key>
 ```
 
-#### Credentials Cleanup
-1. Delete the secret when no longer needed:
+**AWS-specific requirements**: When using manual AWS credentials for image creation, you must pre-create the S3 bucket and vmimport IAM role before deploying KataConfig. You can use the `ami-helper.sh` script to automate this setup:
+
+```bash
+# Set your bucket name and region
+export BUCKET_NAME=podvm-image-bucket-name-example
+export REGION=us-east-1
+
+# Create bucket and vmimport role (requires AWS credentials with appropriate permissions)
+./config/peerpods/podvm/ami-helper.sh -s -b ${BUCKET_NAME} -r ${REGION}
+
+# Set the bucket name in the peer-pods ConfigMap
+oc patch configmap peer-pods-cm -n openshift-sandboxed-containers-operator \
+  --type merge -p "{\"data\":{\"BUCKET_NAME\":\"${BUCKET_NAME}\"}}"
 ```
+
+The script will:
+- Create an S3 bucket with the specified name
+- Set up the vmimport IAM service role for EC2 VM Import
+- Grant the vmimport role access to the S3 bucket
+
+Alternatively, you can create these resources manually. The vmimport role trust policy and permissions must allow EC2 VM Import to access your S3 bucket.
+
+#### Credentials Cleanup
+1. Delete the S3 bucket and vmimport role (can be done after image creation is completed):
+```bash
+./config/peerpods/podvm/ami-helper.sh -s -d -b ${BUCKET_NAME} -r ${REGION}
+```
+
+2. Delete the secret:
+```bash
 oc delete secret/peer-pods-secret -n openshift-sandboxed-containers-operator
 ```
 
-
-### How it works
+#### How it works
 1. User creates `peer-pods-secret` with required cloud credentials
 2. Operator detects the existing secret and skips automated credential setup
 3. Secret persists until manually deleted by the user
 
 ---
 
-## Flow 2: STS Workflow (Workload Identity)
+## Azure Credentials
 
-**Priority**: Second (if user's secret was not created)
+### Option 1: Tokenized Authentication (Workload Identity)
 
-**Supported Providers**: Azure
-
-### Description
-When the cluster is in workload/federated identitiy mode and an identity was provided during OLM installation (when applying the subscription), the operator uses Azure Workload Identity (federated tokens) for authentication without long-lived secrets.
-
-The operator reads environment variables set during OLM installation and creates a secret pointing to the projected service account token.
+#### Description
+Uses Azure Workload Identity for authentication without long-lived secrets. This is the recommended option for Azure credentials. When the cluster is configured for tokenized authentication and appropriate credentials were provided during OLM installation (and the user has not provided credentials in peer-pods-secret), the operator reads environment variables set during OLM installation and creates a secret containing the provided variables and pointing to the projected volume containing the service account token.
 
 Reference: [OpenShift Enhancement Proposal #1800](https://github.com/openshift/enhancements/pull/1800)
 
-### User Guide
+#### Prerequisites
+- [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) installed locally
+- Azure credentials with permissions to create identities and assign roles (one-time setup only)
+
 #### Credentials Setup
 1. Create an identity within your RG
 ```
@@ -120,7 +393,8 @@ spec:
 ```
 az identity delete --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --location $LOCATION
 ```
-### How it works
+
+#### How it works
 
 **Setup Flow:**
 1. User creates an identity within their resource group
@@ -147,31 +421,25 @@ az identity delete --name $IDENTITY_NAME --resource-group $RESOURCE_GROUP --loca
 1. On KataConfig deletion or `enablePeerPods: false`:
    - Operator identifies STS secret by its label and deletes `peer-pods-secret`
 
-### Identification
-- Secret is labeled with `kataconfiguration.openshift.io/sts: azure`
+
 
 ---
 
-## Flow 3: CCO Workflow (Cloud Credential Operator)
+### Option 2: Cloud Credential Operator (CCO)
 
-**Priority**: Third (fallback, automatic)
+#### Description
+Leverages OpenShift's Cloud Credential Operator to dynamically provision cloud credentials. The operator creates a CredentialsRequest, CCO provisions credentials, and the credentials controller translates them to the peer-pods format. This is the default option when the user does not provide credentials.
 
-**Supported Providers**: AWS, Azure, GCP
-
-### Description
-Leverages OpenShift's Cloud Credential Operator to dynamically provision cloud credentials. The operator creates a CredentialsRequest, CCO provisions credentials, and the credentials controller translates them to the peer-pods format.
-
-### User Guide
 #### Credentials Setup
 1. The peer-pods-secret will be created automatically
+
 #### Credentials Cleanup
 1. The peer-pods-secret will be deleted automatically
 
-
-### How it works
+#### How it works
 
 **Setup Flow:**
-1. KataConfig created with enablePeerPods: true
+1. KataConfig created with `enablePeerPods: true`
 2. credentials-controller creates CredentialsRequest for provider
 3. CCO creates cco-secret in response to CredentialsRequest
 4. credentials-controller triggered by cco-secret creation
@@ -184,10 +452,42 @@ Leverages OpenShift's Cloud Credential Operator to dynamically provision cloud c
 3. CCO deletes cco-secret
 4. Garbage Collector deletes owned peer-pods-secret
 
-### Identification
+#### Identification
 CCO-created secrets are identified by:
-- Owner reference: controlled by `cco-secret`
-- Kind: `Secret`
-- Name: `cco-secret`
+- Label `kataconfiguration.openshift.io/credentials-request-based: true`
+- OwnerReference to the cco-secret
 
 ---
+
+### Option 3: Manual Credentials
+
+#### Description
+Users manually create the `peer-pods-secret` in the `openshift-sandboxed-containers-operator` namespace with Azure credentials.
+
+#### Credentials Setup
+1. At configuration time (before deploying KataConfig), create `peer-pods-secret` with Azure credentials:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: peer-pods-secret
+  namespace: openshift-sandboxed-containers-operator
+type: Opaque
+data:
+  AZURE_CLIENT_ID: <base64-encoded-client-id>
+  AZURE_CLIENT_SECRET: <base64-encoded-client-secret>
+  AZURE_TENANT_ID: <base64-encoded-tenant-id>
+  AZURE_SUBSCRIPTION_ID: <base64-encoded-subscription-id>
+```
+
+#### Credentials Cleanup
+1. Delete the secret when no longer needed:
+```
+oc delete secret/peer-pods-secret -n openshift-sandboxed-containers-operator
+```
+
+#### How it works
+1. User creates `peer-pods-secret` with required cloud credentials
+2. Operator detects the existing secret and skips automated credential setup
+3. Secret persists until manually deleted by the user

--- a/docs/credentials-handling.md
+++ b/docs/credentials-handling.md
@@ -40,7 +40,7 @@ OIDC_PROVIDER=$(oc get authentication cluster -ojson | jq -r .spec.serviceAccoun
 2. Create the IAM role with trust policy:
 ```bash
 # Set variables
-ROLE_NAME=openshift-sandboxed-containers-role
+export ROLE_NAME=openshift-sandboxed-containers-role
 
 # Create trust policy document
 cat > trust-policy.json <<EOF
@@ -190,10 +190,6 @@ aws iam delete-role --role-name $ROLE_NAME
 
 # Delete the custom policy
 aws iam delete-policy --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/OSC-ImageCreation-Policy
-
-# Delete vmimport role (created during image creation)
-aws iam delete-role-policy --role-name vmimport --policy-name vmimport
-aws iam delete-role --role-name vmimport
 ```
 
 #### How it works


### PR DESCRIPTION
Add support for AWS IAM Roles for Service Accounts (IRSA) to enable workload identity authentication for peer-pods, similar to the existing Azure workload identity support.

- credentials_controller: detect ROLEARN env var and create peer-pods-secret with AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE
- peerpods: mount bound-sa-token volume to CAA DaemonSet when IRSA detected
- image_generator: validate IRSA credentials as alternative to static keys
- Refactor addBoundSATokenVolume into shared helper for Azure and AWS

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
