### PR TITLE
konflux: add a tag to our images that mentions the PR it built from

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -94,6 +94,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: additional-tags
+    type: array
+    default: []
+    description: Additional tags to apply to the built image (e.g. pr-<number> for PR builds)
   results:
   - description: ''
     name: IMAGE_URL
@@ -521,6 +525,9 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value:
+      - $(params.additional-tags[*])
     runAfter:
     - build-image-index
     taskRef:

--- a/.tekton/osc-hermeto-pull-request.yaml
+++ b/.tekton/osc-hermeto-pull-request.yaml
@@ -523,6 +523,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/osc-must-gather-pull-request.yaml
+++ b/.tekton/osc-must-gather-pull-request.yaml
@@ -41,6 +41,10 @@ spec:
     value: must-gather
   - name: prefetch-input
     value: '{"type": "rpm", "path": "./must-gather/"}'
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -531,6 +531,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -41,6 +41,10 @@ spec:
     value: Dockerfile
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-podvm-builder-pull-request.yaml
+++ b/.tekton/osc-podvm-builder-pull-request.yaml
@@ -48,6 +48,10 @@ spec:
         {"type": "pip", "path": "./config/peerpods/podvm/", "requirements_files": ["azure-cli-pip.txt"]},
         {"type": "rpm", "path": "./config/peerpods/podvm/"}
       ]
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-test-fbc-pull-request.yaml
+++ b/.tekton/osc-test-fbc-pull-request.yaml
@@ -298,6 +298,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Identifying images on quay is hard. This commit makes sure we tag our image with the PR number it was built from. This should make it easier to identify what image we can use for testing a build before we merge the PR.
