### PR TITLE
tests: update KATA_RPM_VERSION to version 3.31.0-5

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -158,7 +158,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate420
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-2.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
       matrix:
         params:
           - name: PROWJOB_NAME
@@ -191,7 +191,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate419
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-2.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -228,7 +228,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate420
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-2.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -263,7 +263,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate421
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-2.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -299,7 +299,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate422
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-2.rhaos4.22.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.22.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES


### PR DESCRIPTION
kata-containers-3.31.0-5 RPMs are available in brew.

For OCP 4.19, 4.20 and 4.21:

https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4083271

For OCP 4.22 :

https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4083275

Signed-off-by: Daniel Kreling <dkreling@redhat.com>