### PR TITLE
fbc: update FBC files to the 1.13.0 release

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -48,6 +48,10 @@ spec:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper-v1-12
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper
 ---
 apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
@@ -99,3 +103,7 @@ spec:
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs
         - quay.io/redhat-user-workloads/ose-osc-tenant/osc-tdx-qgs-v1-12
       source: registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs
+    - mirrors:
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper
+        - quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper-v1-12
+      source: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper

--- a/fbc/v4.19/catalog-template.yaml
+++ b/fbc/v4.19/catalog-template.yaml
@@ -68,6 +68,9 @@ entries:
       - name: sandboxed-containers-operator.v1.12.1
         replaces: sandboxed-containers-operator.v1.12.0
         skipRange: '>=1.1.0 <1.12.1'
+      - name: sandboxed-containers-operator.v1.13.0
+        replaces: sandboxed-containers-operator.v1.12.1
+        skipRange: '>=1.1.0 <1.13.0'
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
@@ -122,6 +125,8 @@ entries:
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:e38b650b4007b7c232d05a9b21990b7bdad73fa0b3b89cbe032c5bbf6f2475e8
     schema: olm.bundle
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62
     schema: olm.bundle
   - schema: olm.deprecations
     package: sandboxed-containers-operator

--- a/fbc/v4.19/catalog/sandboxed-containers-operator/catalog.json
+++ b/fbc/v4.19/catalog/sandboxed-containers-operator/catalog.json
@@ -116,6 +116,11 @@
             "name": "sandboxed-containers-operator.v1.12.1",
             "replaces": "sandboxed-containers-operator.v1.12.0",
             "skipRange": ">=1.1.0 <1.12.1"
+        },
+        {
+            "name": "sandboxed-containers-operator.v1.13.0",
+            "replaces": "sandboxed-containers-operator.v1.12.1",
+            "skipRange": ">=1.1.0 <1.13.0"
         }
     ]
 }
@@ -1584,10 +1589,6 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
-        },
-        {
             "name": "caa",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:dc519d24e7ce748f9a980598f8b9ffd95b41f77c053ce6254419238dd9dd292a"
         },
