### PR TITLE
kata-install: use TP_ prefix for DS image temporarly

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -398,7 +398,7 @@ spec:
                 env:
                 - name: PEERPODS_NAMESPACE
                   value: openshift-sandboxed-containers-operator
-                - name: RELATED_IMAGE_KATA_DAEMONSET
+                - name: TP_KATA_DAEMONSET
                   value: quay.io/openshift_sandboxed_containers/osc-daemonset:1.13
                 - name: RELATED_IMAGE_KATA_MONITOR
                   value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:7b9adb111b0277f41222b409fc8815b2d075ce945401741ea6e0670dfa8ec5a1
@@ -571,8 +571,6 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/openshift_sandboxed_containers/osc-daemonset:1.13
-    name: kata-daemonset
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:7b9adb111b0277f41222b409fc8815b2d075ce945401741ea6e0670dfa8ec5a1
     name: kata-monitor
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9@sha256:7523fc2133233196f8fcbbe7c96d44c24ec4d3d60b40a0c306da4240e5997e4c

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -86,7 +86,7 @@ spec:
           env:
             - name: PEERPODS_NAMESPACE
               value: "openshift-sandboxed-containers-operator"
-            - name: RELATED_IMAGE_KATA_DAEMONSET
+            - name: TP_KATA_DAEMONSET
               value: quay.io/openshift_sandboxed_containers/osc-daemonset:1.13
             - name: RELATED_IMAGE_KATA_MONITOR
               value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9@sha256:7b9adb111b0277f41222b409fc8815b2d075ce945401741ea6e0670dfa8ec5a1

--- a/controllers/daemonset_reconcile.go
+++ b/controllers/daemonset_reconcile.go
@@ -34,7 +34,7 @@ const (
 	rhelCoreOsExtensionsImageName = "rhel-coreos-extensions"
 	cliImageName                  = "cli"
 
-	relatedImageKataDaemonSetName = "RELATED_IMAGE_KATA_DAEMONSET"
+	relatedImageKataDaemonSetName = "TP_KATA_DAEMONSET"
 )
 
 // KataInstallationDaemonSetState defines the possible states of the Kata installation DaemonSet.
@@ -405,7 +405,7 @@ func (r *KataConfigOpenShiftReconciler) daemonSetForKataInstall(action KataDaemo
 
 	dsImage := os.Getenv(relatedImageKataDaemonSetName)
 	if dsImage == "" {
-		r.Log.Info("RELATED_IMAGE_KATA_DAEMONSET env var is unset or empty, kata install pods will not run")
+		r.Log.Info("TP_KATA_DAEMONSET env var is unset or empty, kata install pods will not run")
 	}
 
 	// Because we use chroot and modify the node we need root priviliges


### PR DESCRIPTION
Rename RELATED_IMAGE_KATA_DAEMONSET to TP_KATA_DAEMONSET to bypass OLM/EC policy validation for this dev image which uses a non-approved registry and tag reference.

This should be reverted once a valid image with a proper digest from an approved registry is available, restoring the RELATED_IMAGE_ prefix.

NOTE: Taken out of https://github.com/openshift/sandboxed-containers-operator/pull/2536 to make a separate PR.
