### PR TITLE
osc-operator-bundle: remove the Intel images

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -412,10 +412,6 @@ spec:
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:a6c3be3831650cb93462c18b16624e40417c953a533fc1948d07f808d38c8ae6
                 - name: RELATED_IMAGE_MUST_GATHER
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:7c32f8d44dfb2134a27400602342f2bbac92414a858a47416f2dbd9e2debbb85
-                - name: RELATED_IMAGE_PCCS
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:5ca118dc5a1d227fba077d399c0ef20a51a8b046b79d3509bb39de28eec15de4
-                - name: RELATED_IMAGE_TDX_QGS
-                  value: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:f41183860b0affa3f809ef2fa6a38e1d791fe40ef675c40fca2cf5da679fe4f8
                 - name: RELATED_IMAGE_STORAGE_HELPER
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:bd9dfb36dc9444f5cf24372ebfbab8d0328b6423ee99ac75e830a9a4ebaf288d
                 envFrom:
@@ -587,10 +583,6 @@ spec:
     name: podvm-oci
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:7c32f8d44dfb2134a27400602342f2bbac92414a858a47416f2dbd9e2debbb85
     name: must-gather
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:5ca118dc5a1d227fba077d399c0ef20a51a8b046b79d3509bb39de28eec15de4
-    name: pccs
-  - image: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:f41183860b0affa3f809ef2fa6a38e1d791fe40ef675c40fca2cf5da679fe4f8
-    name: tdx-qgs
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:bd9dfb36dc9444f5cf24372ebfbab8d0328b6423ee99ac75e830a9a4ebaf288d
     name: storage-helper
   replaces: sandboxed-containers-operator.v1.12.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -100,10 +100,6 @@ spec:
               value: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:a6c3be3831650cb93462c18b16624e40417c953a533fc1948d07f808d38c8ae6
             - name: RELATED_IMAGE_MUST_GATHER
               value: registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:7c32f8d44dfb2134a27400602342f2bbac92414a858a47416f2dbd9e2debbb85
-            - name: RELATED_IMAGE_PCCS
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-pccs@sha256:5ca118dc5a1d227fba077d399c0ef20a51a8b046b79d3509bb39de28eec15de4
-            - name: RELATED_IMAGE_TDX_QGS
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:f41183860b0affa3f809ef2fa6a38e1d791fe40ef675c40fca2cf5da679fe4f8
             - name: RELATED_IMAGE_STORAGE_HELPER
               value: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:bd9dfb36dc9444f5cf24372ebfbab8d0328b6423ee99ac75e830a9a4ebaf288d
           imagePullPolicy: Always


### PR DESCRIPTION
Now that they can be deployed with their own operator, we don't need to build and ship them with the Sandboxed Containers operator.

Fixes: [KATA-5347](https://redhat.atlassian.net/browse/KATA-5347)