@@ -1606,6 +1607,10 @@
         {
             "name": "must-gather",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:80726dfef5dcc48719e9c1c023c93a3a0bca5cda789fac69301707e618b1afb9"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
         },
         {
             "name": "pccs",
@@ -1630,6 +1635,168 @@
         {
             "name": "tdx-qgs",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:42154e82e433eda6d5a59b5f7cadd7702cc0cba1ca4622358322669c5008d14b"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "sandboxed-containers-operator.v1.13.0",
+    "package": "sandboxed-containers-operator",
+    "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "confidentialcontainers.org",
+                "kind": "PeerPod",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kataconfiguration.openshift.io",
+                "kind": "KataConfig",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "sandboxed-containers-operator",
+                "version": "1.13.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kataconfiguration.openshift.io/v1\",\n    \"kind\": \"KataConfig\",\n    \"metadata\": {\n      \"name\": \"example-kataconfig\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "createdAt": "2026-06-19T12:35:42Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "false",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "true",
+                    "features.operators.openshift.io/token-auth-azure": "true",
+                    "features.operators.openshift.io/token-auth-gcp": "true",
+                    "olm.skipRange": ">=1.1.0 <1.13.0",
+                    "operatorframework.io/suggested-namespace": "openshift-sandboxed-containers-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.39.1",
+                    "operators.operatorframework.io/internal-objects": "[\"peerpods.confidentialcontainers.org\",\"peerpodconfigs.confidentialcontainers.org\"]",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "repository": "https://github.com/openshift/sandboxed-containers-operator"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kataconfigs.kataconfiguration.openshift.io",
+                            "version": "v1",
+                            "kind": "KataConfig",
+                            "description": "The kataconfig CR represent a installation of Kata in a cluster and its current state."
+                        },
+                        {
+                            "name": "peerpods.confidentialcontainers.org",
+                            "version": "v1alpha1",
+                            "kind": "PeerPod"
+                        }
+                    ]
+                },
+                "description": "OpenShift sandboxed containers, based on the Kata Containers open source\nproject, provides an Open Container Initiative (OCI) compliant container\nruntime using lightweight virtual machines, running your workloads in their own\nisolated kernel and therefore contributing an additional layer of isolation\nback to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for\nmore information.\n\n# Requirements\nYour cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.\n\n# Features & benefits\n- **Isolated Developer Environments & Privileges Scoping**\n  As a developer working on debugging an application using state-of-the-art\n  tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With\n  OpenShift sandboxed containers, any impact will be limited to a separate\n  dedicated kernel.\n\n- **Legacy Containerized Workload Isolation**\n  You are mid-way in converting a containerized monolith into cloud-native\n  microservices. However, the monolith still runs on your cluster unpatched and\n  unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel\n  to reduce risk.\n\n- **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**\n  If you are providing a service to multiple tenants, it could mean that the\n  service workloads are sharing the same resources (e.g., worker node). By\n  deploying in a dedicated kernel, the impact of these workloads have on one\n  another is greatly reduced.\n\n- **Additional Isolation with Native Kubernetes User Experience**\n  OpenShift sandboxed containers is used as a compliant OCI runtime.\n  Therefore, many operational patterns used with normal containers are still\n  preserved including but not limited to image scanning, GitOps, Imagestreams,\n  and so on.\n\n# How to install\n  Read the information about the Operator and click Install.\n\n  On the Install Operator page:\n\n  - Select `candidate` from the list of available Update Channel options.\n  This ensures that you install the latest version of OpenShift sandboxed containers\n  that is compatible with your OpenShift Container Platform version.\n\n  - For Installed Namespace, ensure that the Operator recommended namespace\n    option is selected. This installs the Operator in the mandatory\n    `openshift-sandboxed-containers-operator` namespace, which is automatically\n    created if it does not exist. Attempting to install the OpenShift\n    sandboxed containers Operator in a namespace other than\n    `openshift-sandboxed-containers-operator` causes the installation to fail.\n\n  - For Approval Strategy, ensure that Automatic, which is the default value,\n    is selected. OpenShift sandboxed containers automatically updates when a new\n    z-stream release is available.\n\n  - Click Install to make the Operator available to the OpenShift sandboxed\n    containers namespace.\n\n  - The OpenShift sandboxed containers Operator is now installed on your\n    cluster. You can trigger the Operator by enabling the runtime on your cluster.\n    You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click\n    on \"create instance\" on the operator overview page.\n\n# Documentation\nSee the [OpenShift sandboxed containers documentation](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/).",
+                "displayName": "OpenShift sandboxed containers Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "sandboxed-containers",
+                    "kata"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.s390x": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Sandboxed Containers Operator",
+                        "url": "https://www.github.com/openshift/sandboxed-containers-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "'Red Hat",
+                        "email": "support@redhat.com'"
+                    }
+                ],
+                "maturity": "beta",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62"
+        },
+        {
+            "name": "caa",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:07c42ec5b059d3af7face3bd7306e7a71322d6f00240be82285bb303f30c13b1"
+        },
+        {
+            "name": "peerpods-webhook",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:706295cfa2ae389edcebb5de9494c929f4da1e06f9e44a0d266cba94ab0f1a0f"
+        },
+        {
+            "name": "podvm-oci",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:00c40a8dc40702a2016c3c43fa843b96b7979c756637a8760901871a3b12369d"
+        },
+        {
+            "name": "kata-monitor",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:2a69854ef50aec3cb1e7ee1e7de9bc698c6c2f52fd87c57e57c5a4c3198904a5"
+        },
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:6463e9ffad314cff44652b2be8d93aba8bd6cd14b2ae1b312ea2c86137a6da20"
+        },
+        {
+            "name": "podvm-builder",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:e2068d1f0aade0aaaa5689cc118be2a3619a32523629e259f97f84776422c16f"
+        },
+        {
+            "name": "podvm-payload",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:1b4762b4b8aa28a8ce4de28f64a72aafc0f0c75a5ccec805177ec840593ccc64"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:d57199ede3a56a51393caf5df72a96a9896c296e4d71f4ee1c86ec7e69bc3123"
+        },
+        {
+            "name": "storage-helper",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:aaa17f717c5da54eaadc2f4c5a9ba98ee4e7879b963675601d2f78abcd733489"
         }
     ]
 }

