### PR TITLE
mintmaker: remove the schedule override

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "schedule": ["* * * * 0,6"],
     "extends": [
         "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
     ],


### PR DESCRIPTION
Running once per week is not enough when we are in release phase. The schedule made sense with all the go/rust updates, but with just the base image updates, we can deal with the flow like we do with other repos.
