### PR TITLE
ami-helper: skip S3 bucket creation if already exists in ami-helper

### DIFF
--- a/config/peerpods/podvm/ami-helper.sh
+++ b/config/peerpods/podvm/ami-helper.sh
@@ -207,6 +207,13 @@ delete_vmimport_role() {
 
 create_bucket() {
 	echo "Create s3 Bucket named ${BUCKET_NAME} at ${REGION}"
+
+	# Check if bucket already exists
+	if aws s3api head-bucket --bucket ${BUCKET_NAME} --region ${REGION} 2>/dev/null; then
+		echo "Bucket ${BUCKET_NAME} already exists, skipping creation"
+		return 0
+	fi
+
 	if [[ ${REGION} == us-east-1 ]]; then
 		aws s3api create-bucket  --bucket ${BUCKET_NAME} --region ${REGION}
 	else


### PR DESCRIPTION
Check if the S3 bucket exists before attempting to create it. If it already exists, skip creation and continue. This will make bucket creation idempotent


Assisted-by: Claude AI

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