--- a/fbc/v4.20/catalog-template.yaml
+++ b/fbc/v4.20/catalog-template.yaml
@@ -68,6 +68,9 @@ entries:
       - name: sandboxed-containers-operator.v1.12.1
         replaces: sandboxed-containers-operator.v1.12.0
         skipRange: '>=1.1.0 <1.12.1'
+      - name: sandboxed-containers-operator.v1.13.0
+        replaces: sandboxed-containers-operator.v1.12.1
+        skipRange: '>=1.1.0 <1.13.0'
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
@@ -122,6 +125,8 @@ entries:
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:e38b650b4007b7c232d05a9b21990b7bdad73fa0b3b89cbe032c5bbf6f2475e8
     schema: olm.bundle
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62
     schema: olm.bundle
   - schema: olm.deprecations
     package: sandboxed-containers-operator

--- a/fbc/v4.20/catalog/sandboxed-containers-operator/catalog.json
+++ b/fbc/v4.20/catalog/sandboxed-containers-operator/catalog.json
@@ -116,6 +116,11 @@
             "name": "sandboxed-containers-operator.v1.12.1",
             "replaces": "sandboxed-containers-operator.v1.12.0",
             "skipRange": ">=1.1.0 <1.12.1"
+        },
+        {
+            "name": "sandboxed-containers-operator.v1.13.0",
+            "replaces": "sandboxed-containers-operator.v1.12.1",
+            "skipRange": ">=1.1.0 <1.13.0"
         }
     ]
 }
@@ -1584,10 +1589,6 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
-        },
-        {
             "name": "caa",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:dc519d24e7ce748f9a980598f8b9ffd95b41f77c053ce6254419238dd9dd292a"
         },
