### PR TITLE
tests/osc-test-fbc-integration: remove duplicate displayName in prowjob-sanity

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -165,7 +165,6 @@ spec:
             value:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-kata
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-aws-ipi-peerpods
-      displayName: "Running prow job $(params.PROWJOB_NAME)"
     - name: prowjob-ocp419
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue


### PR DESCRIPTION
The prowjob-sanity task had displayName set twice, causing a strict YAML decoding error that prevented the pipeline from running.
