### PR TITLE
konflux: add a filter file for snyk check

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file
+#
+# Exclude submodule code embedded under config/peerpods/podvm/cloud-api-adaptor.
+# This subtree contains sources from cloud-api-adaptor, guest-components and
+# kata-containers — all maintained in separate repositories.
+# Findings there are addressed in our corresponding forks, not here.
+exclude:
+  global:
+    - config/peerpods/podvm/cloud-api-adaptor


### PR DESCRIPTION
We are getting some reports from the snyk check because of the cloud-api-adaptor submodule. This module comes from our fork, where we also have builds and snyk check running. No need to duplicate the checks.

This file addition will disable the snyk check on the submodule folder. Any issue with cloud-api-adaptor will be treated in our fork.