@@ -1606,6 +1607,10 @@
         {
             "name": "must-gather",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:80726dfef5dcc48719e9c1c023c93a3a0bca5cda789fac69301707e618b1afb9"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
         },
         {
             "name": "pccs",
@@ -1630,6 +1635,168 @@
         {
             "name": "tdx-qgs",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:42154e82e433eda6d5a59b5f7cadd7702cc0cba1ca4622358322669c5008d14b"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "sandboxed-containers-operator.v1.13.0",
+    "package": "sandboxed-containers-operator",
+    "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "confidentialcontainers.org",
+                "kind": "PeerPod",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kataconfiguration.openshift.io",
+                "kind": "KataConfig",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "sandboxed-containers-operator",
+                "version": "1.13.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kataconfiguration.openshift.io/v1\",\n    \"kind\": \"KataConfig\",\n    \"metadata\": {\n      \"name\": \"example-kataconfig\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "createdAt": "2026-06-19T12:35:42Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "false",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "true",
+                    "features.operators.openshift.io/token-auth-azure": "true",
+                    "features.operators.openshift.io/token-auth-gcp": "true",
+                    "olm.skipRange": ">=1.1.0 <1.13.0",
+                    "operatorframework.io/suggested-namespace": "openshift-sandboxed-containers-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.39.1",
+                    "operators.operatorframework.io/internal-objects": "[\"peerpods.confidentialcontainers.org\",\"peerpodconfigs.confidentialcontainers.org\"]",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "repository": "https://github.com/openshift/sandboxed-containers-operator"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kataconfigs.kataconfiguration.openshift.io",
+                            "version": "v1",
+                            "kind": "KataConfig",
+                            "description": "The kataconfig CR represent a installation of Kata in a cluster and its current state."
+                        },
+                        {
+                            "name": "peerpods.confidentialcontainers.org",
+                            "version": "v1alpha1",
+                            "kind": "PeerPod"
+                        }
+                    ]
+                },
+                "description": "OpenShift sandboxed containers, based on the Kata Containers open source\nproject, provides an Open Container Initiative (OCI) compliant container\nruntime using lightweight virtual machines, running your workloads in their own\nisolated kernel and therefore contributing an additional layer of isolation\nback to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for\nmore information.\n\n# Requirements\nYour cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.\n\n# Features & benefits\n- **Isolated Developer Environments & Privileges Scoping**\n  As a developer working on debugging an application using state-of-the-art\n  tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With\n  OpenShift sandboxed containers, any impact will be limited to a separate\n  dedicated kernel.\n\n- **Legacy Containerized Workload Isolation**\n  You are mid-way in converting a containerized monolith into cloud-native\n  microservices. However, the monolith still runs on your cluster unpatched and\n  unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel\n  to reduce risk.\n\n- **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**\n  If you are providing a service to multiple tenants, it could mean that the\n  service workloads are sharing the same resources (e.g., worker node). By\n  deploying in a dedicated kernel, the impact of these workloads have on one\n  another is greatly reduced.\n\n- **Additional Isolation with Native Kubernetes User Experience**\n  OpenShift sandboxed containers is used as a compliant OCI runtime.\n  Therefore, many operational patterns used with normal containers are still\n  preserved including but not limited to image scanning, GitOps, Imagestreams,\n  and so on.\n\n# How to install\n  Read the information about the Operator and click Install.\n\n  On the Install Operator page:\n\n  - Select `candidate` from the list of available Update Channel options.\n  This ensures that you install the latest version of OpenShift sandboxed containers\n  that is compatible with your OpenShift Container Platform version.\n\n  - For Installed Namespace, ensure that the Operator recommended namespace\n    option is selected. This installs the Operator in the mandatory\n    `openshift-sandboxed-containers-operator` namespace, which is automatically\n    created if it does not exist. Attempting to install the OpenShift\n    sandboxed containers Operator in a namespace other than\n    `openshift-sandboxed-containers-operator` causes the installation to fail.\n\n  - For Approval Strategy, ensure that Automatic, which is the default value,\n    is selected. OpenShift sandboxed containers automatically updates when a new\n    z-stream release is available.\n\n  - Click Install to make the Operator available to the OpenShift sandboxed\n    containers namespace.\n\n  - The OpenShift sandboxed containers Operator is now installed on your\n    cluster. You can trigger the Operator by enabling the runtime on your cluster.\n    You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click\n    on \"create instance\" on the operator overview page.\n\n# Documentation\nSee the [OpenShift sandboxed containers documentation](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/).",
+                "displayName": "OpenShift sandboxed containers Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "sandboxed-containers",
+                    "kata"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.s390x": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Sandboxed Containers Operator",
+                        "url": "https://www.github.com/openshift/sandboxed-containers-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "'Red Hat",
+                        "email": "support@redhat.com'"
+                    }
+                ],
+                "maturity": "beta",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62"
+        },
+        {
+            "name": "caa",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:07c42ec5b059d3af7face3bd7306e7a71322d6f00240be82285bb303f30c13b1"
+        },
+        {
+            "name": "peerpods-webhook",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:706295cfa2ae389edcebb5de9494c929f4da1e06f9e44a0d266cba94ab0f1a0f"
+        },
+        {
+            "name": "podvm-oci",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:00c40a8dc40702a2016c3c43fa843b96b7979c756637a8760901871a3b12369d"
+        },
+        {
+            "name": "kata-monitor",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:2a69854ef50aec3cb1e7ee1e7de9bc698c6c2f52fd87c57e57c5a4c3198904a5"
+        },
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:6463e9ffad314cff44652b2be8d93aba8bd6cd14b2ae1b312ea2c86137a6da20"
+        },
+        {
+            "name": "podvm-builder",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:e2068d1f0aade0aaaa5689cc118be2a3619a32523629e259f97f84776422c16f"
+        },
+        {
+            "name": "podvm-payload",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:1b4762b4b8aa28a8ce4de28f64a72aafc0f0c75a5ccec805177ec840593ccc64"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:d57199ede3a56a51393caf5df72a96a9896c296e4d71f4ee1c86ec7e69bc3123"
+        },
+        {
+            "name": "storage-helper",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:aaa17f717c5da54eaadc2f4c5a9ba98ee4e7879b963675601d2f78abcd733489"
         }
     ]
 }

--- a/fbc/v4.21/catalog-template.yaml
+++ b/fbc/v4.21/catalog-template.yaml
@@ -68,6 +68,9 @@ entries:
       - name: sandboxed-containers-operator.v1.12.1
         replaces: sandboxed-containers-operator.v1.12.0
         skipRange: '>=1.1.0 <1.12.1'
