### PR TITLE
fix: controller: return empty Result when bubbling errors

### DIFF
--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -70,7 +70,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 	kataInstallDaemonSet, err := r.daemonSetForKataInstall(InstallKata)
 	if err != nil {
 		r.Log.Error(err, "Failed getting DaemonSet for Kata installation")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 	err = r.Client.Delete(context.TODO(), kataInstallDaemonSet)
 	if err != nil {
@@ -78,7 +78,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 			r.Log.Info("kata install daemonset was already deleted")
 		} else {
 			r.Log.Error(err, "error when deleting kata install Daemonset, try again")
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 15}, err
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -89,11 +89,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 	kataUninstallDaemonSet, err := r.daemonSetForKataInstall(UninstallKata)
 	if err != nil {
 		r.Log.Error(err, "Failed getting DaemonSet for Kata uninstallation")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 	if err := controllerutil.SetControllerReference(r.kataConfig, kataUninstallDaemonSet, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed setting ControllerReference for kata uninstallation DaemonSet")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	foundKataDaemonSet := &appsv1.DaemonSet{}
@@ -104,7 +104,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 			err = r.Client.Create(context.TODO(), kataUninstallDaemonSet)
 			if err != nil {
 				r.Log.Error(err, "Error when creating kata uninstallation daemonset")
-				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+				return ctrl.Result{}, err
 			}
 			isUninstallDaemonSetJustCreated = true
 
@@ -119,7 +119,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 			}
 		} else {
 			r.Log.Error(err, "Could not get kata uninstallation daemonset, try again")
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -131,7 +131,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 	uninstallInProgress, err := r.isKataUninstallDaemonSetUninstalling()
 	if err != nil {
 		r.Log.Error(err, "Error getting uninstallation status")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	// Wait for the Kata uninstall DaemonSet to uninstall the kata-containers rpm package and its dependencies
@@ -149,14 +149,14 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 
 	err = r.deleteDaemonsetForMonitor()
 	if err != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 15}, err
+		return ctrl.Result{}, err
 	}
 
 	if r.kataConfig.Spec.EnablePeerPods {
 		// We will try again in case of an error
 		err = r.disablePeerPodsMiscConfigs()
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 15}, err
+			return ctrl.Result{}, err
 		}
 
 		// Handle podvm image deletion
@@ -165,13 +165,13 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigDeleteRequestDaemonSet(
 			return *res, err
 		}
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	}
 
 	err = r.deleteScc()
 	if err != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	kataNodeSelector, err := r.getKataConfigNodeSelectorAsSelector()
@@ -205,7 +205,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 		if err != nil {
 			// If no nodes are found, requeue to check again for eligible nodes
 			r.Log.Error(err, "Failed to check Node eligibility for running Kata containers")
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 20}, err
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -241,11 +241,11 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 	kataInstallDaemonSet, err := r.daemonSetForKataInstall(InstallKata)
 	if err != nil {
 		r.Log.Error(err, "Failed getting DaemonSet for Kata installation")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 	if err := controllerutil.SetControllerReference(r.kataConfig, kataInstallDaemonSet, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed setting ControllerReference for kata installation DaemonSet")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	foundKataDaemonSet := &appsv1.DaemonSet{}
@@ -256,7 +256,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 			err = r.Client.Create(context.TODO(), kataInstallDaemonSet)
 			if err != nil {
 				r.Log.Error(err, "Error when creating kata installation daemonset")
-				return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+				return ctrl.Result{}, err
 			}
 			// If the daemonset just got created we change the progress condition and label the nodes with the initial value
 			r.setInProgressConditionToInstalling()
@@ -272,14 +272,14 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 			}
 		} else {
 			r.Log.Error(err, "Could not get kata installation daemonset, try again")
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	} else {
 		r.Log.Info("Updating kata installation daemonset", "kataInstallDaemonSet.Namespace", kataInstallDaemonSet.Namespace, "kataInstallDaemonSet.Name", kataInstallDaemonSet.Name)
 		err = r.Client.Update(context.TODO(), kataInstallDaemonSet)
 		if err != nil {
 			r.Log.Error(err, "error when updating kata installation daemonset")
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -287,7 +287,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 	installInProgress, err := r.isKataInstallDaemonSetInstalling()
 	if err != nil {
 		r.Log.Error(err, "Error getting installation status")
-		return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	if installInProgress && r.getInProgressConditionValue() == corev1.ConditionFalse {
@@ -307,7 +307,7 @@ func (r *KataConfigOpenShiftReconciler) processKataConfigInstallRequestDaemonSet
 		}
 		if err != nil {
 			// Give sometime for the error to go away before reconciling again
-			return ctrl.Result{Requeue: true, RequeueAfter: 15 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	} else {
 		// NodeEventHandler should trigger reconciliation on label changes


### PR DESCRIPTION
controller-runtime ignores the Result when `err != nil`, using exponential backoff instead. Returning both a `RequeueAfter` delay and an error is misleading - the delay is never applied.

Changed all error returns from:
```go
  return ctrl.Result{Requeue: true, RequeueAfter: duration}, err
```
to:
```go
  return ctrl.Result{}, err
```
This makes the error handling behavior explicit and matches controller-runtime semantics. The controller will still requeue, but using its default exponential backoff mechanism.

Found while addressing [code review comments](https://github.com/openshift/sandboxed-containers-operator/pull/2410#discussion_r3507799778) on PR #2410

Fixes: #2433


Assisted-By: Claude Sonnet 4.5
