### PR TITLE
pipelines: update the pipeline definitions for 1.12

### DIFF
--- a/pipelinedef/project.yaml
+++ b/pipelinedef/project.yaml
@@ -6,7 +6,9 @@ spec:
   displayName: "This project is used to deploy sandboxed containers pipelines"
   description: |
     Most of the development for Sandboxed Containers happen in the default branch
-    of its repositories, releasing a new version every 6 months.
+    of its repositories, releasing a new version every 4 months.
     Now sometimes we need to release an intermediate version without stopping
     work on the future longer term release.
     This project is used to deploy pipelines that support such concurrent work.
+    This is supposed to be temporary - as a single-stream product, releasing a
+    new version makes the previous one EOL and we can remove the pipelines for it.

--- a/pipelinedef/template.yaml
+++ b/pipelinedef/template.yaml
@@ -41,6 +41,13 @@ spec:
     spec:
       displayName: "osc-dm-verity-image-debug-{{.versionName}}"
 
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "build-initrds-{{.versionName}}"
+    spec:
+      displayName: "build-initrds-{{.versionName}}"
+
   # Components
 
   - apiVersion: appstudio.redhat.com/v1alpha1
@@ -257,6 +264,7 @@ spec:
       build-nudges-ref:
       - "osc-operator-bundle-{{.versionName}}"
       - "osc-dm-verity-image-{{.versionName}}"
+      - "initrd-builder-{{.versionName}}"
       componentName: "osc-podvm-payload-{{.versionName}}"
       resources: {}
       source:
@@ -363,7 +371,7 @@ spec:
           17 Nov 2025 15:31:45 UTC"},"message":"done"}'
         git-provider: github
         git-provider-url: https://github.com
-      name: "build-dm-verity-image-task-{{.versionName}}"
+      name: "osc-dm-verity-image-debug-{{.versionName}}"
     spec:
       application: "osc-dm-verity-image-debug-{{.versionName}}"
       componentName: "osc-dm-verity-image-debug-{{.versionName}}"
@@ -372,6 +380,26 @@ spec:
         git:
           revision: "osc-release-{{.version}}"
           url: https://github.com/confidential-devhub/coco-podvm-scripts/
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/confidential-compute-artifacts/pull/123","configuration-time":"Wed,
+          11 Feb 2026 09:14:33 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
+      name: "initrd-builder-{{.versionName}}"
+    spec:
+      application: "build-initrds-{{.versionName}}"
+      componentName: "initrd-builder-{{.versionName}}"
+      source:
+        git:
+          context: containerfiles/initrd-builder/
+          dockerfileUrl: Containerfile
+          revision: "osc-release-{{.version}}"
+          url: https://github.com/openshift/confidential-compute-artifacts
 
     # ImageRepository is the object that links the component to a location on quay.io
     # where the built images will be stored.
@@ -678,6 +706,26 @@ spec:
         method: webhook
         title: SBOM-event-to-Bombino
 
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: ImageRepository
+    metadata:
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
+      labels:
+        appstudio.redhat.com/application: "build-initrds-{{.versionName}}"
+        appstudio.redhat.com/component: "initrd-builder-{{.versionName}}"
+      name: "initrd-builder-{{.versionName}}"
+    spec:
+      image:
+        name: "ose-osc-tenant/initrd-builder-{{.versionName}}"
+        visibility: public
+      notifications:
+      - config:
+          url: https://bombino.api.redhat.com/v1/sbom/quay/push
+        event: repo_push
+        method: webhook
+        title: SBOM-event-to-Bombino
+
   # IntegrationTestScenario
   # NOTE: we don't need to duplicate the Enterprise Contract, as it will be
   # created automatically when the ReleasePlan is created.
@@ -729,3 +777,4 @@ spec:
           value: tests/osc-test-fbc-integration.yaml
         resolver: git
         resourceKind: pipeline
+


### PR DESCRIPTION
- fix template name for the dm-verity-debug component
- add build-initrds application and initrd-builder component
- update project definition description

Fixes: [KATA-5167](https://redhat.atlassian.net/browse/KATA-5167)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Release cadence changed to a 4‑month cycle; clarified concurrent-work support and that prior versions become EOL when new versions are released.
* **New Features**
  * Added a new build application, component, and image repository entry with SBOM webhook configuration to support initrd/image workflows.
* **Other**
  * Renamed an existing build component to reflect debug-oriented usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->