+      - name: sandboxed-containers-operator.v1.13.0
+        replaces: sandboxed-containers-operator.v1.12.1
+        skipRange: '>=1.1.0 <1.13.0'
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
@@ -122,6 +125,8 @@ entries:
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:e38b650b4007b7c232d05a9b21990b7bdad73fa0b3b89cbe032c5bbf6f2475e8
     schema: olm.bundle
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62
     schema: olm.bundle
   - schema: olm.deprecations
     package: sandboxed-containers-operator

--- a/fbc/v4.21/catalog/sandboxed-containers-operator/catalog.json
+++ b/fbc/v4.21/catalog/sandboxed-containers-operator/catalog.json
@@ -116,6 +116,11 @@
             "name": "sandboxed-containers-operator.v1.12.1",
             "replaces": "sandboxed-containers-operator.v1.12.0",
             "skipRange": ">=1.1.0 <1.12.1"
+        },
+        {
+            "name": "sandboxed-containers-operator.v1.13.0",
+            "replaces": "sandboxed-containers-operator.v1.12.1",
+            "skipRange": ">=1.1.0 <1.13.0"
         }
     ]
 }
@@ -1584,10 +1589,6 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
-        },
-        {
             "name": "caa",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:dc519d24e7ce748f9a980598f8b9ffd95b41f77c053ce6254419238dd9dd292a"
         },
