### PR TITLE
osc-podvm-builder: update the submodules to point to the 1.12 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "config/peerpods/podvm/cloud-api-adaptor"]
 	path = config/peerpods/podvm/cloud-api-adaptor
 	url = https://github.com/openshift/cloud-api-adaptor/
-	branch = osc-release
+	branch = osc-release-v1.12


### PR DESCRIPTION
Fixes: [KATA-5167](https://redhat.atlassian.net/browse/KATA-5167)