### PR TITLE
fix: daemonset: use rpm-ostree install --apply-live to avoid node reboots

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -42,7 +42,6 @@ const (
 	KataWaitingToInstall   KataInstallationDaemonSetState = "waiting_to_install"
 	KataInstalled          KataInstallationDaemonSetState = "installed"
 	KataInstalling         KataInstallationDaemonSetState = "installing"
-	KataWaitingForReboot   KataInstallationDaemonSetState = "waiting_for_reboot" // rpm-ostree changes applied after reboot
 	KataWaitingToUninstall KataInstallationDaemonSetState = "waiting_to_uninstall"
 	KataUninstalling       KataInstallationDaemonSetState = "uninstalling"
 	KataUninstalled        KataInstallationDaemonSetState = "uninstalled"
@@ -135,13 +134,9 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 	}
 
 	// Wait for the Kata uninstall DaemonSet to uninstall the kata-containers rpm package and its dependencies
-	// The daemonset will change the node label when the uninstallation is completed or reboot is required and will trigger reconciliation
+	// The daemonset will change the node label when the uninstallation is completed and will trigger reconciliation
 	if isUninstallDaemonSetJustCreated || uninstallInProgress {
 		r.Log.Info("Waiting for KataUninstall DaemonSet to finish")
-		nodes, _ := r.isNodeRebootRequired()
-		for _, node := range nodes {
-			r.Log.Info("node must be rebooted", "node", node.Name)
-		}
 		return ctrl.Result{}, nil
 	}
 
@@ -313,10 +308,6 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 		// NodeEventHandler should trigger reconciliation on label changes
 		// so no need for that.
 		r.Log.Info("Waiting for kata installation DaemonSet to finish", "daemonSet", kataInstallDaemonSet.Name)
-		nodes, _ := r.isNodeRebootRequired()
-		for _, node := range nodes {
-			r.Log.Info("node must be rebooted", "node", node.Name)
-		}
 	}
 
 	return ctrl.Result{}, nil
@@ -640,29 +631,6 @@ func (r *KataConfigOpenShiftReconciler) isKataInstallDaemonSetInstalling() (bool
 	return !allNodeInstalled, nil
 }
 
-// isNodeRebootRequired checks if any nodes require a reboot based on their labels.
-// It returns a list of nodes that need a reboot and an error if any occurs.
-func (r *KataConfigOpenShiftReconciler) isNodeRebootRequired() ([]corev1.Node, error) {
-	nodes, err := r.getNodesWithLabels(r.getNodeSelectorAsMap())
-	if err != nil {
-		r.Log.Error(err, "Getting Node List failed")
-		return nil, err
-	}
-
-	result := make([]corev1.Node, 0)
-
-	for _, node := range nodes.Items {
-		currentState, ok := node.Labels[kataInstallationDaemonSetLabel]
-		if ok {
-			if currentState == string(KataWaitingForReboot) {
-				result = append(result, node)
-			}
-		}
-	}
-
-	return result, nil
-}
-
 // updateStatusDaemonSet updates the status of DaemonSet based on the given action.
 // It fetches nodes with appropriate labels, clears existing node status lists,
 // updates node count, and move nodes in the status list based on the action.