@@ -1606,6 +1607,10 @@
         {
             "name": "must-gather",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:80726dfef5dcc48719e9c1c023c93a3a0bca5cda789fac69301707e618b1afb9"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
         },
         {
             "name": "pccs",
@@ -1630,6 +1635,168 @@
         {
             "name": "tdx-qgs",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:42154e82e433eda6d5a59b5f7cadd7702cc0cba1ca4622358322669c5008d14b"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "sandboxed-containers-operator.v1.13.0",
+    "package": "sandboxed-containers-operator",
+    "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "confidentialcontainers.org",
+                "kind": "PeerPod",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kataconfiguration.openshift.io",
+                "kind": "KataConfig",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "sandboxed-containers-operator",
+                "version": "1.13.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kataconfiguration.openshift.io/v1\",\n    \"kind\": \"KataConfig\",\n    \"metadata\": {\n      \"name\": \"example-kataconfig\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "createdAt": "2026-06-19T12:35:42Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "false",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "true",
+                    "features.operators.openshift.io/token-auth-azure": "true",
+                    "features.operators.openshift.io/token-auth-gcp": "true",
+                    "olm.skipRange": ">=1.1.0 <1.13.0",
+                    "operatorframework.io/suggested-namespace": "openshift-sandboxed-containers-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.39.1",
+                    "operators.operatorframework.io/internal-objects": "[\"peerpods.confidentialcontainers.org\",\"peerpodconfigs.confidentialcontainers.org\"]",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "repository": "https://github.com/openshift/sandboxed-containers-operator"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kataconfigs.kataconfiguration.openshift.io",
+                            "version": "v1",
+                            "kind": "KataConfig",
+                            "description": "The kataconfig CR represent a installation of Kata in a cluster and its current state."
+                        },
+                        {
+                            "name": "peerpods.confidentialcontainers.org",
+                            "version": "v1alpha1",
+                            "kind": "PeerPod"
+                        }
+                    ]
+                },
+                "description": "OpenShift sandboxed containers, based on the Kata Containers open source\nproject, provides an Open Container Initiative (OCI) compliant container\nruntime using lightweight virtual machines, running your workloads in their own\nisolated kernel and therefore contributing an additional layer of isolation\nback to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for\nmore information.\n\n# Requirements\nYour cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.\n\n# Features & benefits\n- **Isolated Developer Environments & Privileges Scoping**\n  As a developer working on debugging an application using state-of-the-art\n  tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With\n  OpenShift sandboxed containers, any impact will be limited to a separate\n  dedicated kernel.\n\n- **Legacy Containerized Workload Isolation**\n  You are mid-way in converting a containerized monolith into cloud-native\n  microservices. However, the monolith still runs on your cluster unpatched and\n  unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel\n  to reduce risk.\n\n- **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**\n  If you are providing a service to multiple tenants, it could mean that the\n  service workloads are sharing the same resources (e.g., worker node). By\n  deploying in a dedicated kernel, the impact of these workloads have on one\n  another is greatly reduced.\n\n- **Additional Isolation with Native Kubernetes User Experience**\n  OpenShift sandboxed containers is used as a compliant OCI runtime.\n  Therefore, many operational patterns used with normal containers are still\n  preserved including but not limited to image scanning, GitOps, Imagestreams,\n  and so on.\n\n# How to install\n  Read the information about the Operator and click Install.\n\n  On the Install Operator page:\n\n  - Select `candidate` from the list of available Update Channel options.\n  This ensures that you install the latest version of OpenShift sandboxed containers\n  that is compatible with your OpenShift Container Platform version.\n\n  - For Installed Namespace, ensure that the Operator recommended namespace\n    option is selected. This installs the Operator in the mandatory\n    `openshift-sandboxed-containers-operator` namespace, which is automatically\n    created if it does not exist. Attempting to install the OpenShift\n    sandboxed containers Operator in a namespace other than\n    `openshift-sandboxed-containers-operator` causes the installation to fail.\n\n  - For Approval Strategy, ensure that Automatic, which is the default value,\n    is selected. OpenShift sandboxed containers automatically updates when a new\n    z-stream release is available.\n\n  - Click Install to make the Operator available to the OpenShift sandboxed\n    containers namespace.\n\n  - The OpenShift sandboxed containers Operator is now installed on your\n    cluster. You can trigger the Operator by enabling the runtime on your cluster.\n    You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click\n    on \"create instance\" on the operator overview page.\n\n# Documentation\nSee the [OpenShift sandboxed containers documentation](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/).",
+                "displayName": "OpenShift sandboxed containers Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "sandboxed-containers",
+                    "kata"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.s390x": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Sandboxed Containers Operator",
+                        "url": "https://www.github.com/openshift/sandboxed-containers-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "'Red Hat",
+                        "email": "support@redhat.com'"
+                    }
+                ],
+                "maturity": "beta",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62"
+        },
+        {
+            "name": "caa",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:07c42ec5b059d3af7face3bd7306e7a71322d6f00240be82285bb303f30c13b1"
+        },
+        {
+            "name": "peerpods-webhook",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:706295cfa2ae389edcebb5de9494c929f4da1e06f9e44a0d266cba94ab0f1a0f"
+        },
+        {
+            "name": "podvm-oci",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:00c40a8dc40702a2016c3c43fa843b96b7979c756637a8760901871a3b12369d"
+        },
+        {
+            "name": "kata-monitor",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:2a69854ef50aec3cb1e7ee1e7de9bc698c6c2f52fd87c57e57c5a4c3198904a5"
+        },
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:6463e9ffad314cff44652b2be8d93aba8bd6cd14b2ae1b312ea2c86137a6da20"
+        },
+        {
+            "name": "podvm-builder",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:e2068d1f0aade0aaaa5689cc118be2a3619a32523629e259f97f84776422c16f"
+        },
+        {
+            "name": "podvm-payload",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:1b4762b4b8aa28a8ce4de28f64a72aafc0f0c75a5ccec805177ec840593ccc64"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:d57199ede3a56a51393caf5df72a96a9896c296e4d71f4ee1c86ec7e69bc3123"
+        },
+        {
+            "name": "storage-helper",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:aaa17f717c5da54eaadc2f4c5a9ba98ee4e7879b963675601d2f78abcd733489"
         }
     ]
 }

--- a/fbc/v4.22/catalog-template.yaml
+++ b/fbc/v4.22/catalog-template.yaml
@@ -68,6 +68,9 @@ entries:
       - name: sandboxed-containers-operator.v1.12.1
         replaces: sandboxed-containers-operator.v1.12.0
         skipRange: '>=1.1.0 <1.12.1'
+      - name: sandboxed-containers-operator.v1.13.0
+        replaces: sandboxed-containers-operator.v1.12.1
+        skipRange: '>=1.1.0 <1.13.0'
     name: stable
     package: sandboxed-containers-operator
     schema: olm.channel
@@ -122,6 +125,8 @@ entries:
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:e38b650b4007b7c232d05a9b21990b7bdad73fa0b3b89cbe032c5bbf6f2475e8
     schema: olm.bundle
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450
+    schema: olm.bundle
+  - image: registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62
     schema: olm.bundle
   - schema: olm.deprecations
     package: sandboxed-containers-operator

