### PR TITLE
Update network policy rbac

### DIFF
--- a/bundle/manifests/kata-install_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kata-install_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,6 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: kata-install
 rules:
 - apiGroups:

--- a/bundle/manifests/kata-install_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/kata-install_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,6 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   name: kata-install
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/kata-install_v1_serviceaccount.yaml
+++ b/bundle/manifests/kata-install_v1_serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   name: kata-install
-  namespace: openshift-sandboxed-containers-operator

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-08-19T07:37:55Z"
+    createdAt: "2026-08-18T07:36:02Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -329,6 +329,14 @@ spec:
           verbs:
           - get
           - patch
+          - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
           - update
         - apiGroups:
           - node.k8s.io

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -207,6 +207,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - node.k8s.io
           resources:
           - runtimeclasses

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -196,6 +196,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - node.k8s.io
   resources:
   - runtimeclasses

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -129,6 +129,7 @@ var (
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 func (r *KataConfigOpenShiftReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("kataconfig", req.NamespacedName)


### PR DESCRIPTION
We're getting failures in Conforma, because of a new rule for operators in OCP 5.0
We need to declare the RBAC for NetworkPolicy.

Running "make bundle" also modified unrelated files. This comes from the changes we made for 1.13.1 I think.
I'm keeping them in a separate commit, we can make a separate PR if needed.