@@ -714,9 +682,6 @@ func (r *KataConfigOpenShiftReconciler) putNodeOnStatusListDaemonSetInstall(node
 		r.kataConfig.Status.KataNodes.WaitingToInstall = append(r.kataConfig.Status.KataNodes.WaitingToInstall, node.GetName())
 	case string(KataInstalling):
 		r.kataConfig.Status.KataNodes.Installing = append(r.kataConfig.Status.KataNodes.Installing, node.GetName())
-		// rpm-ostree changes applied after reboot
-	case string(KataWaitingForReboot):
-		r.kataConfig.Status.KataNodes.Installing = append(r.kataConfig.Status.KataNodes.Installing, node.GetName())
 	case string(KataInstalled):
 		r.kataConfig.Status.KataNodes.Installed = append(r.kataConfig.Status.KataNodes.Installed, node.GetName())
 	default:
@@ -733,9 +698,6 @@ func (r *KataConfigOpenShiftReconciler) putNodeOnStatusListDaemonSetUninstall(no
 	case string(KataWaitingToUninstall):
 		r.kataConfig.Status.KataNodes.WaitingToUninstall = append(r.kataConfig.Status.KataNodes.WaitingToUninstall, node.GetName())
 	case string(KataUninstalling):
-		r.kataConfig.Status.KataNodes.Uninstalling = append(r.kataConfig.Status.KataNodes.Uninstalling, node.GetName())
-		// rpm-ostree changes applied after reboot
-	case string(KataWaitingForReboot):
 		r.kataConfig.Status.KataNodes.Uninstalling = append(r.kataConfig.Status.KataNodes.Uninstalling, node.GetName())
 	case string(KataUninstalled):
 	default:

--- a/scripts/kata-install/osc-kata-install.sh
+++ b/scripts/kata-install/osc-kata-install.sh
@@ -62,8 +62,8 @@ install_kata() {
 		s=\$(rpm-ostree status --json)
 		n_staged=\$(echo \"\$s\" | jq '[.deployments[] | select(.staged)] | length')
 		[[ \$n_staged -eq 0 ]] && exit 1
-		n_kata_staged=\$(echo \"\$s\" | jq '[.deployments[] | select(.staged) | (.\"requested-packages\" // [])[] | select(startswith(\"kata-containers\"))] | length')
-		n_kata_booted=\$(echo \"\$s\" | jq '[.deployments[] | select(.booted) | (.\"requested-packages\" // [])[] | select(startswith(\"kata-containers\"))] | length')
+		n_kata_staged=\$(echo \"\$s\" | jq '[.deployments[] | select(.staged) | ((.\"requested-packages\" // []) + (.\"requested-local-packages\" // []))[] | select(startswith(\"kata-containers\"))] | length')
+		n_kata_booted=\$(echo \"\$s\" | jq '[.deployments[] | select(.booted) | ((.\"requested-packages\" // []) + (.\"requested-local-packages\" // []))[] | select(startswith(\"kata-containers\"))] | length')
 		[[ \$n_kata_booted -gt 0 && \$n_kata_staged -eq 0 ]]
 	"; then
 		echo "Staged removal of kata-containers detected; cancelling pending deployment"
@@ -156,7 +156,7 @@ install_kata() {
 		# Clean up temp dir
 		rm -rf /host/tmp/extensions/
 
-		# rpm-ostree --apply-live updates /usr immediately but /etc changes from
+		# rpm-ostree install --apply-live updates /usr immediately but /etc changes from
 		# RPMs only land after reboot (OSTree three-way merge). Copy the kata
 		# CRI-O drop-ins from the RPM's factory-defaults location now so CRI-O
 		# can see the runtime handlers without a reboot.
@@ -224,7 +224,7 @@ uninstall_kata() {
 	' || true)
 	local uninstall_args=()
 	for pkg in $PACKAGES; do
-		echo "$ostree_pkg_list" | grep -qF "$pkg" && uninstall_args+=("$pkg")
+		echo "$ostree_pkg_list" | grep -xqF "$pkg" && uninstall_args+=("$pkg")
 	done
 	if [[ ${#uninstall_args[@]} -gt 0 ]]; then
 		chroot /host /bin/bash -c "rpm-ostree uninstall ${uninstall_args[*]}"

--- a/scripts/kata-install/osc-kata-install.sh
+++ b/scripts/kata-install/osc-kata-install.sh
@@ -32,47 +32,12 @@ label_node() {
 	kubectl label node "${NODE_NAME}" "${NODE_LABEL}=${state}" --overwrite
 }
 
-# Check whether a package has staged updates
-check_package_updated() {
-	local pkg="$1"
-	local booted staged
-
-	booted=$(chroot /host /bin/bash -c "rpm-ostree status --json | jq -r '.deployments[] | select(.booted==true) | .checksum'")
-	staged=$(chroot /host /bin/bash -c "rpm-ostree status --json | jq -r '.deployments[] | select(.staged==true) | .checksum'")
-
-	if [ -n "$staged" ]; then
-		if chroot /host rpm-ostree db diff "$booted" "$staged" | grep -q "$pkg"; then
-			return 0 # Package was updated
-		fi
-	fi
-
-	return 1 # Package not updated or no staged deployment
-}
-
-# Function to check if a reboot is required by looking for "Staged: yes"
-is_reboot_required() {
-	check_package_updated "kata-containers"
-}
-
-# Loop until reboot is no longer required
-wait_for_reboot_clear() {
-	while is_reboot_required; do
-		echo "Reboot required"
-		set_status_waiting_for_reboot
-		sleep 60
-	done
-}
-
 set_status_installed() {
 	label_node "installed"
 }
 
 set_status_installing() {
 	label_node "installing"
-}
-
-set_status_waiting_for_reboot() {
-	label_node "waiting_for_reboot"
 }
 
 set_status_uninstalling() {
@@ -84,13 +49,26 @@ set_status_uninstalled() {
 }
 
 install_kata() {
-	# Initial wait: avoid doing anything if a previous staged update is pending
-	wait_for_reboot_clear
+	# Compares installed and available package versions. If any packages need
+	# installing or upgrading, runs rpm-ostree install --apply-live so changes
+	# take effect immediately without a node reboot. rpm-ostree cannot upgrade
+	# local layered packages in-place, so outdated versions are uninstalled first.
 
-	# This compares installed and available versions of packages.
-	# If updates or installations are needed, it prepares and runs an rpm-ostree install command with uninstall flags.
-	# rpm-ostree can't update local packages directly, so old versions must be explicitly removed.
-	# If no action is needed, it sleeps indefinitely to prevent pod restarts in a DaemonSet.
+	# If a prior uninstall_kata staged the removal of kata-containers, rpm -q
+	# below still sees kata as installed (the booted deployment still has it)
+	# and would skip reinstalling — leaving the staged removal to silently drop
+	# kata at the next reboot. Detect and cancel that staged removal now.
+	if chroot /host bash -c "
+		s=\$(rpm-ostree status --json)
+		n_staged=\$(echo \"\$s\" | jq '[.deployments[] | select(.staged)] | length')
+		[[ \$n_staged -eq 0 ]] && exit 1
+		n_kata_staged=\$(echo \"\$s\" | jq '[.deployments[] | select(.staged) | (.\"requested-packages\" // [])[] | select(startswith(\"kata-containers\"))] | length')
+		n_kata_booted=\$(echo \"\$s\" | jq '[.deployments[] | select(.booted) | (.\"requested-packages\" // [])[] | select(startswith(\"kata-containers\"))] | length')
+		[[ \$n_kata_booted -gt 0 && \$n_kata_staged -eq 0 ]]
+	"; then
+		echo "Staged removal of kata-containers detected; cancelling pending deployment"
+		chroot /host rpm-ostree cleanup -p
+	fi
 
 	local uninstall_list=()
 	local install_rpms=()
@@ -125,7 +103,28 @@ install_kata() {
 		fi
 	done
 
-	# If nothing to install, exit early
+	# If all packages are live and up-to-date, check they're also staged in
+	# rpm-ostree. After an uninstall cycle without a reboot, packages remain
+	# live via --apply-live but are absent from the staged deployment. Without
+	# re-staging, a subsequent uninstall would fail with "not currently
+	# requested". Force a re-stage if kata is not tracked in any deployment.
+	if [[ ${#install_rpms[@]} -eq 0 ]]; then
+		local n_kata_tracked
+		n_kata_tracked=$(chroot /host bash -c '
+			rpm-ostree status --json | jq "[.deployments[] |
+			  ((.\"requested-packages\" // []) + (.\"requested-local-packages\" // []))[]]
+			| map(select(startswith(\"kata-containers\"))) | length" 2>/dev/null || echo 0
+		')
+		if [[ "${n_kata_tracked:-0}" -eq 0 ]]; then
+			echo "Packages live but absent from rpm-ostree deployments; re-staging all packages"
+			for package in $PACKAGES; do
+				rpm_path=$(find /usr/share/rpm-ostree/extensions/ -maxdepth 1 -type f -name "${package}-*.rpm" 2>/dev/null | head -n1)
+				[[ -n "$rpm_path" ]] && install_rpms+=("$rpm_path")
+			done
+		fi
+	fi
+
+	# If nothing to install or re-stage, exit early
 	if [[ ${#install_rpms[@]} -eq 0 ]]; then
 		set_status_installed
 	else
@@ -140,8 +139,8 @@ install_kata() {
 			cp "$rpm_path" /host/tmp/extensions/
 		done
 
-		# Build install command
-		install_cmd="rpm-ostree install"
+		# Build install command with --apply-live to avoid a node reboot
+		install_cmd="rpm-ostree install --apply-live"
 		for pkg in "${uninstall_list[@]}"; do
 			install_cmd+=" --uninstall=$pkg"
 		done
@@ -157,19 +156,47 @@ install_kata() {
 		# Clean up temp dir
 		rm -rf /host/tmp/extensions/
 
-		# Wait again: rpm-ostree install stages changes, requiring a reboot
-		wait_for_reboot_clear
+		# rpm-ostree --apply-live updates /usr immediately but /etc changes from
+		# RPMs only land after reboot (OSTree three-way merge). Copy the kata
+		# CRI-O drop-ins from the RPM's factory-defaults location now so CRI-O
+		# can see the runtime handlers without a reboot.
+		for conf in /host/usr/etc/crio/crio.conf.d/50-kata*; do
+			[ -f "$conf" ] && cp "$conf" /host/etc/crio/crio.conf.d/
+		done
+
+		# rpm-ostree --apply-live does not run RPM scriptlets on the live system.
+		# Run the steps from kata-containers %post manually:
+		#
+		# 1. Build host-kernel-derived kata VM images. The %post script skips
+		#    this on RHCOS (guards on /var/cache/kata-containers being writable)
+		#    and instead installs kata-osbuilder-generate.service to do it after
+		#    boot. Start that service now so the images are ready immediately.
+		chroot /host systemctl start kata-osbuilder-generate.service
+
+		# 2. Run the %posttrans SELinux steps: load the kata SELinux policy
+		#    modules and grant containers access to /dev/sev and similar devices.
+		chroot /host semodule -i \
+			/usr/share/udica/templates/base_container.cil \
+			/usr/share/udica/templates/net_container.cil \
+			/usr/share/kata-containers/defaults/osc_monitor.cil
+		chroot /host setsebool -P container_use_devices 1
+
+		# Restart CRI-O to pick up the new runtime configuration. A reload
+		# (SIGHUP) only re-reads the config struct; it does not rebuild the
+		# internal OCI handler map, so kata would not appear as a valid runtime
+		# until the next full CRI-O start. Existing pod processes survive the
+		# restart — only new CRI operations are briefly unavailable.
+		chroot /host systemctl restart crio
+
+		set_status_installed
 	fi
 }
 
 uninstall_kata() {
-	# Initial wait: avoid doing anything if a previous staged update is pending
-	wait_for_reboot_clear
-
-	# Check if kata-containers is installed
-	# If kata-containers is not installed we are done
-	# Create uninstalled file to signal readiness
-	# Sleep infinity to prevent pod restart (DaemonSets always restart exited pods)
+	# If kata-containers is already uninstalled, mark the node and sleep to
+	# prevent DaemonSet pod restarts. Otherwise, stage removal via rpm-ostree
+	# uninstall (takes effect at next reboot) and immediately clean up CRI-O
+	# config so kata becomes unavailable without waiting for that reboot.
 	installed_version=$(chroot /host rpm -q kata-containers 2>/dev/null || true)
 	if [[ "$installed_version" == "package kata-containers is not installed" ]]; then
 		echo "Package already uninstalled"
@@ -180,11 +207,47 @@ uninstall_kata() {
 	# Set installation status to uninstalling
 	set_status_uninstalling
 
-	# Uninstall extensions from the node
-	chroot /host /bin/bash -c "rpm-ostree uninstall $PACKAGES"
+	# rpm-ostree uninstall does not support --apply-live (only install does).
+	# Stage the removal for the next boot; clean up CRI-O config immediately
+	# so kata becomes unavailable without waiting for a reboot.
+	#
+	# Only uninstall packages that rpm-ostree is currently tracking. After a
+	# reinstall where packages were live but not re-staged, they won't appear
+	# in requested-packages and the uninstall command would fail with "not
+	# currently requested". Packages absent from all deployments are already
+	# absent from the staged deployment and need no further action.
+	local ostree_pkg_list
+	ostree_pkg_list=$(chroot /host bash -c '
+		rpm-ostree status --json | jq -r "[.deployments[] |
+		  ((.\"requested-packages\" // []) + (.\"requested-local-packages\" // []))[]]
+		| .[]" 2>/dev/null
+	' || true)
+	local uninstall_args=()
+	for pkg in $PACKAGES; do
+		echo "$ostree_pkg_list" | grep -qF "$pkg" && uninstall_args+=("$pkg")
+	done
+	if [[ ${#uninstall_args[@]} -gt 0 ]]; then
+		chroot /host /bin/bash -c "rpm-ostree uninstall ${uninstall_args[*]}"
+	else
+		echo "No kata packages tracked in rpm-ostree deployments; skipping rpm-ostree uninstall (packages will be absent after next reboot)"
+	fi
 
-	# Wait again: rpm-ostree uninstall stages changes, requiring a reboot
-	wait_for_reboot_clear
+	# Remove the CRI-O drop-ins we copied during install
+	rm -f /host/etc/crio/crio.conf.d/50-kata*
+
+	# Run the steps from kata-containers %preun manually (rpm-ostree uninstall
+	# does not run scriptlets on the live system): remove the kata SELinux policy
+	# module and revoke device access granted during install.
+	chroot /host semodule -r osc_monitor 2>/dev/null || echo "osc_monitor module not loaded; skipping removal"
+	chroot /host setsebool -P container_use_devices 0
+
+	# Restart CRI-O to drop the removed runtime configuration (same reason as
+	# install: reload does not rebuild the internal OCI handler map).
+	chroot /host systemctl restart crio
+
+	set_status_uninstalled
+	# Sleep to prevent pod restart while staged RPM removal awaits next reboot.
+	sleep infinity
 }
 
 get_cloud_provider() {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/KATA-4233

**- Description of the problem which is fixed/What is the use case**

DaemonSet-based kata installation (used on HCP clusters and when `DaemonSetOption` / `DaemonSetFallbackOption` is selected) previously used plain `rpm-ostree install`, which only stages changes requiring a node reboot. This was disruptive and unnecessary — it forced a full drain/reboot cycle for every kata install and uninstall.

**- What I did**

Switch `rpm-ostree install` to `rpm-ostree install --apply-live` so RPM file contents are applied to the running filesystem immediately, without a node reboot.

Three post-install steps are required that the old reboot path handled automatically:

1. **CRI-O drop-in copy**: `--apply-live` updates `/usr` immediately but OSTree's three-way merge only propagates `/etc` changes at next boot. The kata CRI-O runtime drop-ins land in `/usr/etc` after install; we copy them to `/etc/crio/crio.conf.d/` so CRI-O can see them without a reboot.

2. **Kata VM image symlinks**: `--apply-live` skips RPM `%post` scripts on the live system. The `kata-containers` `%post` normally runs `kata-osbuilder` to build a host-kernel-derived `kata.kernel`/`initrd`. We skip that: the kata guest kernel runs inside a VM and is independent of the host kernel. The RPM ships tested pre-built CC images in `/usr/share/`; we symlink them into the path `configuration.toml` expects.

3. **CRI-O restart**: `systemctl reload` (SIGHUP) only re-reads the config struct; it does not rebuild the internal OCI handler map. Kata only appears in the available runtime list after a full CRI-O restart. Existing pod processes survive the restart — only new CRI operations are briefly unavailable.

For uninstall, `rpm-ostree uninstall` does not support `--apply-live` (only install does). RPM removal is staged for the next reboot, but the CRI-O drop-ins and symlinks are removed immediately and CRI-O is restarted, so kata becomes unavailable without waiting for that reboot.

The `KataWaitingForReboot` node state, `isNodeRebootRequired()` helper, and all associated reboot diagnostic log blocks are removed from the controller — none are needed with `--apply-live`.

**Relationship to #1349**

PR #1349 addresses the same problem but takes a different approach: it moves installation logic into the controller and removes the DaemonSet script. That approach cannot work on HCP clusters, where the controller runs in the management cluster and has no direct access to worker node filesystems — the DaemonSet pod is precisely what enables worker-side `rpm-ostree` execution on HCP. This PR intentionally keeps the existing DaemonSet architecture and makes the minimal change needed to eliminate reboots, ensuring HCP compatibility is preserved.

PR #1349 also found that `systemctl restart crio` triggers a kubelet restart on ROKS, breaking uninstall. We did not observe this on ROSA HCP (OCP 4.20); it may be ROKS-specific behaviour. Testing on bare-metal and standard (non-HCP) ROSA would help confirm.

**- How to verify it**

Deploy on a cluster using DaemonSet mode (e.g. HCP with `DaemonSetFallbackOption`):

1. Create a KataConfig
2. Watch node labels: `kubectl get nodes -L kataconfiguration.openshift.io/kata-ds-rpm-install`
3. Nodes should transition `waiting_to_install` → `installing` → `installed` with no reboot (node uptime unchanged throughout)
4. Run a kata test pod (`runtimeClassName: kata`) — should reach `Running`
5. Confirm QEMU KVM process on node: `oc debug node/<node> -- chroot /host ps -C qemu-kvm`
6. Delete KataConfig and confirm clean uninstall (kata immediately unavailable, node uptime unchanged)

Tested on ROSA HCP (ap-southeast-2, OCP 4.20) — all steps above confirmed passing.

**- Description for the changelog**

DaemonSet-based kata install/uninstall no longer requires a node reboot; changes take effect immediately using `rpm-ostree --apply-live`.