--- a/fbc/v4.22/catalog/sandboxed-containers-operator/catalog.json
+++ b/fbc/v4.22/catalog/sandboxed-containers-operator/catalog.json
@@ -116,6 +116,11 @@
             "name": "sandboxed-containers-operator.v1.12.1",
             "replaces": "sandboxed-containers-operator.v1.12.0",
             "skipRange": ">=1.1.0 <1.12.1"
+        },
+        {
+            "name": "sandboxed-containers-operator.v1.13.0",
+            "replaces": "sandboxed-containers-operator.v1.12.1",
+            "skipRange": ">=1.1.0 <1.13.0"
         }
     ]
 }
@@ -1584,10 +1589,6 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
-        },
-        {
             "name": "caa",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:dc519d24e7ce748f9a980598f8b9ffd95b41f77c053ce6254419238dd9dd292a"
         },
@@ -1606,6 +1607,10 @@
         {
             "name": "must-gather",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:80726dfef5dcc48719e9c1c023c93a3a0bca5cda789fac69301707e618b1afb9"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:0b17ffc774ff982d75f6514f4bf9a11e4d040ba8841d8f7b5b266c3ccdd50450"
         },
         {
             "name": "pccs",
@@ -1630,6 +1635,168 @@
         {
             "name": "tdx-qgs",
             "image": "registry.redhat.io/openshift-sandboxed-containers/osc-tdx-qgs@sha256:42154e82e433eda6d5a59b5f7cadd7702cc0cba1ca4622358322669c5008d14b"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "sandboxed-containers-operator.v1.13.0",
+    "package": "sandboxed-containers-operator",
+    "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "confidentialcontainers.org",
+                "kind": "PeerPod",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kataconfiguration.openshift.io",
+                "kind": "KataConfig",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "sandboxed-containers-operator",
+                "version": "1.13.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kataconfiguration.openshift.io/v1\",\n    \"kind\": \"KataConfig\",\n    \"metadata\": {\n      \"name\": \"example-kataconfig\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "createdAt": "2026-06-19T12:35:42Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "false",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "true",
+                    "features.operators.openshift.io/token-auth-azure": "true",
+                    "features.operators.openshift.io/token-auth-gcp": "true",
+                    "olm.skipRange": ">=1.1.0 <1.13.0",
+                    "operatorframework.io/suggested-namespace": "openshift-sandboxed-containers-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.39.1",
+                    "operators.operatorframework.io/internal-objects": "[\"peerpods.confidentialcontainers.org\",\"peerpodconfigs.confidentialcontainers.org\"]",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "repository": "https://github.com/openshift/sandboxed-containers-operator"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kataconfigs.kataconfiguration.openshift.io",
+                            "version": "v1",
+                            "kind": "KataConfig",
+                            "description": "The kataconfig CR represent a installation of Kata in a cluster and its current state."
+                        },
+                        {
+                            "name": "peerpods.confidentialcontainers.org",
+                            "version": "v1alpha1",
+                            "kind": "PeerPod"
+                        }
+                    ]
+                },
+                "description": "OpenShift sandboxed containers, based on the Kata Containers open source\nproject, provides an Open Container Initiative (OCI) compliant container\nruntime using lightweight virtual machines, running your workloads in their own\nisolated kernel and therefore contributing an additional layer of isolation\nback to OpenShift's Defense-in-Depth strategy. Click [this link](https://catalog.redhat.com/software/operators/detail/5ee0d499fdbe7cddc2c91cf5) for\nmore information.\n\n# Requirements\nYour cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers.\n\n# Features & benefits\n- **Isolated Developer Environments & Privileges Scoping**\n  As a developer working on debugging an application using state-of-the-art\n  tooling you might need elevated privileges such as `CAP_ADMIN` or `CAP_BPF`. With\n  OpenShift sandboxed containers, any impact will be limited to a separate\n  dedicated kernel.\n\n- **Legacy Containerized Workload Isolation**\n  You are mid-way in converting a containerized monolith into cloud-native\n  microservices. However, the monolith still runs on your cluster unpatched and\n  unmaintained. OpenShift sandboxed containers helps isolate it in its own kernel\n  to reduce risk.\n\n- **Safe Multi-tenancy & Resource Sharing (CI/CD Jobs, CNFs, ..)**\n  If you are providing a service to multiple tenants, it could mean that the\n  service workloads are sharing the same resources (e.g., worker node). By\n  deploying in a dedicated kernel, the impact of these workloads have on one\n  another is greatly reduced.\n\n- **Additional Isolation with Native Kubernetes User Experience**\n  OpenShift sandboxed containers is used as a compliant OCI runtime.\n  Therefore, many operational patterns used with normal containers are still\n  preserved including but not limited to image scanning, GitOps, Imagestreams,\n  and so on.\n\n# How to install\n  Read the information about the Operator and click Install.\n\n  On the Install Operator page:\n\n  - Select `candidate` from the list of available Update Channel options.\n  This ensures that you install the latest version of OpenShift sandboxed containers\n  that is compatible with your OpenShift Container Platform version.\n\n  - For Installed Namespace, ensure that the Operator recommended namespace\n    option is selected. This installs the Operator in the mandatory\n    `openshift-sandboxed-containers-operator` namespace, which is automatically\n    created if it does not exist. Attempting to install the OpenShift\n    sandboxed containers Operator in a namespace other than\n    `openshift-sandboxed-containers-operator` causes the installation to fail.\n\n  - For Approval Strategy, ensure that Automatic, which is the default value,\n    is selected. OpenShift sandboxed containers automatically updates when a new\n    z-stream release is available.\n\n  - Click Install to make the Operator available to the OpenShift sandboxed\n    containers namespace.\n\n  - The OpenShift sandboxed containers Operator is now installed on your\n    cluster. You can trigger the Operator by enabling the runtime on your cluster.\n    You can do this by creating a `KataConfig` CustomResourceDefinition(CRD) instance. For this click\n    on \"create instance\" on the operator overview page.\n\n# Documentation\nSee the [OpenShift sandboxed containers documentation](https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/).",
+                "displayName": "OpenShift sandboxed containers Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "sandboxed-containers",
+                    "kata"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.s390x": "supported",
+                    "operatorframework.io/os.linux": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Sandboxed Containers Operator",
+                        "url": "https://www.github.com/openshift/sandboxed-containers-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "'Red Hat",
+                        "email": "support@redhat.com'"
+                    }
+                ],
+                "maturity": "beta",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-operator-bundle@sha256:5481302afde8a317f70036258612aebb6222fb9d6f5aa398126d3d247dd34d62"
+        },
+        {
+            "name": "caa",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:07c42ec5b059d3af7face3bd7306e7a71322d6f00240be82285bb303f30c13b1"
+        },
+        {
+            "name": "peerpods-webhook",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9@sha256:706295cfa2ae389edcebb5de9494c929f4da1e06f9e44a0d266cba94ab0f1a0f"
+        },
+        {
+            "name": "podvm-oci",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:00c40a8dc40702a2016c3c43fa843b96b7979c756637a8760901871a3b12369d"
+        },
+        {
+            "name": "kata-monitor",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:2a69854ef50aec3cb1e7ee1e7de9bc698c6c2f52fd87c57e57c5a4c3198904a5"
+        },
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel9@sha256:6463e9ffad314cff44652b2be8d93aba8bd6cd14b2ae1b312ea2c86137a6da20"
+        },
+        {
+            "name": "podvm-builder",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9@sha256:e2068d1f0aade0aaaa5689cc118be2a3619a32523629e259f97f84776422c16f"
+        },
+        {
+            "name": "podvm-payload",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9@sha256:1b4762b4b8aa28a8ce4de28f64a72aafc0f0c75a5ccec805177ec840593ccc64"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-rhel9-operator@sha256:d57199ede3a56a51393caf5df72a96a9896c296e4d71f4ee1c86ec7e69bc3123"
+        },
+        {
+            "name": "storage-helper",
+            "image": "registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:aaa17f717c5da54eaadc2f4c5a9ba98ee4e7879b963675601d2f78abcd733489"
         }
     ]
 }


### PR DESCRIPTION
Add sandboxed-containers-operator.v1.13.0 channel entry to the stable channel.
Also update olm.bundle reference with digest sha256:5481302a for OCP versions v4.19 through v4.22

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
