### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,22 @@
 reviewers:
-  - jensfr	
-  - pmores
-  - bpradipt
-  - gkurz
-  - littlejawa
-  - snir911
-  - vvoronko
-  - tbuskey
-  - wainersm
   - c3d
+  - gkurz
+  - jensfr
+  - littlejawa
+  - ldoktor
+  - pmores
+  - snir911
+  - tbuskey
+  - vvoronko
+  - wainersm
 approvers:
-  - jensfr	
-  - pmores
-  - bpradipt
-  - gkurz
-  - littlejawa
-  - snir911
-  - vvoronko
-  - tbuskey
-  - wainersm
   - c3d
+  - gkurz
+  - jensfr
+  - littlejawa
+  - ldoktor
+  - pmores
+  - snir911
+  - tbuskey
+  - vvoronko
+  - wainersm


### PR DESCRIPTION
fix: Update OWNERS

Add ldoktor, remove bpradipt

The OWNERS file is used to generate the OWNERS in the prow ci-operator/config/openshift/sandboxed-containers-operator and ci-operator/step-registry/sandboxed-containers-operator.  prow has tools to propagate it to subdirectories as explained there.
