### PR TITLE
konflux: update the mirrors file to take 1.12 builds into account

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,36 +6,47 @@ spec:
   imageTagMirrors:
     - mirrors:
       - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
     - mirrors:
       - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-pccs
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs
 ---
 apiVersion: config.openshift.io/v1
@@ -46,34 +57,45 @@ spec:
   imageDigestMirrors:
     - mirrors:
       - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9
     - mirrors:
       - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa
+      - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-builder-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-must-gather-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-pccs
     - mirrors:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs


### PR DESCRIPTION
Fixes: [KATA-5167](https://redhat.atlassian.net/browse/KATA-5167)

NOTE: this is actually needed on the 1.12 branch, but having both mirrors mentioned here will help for testing (no need to choose which mirror file to use).
I will pick this on the branch after it's merged, so that the Konflux automation running there can find and use this mirror.