### PR TITLE
controller: skip MCP use when MachineConfigPool API is absent on HCP

### DIFF
--- a/controllers/deployment_mode_handler.go
+++ b/controllers/deployment_mode_handler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -29,9 +30,10 @@ const (
 )
 
 const (
-	machineConfigGroup   = "machineconfiguration.openshift.io"
-	machineConfigVersion = "v1"
-	machineConfigKind    = "MachineConfig"
+	machineConfigGroup    = "machineconfiguration.openshift.io"
+	machineConfigVersion  = "v1"
+	machineConfigKind     = "MachineConfig"
+	machineConfigPoolKind = "MachineConfigPool"
 )
 
 func ParseDeploymentModeOption(s string) (DeploymentModeOption, error) {
@@ -106,7 +108,9 @@ func (r *KataConfigOpenShiftReconciler) isMachineConfigAvailable() (bool, error)
 
 	// Attempt to GET any MachineConfig to verify if the GVK is known.
 	// If the CRD isn’t installed, it will return a NoMatchError.
-	err := r.Client.Get(context.Background(), client.ObjectKey{Name: "dummy-machine-config"}, machineConfig)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := r.Client.Get(ctx, client.ObjectKey{Name: "dummy-machine-config"}, machineConfig)
 	if err == nil || k8serrors.IsNotFound(err) {
 		r.Log.Info("MachineConfig CRD is present")
 		return true, nil
@@ -114,6 +118,33 @@ func (r *KataConfigOpenShiftReconciler) isMachineConfigAvailable() (bool, error)
 
 	if meta.IsNoMatchError(err) {
 		r.Log.Info("MachineConfig CRD not found")
+		return false, nil
+	}
+
+	return false, err
+}
+
+// isMachineConfigPoolAvailable reports whether the MachineConfigPool API is registered.
+// Hosted control plane guest clusters often omit MCP while still exposing other MCO types;
+// an unconditional MCP watch prevents the operator manager from starting (see KATA-4840).
+func (r *KataConfigOpenShiftReconciler) isMachineConfigPoolAvailable() (bool, error) {
+	mcp := &unstructured.Unstructured{}
+	mcp.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   machineConfigGroup,
+		Version: machineConfigVersion,
+		Kind:    machineConfigPoolKind,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := r.Client.Get(ctx, client.ObjectKey{Name: "dummy-machine-config-pool"}, mcp)
+	if err == nil || k8serrors.IsNotFound(err) {
+		r.Log.Info("MachineConfigPool CRD is present")
+		return true, nil
+	}
+
+	if meta.IsNoMatchError(err) {
+		r.Log.Info("MachineConfigPool CRD not found")
 		return false, nil
 	}
 

--- a/controllers/deployment_mode_handler_test.go
+++ b/controllers/deployment_mode_handler_test.go
@@ -1,0 +1,146 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// mcpProbeClient stubs Get for MachineConfigPool probes (fake client returns NotFound, not NoMatch).
+type mcpProbeClient struct {
+	client.Client
+	mcpGetErr error
+}
+
+func (c *mcpProbeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == machineConfigPoolKind {
+		if c.mcpGetErr != nil {
+			return c.mcpGetErr
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestIsMachineConfigPoolAvailable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns false when MCP API is not registered", func(t *testing.T) {
+		t.Parallel()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+
+		base := fake.NewClientBuilder().WithScheme(scheme).Build()
+		noMatch := &meta.NoKindMatchError{
+			GroupKind: schema.GroupKind{
+				Group: machineConfigGroup,
+				Kind:  machineConfigPoolKind,
+			},
+			SearchedVersions: []string{machineConfigVersion},
+		}
+		r := &KataConfigOpenShiftReconciler{
+			Client: &mcpProbeClient{Client: base, mcpGetErr: noMatch},
+			Log:    logr.Discard(),
+		}
+
+		avail, err := r.isMachineConfigPoolAvailable()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if avail {
+			t.Fatal("expected MachineConfigPool to be unavailable")
+		}
+	})
+
+	t.Run("returns true when MCP API is registered", func(t *testing.T) {
+		t.Parallel()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := mcfgv1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+
+		r := &KataConfigOpenShiftReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Log:    logr.Discard(),
+		}
+
+		avail, err := r.isMachineConfigPoolAvailable()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !avail {
+			t.Fatal("expected MachineConfigPool to be available")
+		}
+	})
+
+	t.Run("returns true when MCP CR exists", func(t *testing.T) {
+		t.Parallel()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := mcfgv1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+
+		mcp := &mcfgv1.MachineConfigPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		}
+		r := &KataConfigOpenShiftReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcp).Build(),
+			Log:    logr.Discard(),
+		}
+
+		avail, err := r.isMachineConfigPoolAvailable()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !avail {
+			t.Fatal("expected MachineConfigPool to be available")
+		}
+	})
+}
+
+func TestCheckConvergedClusterWhenMCPUnavailable(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	noMatch := &meta.NoKindMatchError{
+		GroupKind: schema.GroupKind{
+			Group: machineConfigGroup,
+			Kind:  machineConfigPoolKind,
+		},
+		SearchedVersions: []string{machineConfigVersion},
+	}
+	r := &KataConfigOpenShiftReconciler{
+		Client: &mcpProbeClient{Client: base, mcpGetErr: noMatch},
+		Log:    logr.Discard(),
+	}
+
+	converged, err := r.checkConvergedCluster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if converged {
+		t.Fatal("expected cluster not to be converged when MCP API is absent")
+	}
+}

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -42,6 +42,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	nodeapi "k8s.io/api/node/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -761,12 +762,24 @@ func (r *KataConfigOpenShiftReconciler) kataOcExists() (bool, error) {
 }
 
 func (r *KataConfigOpenShiftReconciler) checkConvergedCluster() (bool, error) {
-	//Check if only master and worker MCP exists
-	//Worker machinecount should be 0
+	mcpAvailable, err := r.isMachineConfigPoolAvailable()
+	if err != nil {
+		return false, err
+	}
+	if !mcpAvailable {
+		r.Log.Info("MachineConfigPool API unavailable; assuming cluster is not converged")
+		return false, nil
+	}
+
+	// Check if only master and worker MCP exists. Worker machinecount should be 0.
 	listOpts := []client.ListOption{}
 	mcpList := &mcfgv1.MachineConfigPoolList{}
-	err := r.Client.List(context.TODO(), mcpList, listOpts...)
+	err = r.Client.List(context.TODO(), mcpList, listOpts...)
 	if err != nil {
+		if meta.IsNoMatchError(err) {
+			r.Log.Info("MachineConfigPool API unavailable; assuming cluster is not converged")
+			return false, nil
+		}
 		r.Log.Error(err, "Unable to get the list of MCPs")
 		return false, err
 	}
@@ -1736,18 +1749,29 @@ func (eh *NodeEventHandler) Generic(ctx context.Context, event event.GenericEven
 }
 
 func (r *KataConfigOpenShiftReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&kataconfigurationv1.KataConfig{}).
-		Watches(
-			&mcfgv1.MachineConfigPool{},
-			&McpEventHandler{r}).
 		Watches(
 			&corev1.Node{},
 			&NodeEventHandler{r}).
 		Watches(
 			&corev1.ConfigMap{},
 			&ConfigMapEventHandler{r},
-		).Complete(r)
+		)
+
+	mcpAvailable, err := r.isMachineConfigPoolAvailable()
+	if err != nil {
+		return err
+	}
+	if mcpAvailable {
+		builder = builder.Watches(
+			&mcfgv1.MachineConfigPool{},
+			&McpEventHandler{r})
+	} else {
+		r.Log.Info("MachineConfigPool API unavailable; skipping MCP watch (use DaemonSet deployment mode on HCP)")
+	}
+
+	return builder.Complete(r)
 }
 
 func (r *KataConfigOpenShiftReconciler) getNodes() (*corev1.NodeList, error) {


### PR DESCRIPTION
## Description of the problem
On ROSA HCP guest clusters, the MachineConfigPool API may be absent while other
MCO types exist. OSC 1.12 unconditionally watches MCP at manager startup and
lists MCPs during reconcile, causing crash loops or repeated ERROR logs before
DaemonSet-based Kata install can complete ([KATA-4840](https://redhat.atlassian.net/browse/KATA-4840)).

## What I did
- Probe for MachineConfigPool API availability (same pattern as MachineConfig)
- Register MCP watch only when the API is present
- Short-circuit `checkConvergedCluster()` when MCP is unavailable
- Unit tests for both paths

## How to verify
1. ROSA HCP cluster without MachineConfigPool API
2. Set `osc-feature-gates` `deploymentMode: DaemonSet`
3. Install operator and apply KataConfig
4. Confirm `controller-manager` stays up (no MCP cache sync failure)
5. Confirm reconcile does not ERROR-spam on MCP list each loop
6. Confirm DaemonSet install path progresses (RuntimeClass `kata` when install completes)

## Lab validation (author)
Validated on ROSA HCP with `c5n.metal` workers: DaemonSet mode, compute pool
`auto_repair: false` (ROSA ops — not part of this PR), manual reboot after
`osc-rpm-install`, then `RuntimeClass/kata` and a pod with `runtimeClassName:
kata` running in a KVM sandbox.
Fixes: rhjira#[KATA-4840](https://redhat.atlassian.net/browse/KATA-4840)
Related: [KATA-4233](https://redhat.atlassian.net/browse/KATA-4233) (DaemonSet reboot), [KATA-5177](https://redhat.atlassian.net/browse/KATA-5177) (live-apply), [KATA-4597](https://redhat.atlassian.net/browse/KATA-4597) (DS image)

## Changelog
HCP: skip MachineConfigPool integration when MCP API is absent so DaemonSet
deployment mode can run on guest clusters without full MCO.