### PR TITLE
test/run_upstream_tests: disable tests, fixes and a couple of improvements

### DIFF
--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESULTS_DIR="${RESULTS_DIR:-${SCRIPT_DIR}/results}"
+RESULTS_DIR="${RESULTS_DIR}/$(date +"%Y-%m-%d_%H%M%S")"
 
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 export AUTO_GENERATE_POLICY="no"

--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Run upstream kata-containers BATS tests on OpenShift.
 # Requires: bats, yq, jq, kubectl, envsubst, oc
-# Usage: KUBECONFIG=/path/to/kubeconfig bash run_upstream_tests.sh [sanity|pods|workloads|resources|volumes|networking|full]
 set -o pipefail
 
 KATA_TESTS_DIR="${KATA_TESTS_DIR:?KATA_TESTS_DIR must be set to kata-containers/tests/integration/kubernetes}"
@@ -12,9 +11,34 @@ export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 export AUTO_GENERATE_POLICY="no"
 export CONTAINER_RUNTIME="crio"
 export K8S_TEST_DEBUG="false"
-export KUBECONFIG="${KUBECONFIG:?KUBECONFIG must be set}"
 
-PROFILE="${1:-full}"
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Run upstream kata-containers BATS tests on an OpenShift cluster.
+Requires: bats, yq, jq, kubectl, envsubst, oc
+
+Options:
+  -t, --test PROFILE     Test profile or .bats file to run (default: full)
+                         Profiles: sanity, pods, workloads, resources, volumes, networking, full
+                         Or a single .bats file, e.g. k8s-env.bats
+  -h, --help             Show this help
+EOF
+    exit "${1:-1}"
+}
+
+PROFILE="full"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t|--test) PROFILE="$2"; shift 2;;
+        -h|--help) usage 0;;
+        *) echo "Unknown argument: $1"; usage;;
+    esac
+done
+
+export KUBECONFIG="${KUBECONFIG:?KUBECONFIG must be set}"
 
 # --- Test sections ---
 PODS=(
@@ -96,18 +120,7 @@ case "$PROFILE" in
     networking) TESTS=("${NETWORKING[@]}") ;;
     full)       TESTS=("${PODS[@]}" "${WORKLOADS[@]}" "${RESOURCES[@]}" "${VOLUMES[@]}" "${NETWORKING[@]}") ;;
     *.bats)     TESTS=("${PROFILE}") ;;
-    *)
-        echo "Usage: $0 [sanity|pods|workloads|resources|volumes|networking|full|<test>.bats]"
-        echo "  sanity       - 5 tests, one per section"
-        echo "  pods         - ${#PODS[@]} tests: exec, caps, security context, etc."
-        echo "  workloads    - ${#WORKLOADS[@]} tests: jobs, cron, replication, scaling"
-        echo "  resources    - ${#RESOURCES[@]} tests: limits, memory, oom, quotas"
-        echo "  volumes      - ${#VOLUMES[@]} tests: configmaps, secrets, volumes"
-        echo "  networking   - ${#NETWORKING[@]} tests: connectivity, port-forward, dns"
-        echo "  full         - all $(( ${#PODS[@]} + ${#WORKLOADS[@]} + ${#RESOURCES[@]} + ${#VOLUMES[@]} + ${#NETWORKING[@]} )) tests (default)"
-        echo "  <test>.bats  - run a single test file, e.g. k8s-file-volume.bats"
-        exit 1
-        ;;
+    *)  echo "Unknown profile: $PROFILE"; usage;;
 esac
 
 # --- Prereq checks ---

--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -26,6 +26,7 @@ Options:
                             (default: https://github.com/openshift/kata-containers)
   --tests-repo-ref REF      Git ref to checkout — branch or tag (default: main)
   --preserve-tests-repo     Do not delete the cloned test repo after execution
+  --skip-setup              Skip cluster setup (node labeling, setup.sh, namespace, SCC)
   -h, --help                Show this help
 EOF
     exit "${1:-1}"
@@ -35,6 +36,7 @@ PROFILE="full"
 TESTS_REPO="https://github.com/openshift/kata-containers"
 TESTS_REPO_REF="main"
 PRESERVE_TESTS_REPO=false
+SKIP_SETUP=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -42,6 +44,7 @@ while [ $# -gt 0 ]; do
         --tests-repo) TESTS_REPO="$2"; shift 2;;
         --tests-repo-ref) TESTS_REPO_REF="$2"; shift 2;;
         --preserve-tests-repo) PRESERVE_TESTS_REPO=true; shift;;
+        --skip-setup) SKIP_SETUP=true; shift;;
         -h|--help) usage 0;;
         *) echo "Unknown argument: $1"; usage;;
     esac
@@ -182,35 +185,38 @@ if [[ ! -d "$KATA_TESTS_DIR" ]]; then
     exit 1
 fi
 
-# --- Ensure kata node label ---
-# Upstream tests look for katacontainers.io/kata-runtime=true
-# OSC uses node-role.kubernetes.io/kata-oc
-if ! kubectl get nodes -l katacontainers.io/kata-runtime=true -o name 2>/dev/null | grep -q .; then
-    echo "Adding upstream kata node label to OSC worker nodes..."
-    for node in $(kubectl get nodes -l node-role.kubernetes.io/kata-oc -o name); do
-        kubectl label "$node" katacontainers.io/kata-runtime=true --overwrite >/dev/null || {
-            echo "ERROR: failed to label node $node" >&2; exit 1
-        }
-    done
-fi
-
-# --- Setup upstream working directory ---
-echo "Running upstream setup.sh..."
 cd "$KATA_TESTS_DIR" || exit 1
-bash setup.sh || exit 1
 
-# Create test namespace
-kubectl apply -f runtimeclass_workloads/tests-namespace.yaml || {
-    echo "ERROR: failed to create test namespace" >&2; exit 1
-}
+if [[ "$SKIP_SETUP" != "true" ]]; then
+    # --- Ensure kata node label ---
+    # Upstream tests look for katacontainers.io/kata-runtime=true
+    # OSC uses node-role.kubernetes.io/kata-oc
+    if ! kubectl get nodes -l katacontainers.io/kata-runtime=true -o name 2>/dev/null | grep -q .; then
+        echo "Adding upstream kata node label to OSC worker nodes..."
+        for node in $(kubectl get nodes -l node-role.kubernetes.io/kata-oc -o name); do
+            kubectl label "$node" katacontainers.io/kata-runtime=true --overwrite >/dev/null || {
+                echo "ERROR: failed to label node $node" >&2; exit 1
+            }
+        done
+    fi
 
-# Upstream tests need root (nginx image) and hostPath volumes.
-# Grant privileged SCC to the test namespace service account.
-if ! oc adm policy who-can use scc/privileged -n kata-containers-k8s-tests 2>/dev/null | grep -q "system:serviceaccount:kata-containers-k8s-tests:default"; then
-    oc adm policy add-scc-to-user privileged -z default -n kata-containers-k8s-tests || {
-        echo "ERROR: failed to grant privileged SCC" >&2; exit 1
+    # --- Setup upstream working directory ---
+    echo "Running upstream setup.sh..."
+    bash setup.sh || exit 1
+
+    # Create test namespace
+    kubectl apply -f runtimeclass_workloads/tests-namespace.yaml || {
+        echo "ERROR: failed to create test namespace" >&2; exit 1
     }
-    SCC_ADDED=true
+
+    # Upstream tests need root (nginx image) and hostPath volumes.
+    # Grant privileged SCC to the test namespace service account.
+    if ! oc adm policy who-can use scc/privileged -n kata-containers-k8s-tests 2>/dev/null | grep -q "system:serviceaccount:kata-containers-k8s-tests:default"; then
+        oc adm policy add-scc-to-user privileged -z default -n kata-containers-k8s-tests || {
+            echo "ERROR: failed to grant privileged SCC" >&2; exit 1
+        }
+        SCC_ADDED=true
+    fi
 fi
 
 kubectl config set-context --current --namespace=kata-containers-k8s-tests

--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -98,13 +98,13 @@ case "$PROFILE" in
     *.bats)     TESTS=("${PROFILE}") ;;
     *)
         echo "Usage: $0 [sanity|pods|workloads|resources|volumes|networking|full|<test>.bats]"
-        echo "  sanity       - 5 tests, one per section (default)"
+        echo "  sanity       - 5 tests, one per section"
         echo "  pods         - ${#PODS[@]} tests: exec, caps, security context, etc."
         echo "  workloads    - ${#WORKLOADS[@]} tests: jobs, cron, replication, scaling"
         echo "  resources    - ${#RESOURCES[@]} tests: limits, memory, oom, quotas"
         echo "  volumes      - ${#VOLUMES[@]} tests: configmaps, secrets, volumes"
         echo "  networking   - ${#NETWORKING[@]} tests: connectivity, port-forward, dns"
-        echo "  full         - all $(( ${#PODS[@]} + ${#WORKLOADS[@]} + ${#RESOURCES[@]} + ${#VOLUMES[@]} + ${#NETWORKING[@]} )) tests"
+        echo "  full         - all $(( ${#PODS[@]} + ${#WORKLOADS[@]} + ${#RESOURCES[@]} + ${#VOLUMES[@]} + ${#NETWORKING[@]} )) tests (default)"
         echo "  <test>.bats  - run a single test file, e.g. k8s-file-volume.bats"
         exit 1
         ;;
@@ -123,13 +123,27 @@ if [[ ! -d "$KATA_TESTS_DIR" ]]; then
     exit 1
 fi
 
+# --- Cleanup ---
+ORIG_NAMESPACE="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}' 2>/dev/null)"
+ORIG_NAMESPACE="${ORIG_NAMESPACE:-default}"
+SCC_ADDED=false
+cleanup() {
+    kubectl config set-context --current --namespace="$ORIG_NAMESPACE" 2>/dev/null || true
+    if [[ "$SCC_ADDED" == "true" ]]; then
+        oc adm policy remove-scc-from-user privileged -z default -n kata-containers-k8s-tests 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
 # --- Ensure kata node label ---
 # Upstream tests look for katacontainers.io/kata-runtime=true
 # OSC uses node-role.kubernetes.io/kata-oc
 if ! kubectl get nodes -l katacontainers.io/kata-runtime=true -o name 2>/dev/null | grep -q .; then
     echo "Adding upstream kata node label to OSC worker nodes..."
     for node in $(kubectl get nodes -l node-role.kubernetes.io/kata-oc -o name); do
-        kubectl label "$node" katacontainers.io/kata-runtime=true --overwrite
+        kubectl label "$node" katacontainers.io/kata-runtime=true --overwrite >/dev/null || {
+            echo "ERROR: failed to label node $node" >&2; exit 1
+        }
     done
 fi
 
@@ -138,12 +152,19 @@ echo "Running upstream setup.sh..."
 cd "$KATA_TESTS_DIR" || exit 1
 bash setup.sh || exit 1
 
-# Create test namespace if needed
-kubectl apply -f runtimeclass_workloads/tests-namespace.yaml 2>/dev/null || true
+# Create test namespace
+kubectl apply -f runtimeclass_workloads/tests-namespace.yaml || {
+    echo "ERROR: failed to create test namespace" >&2; exit 1
+}
 
 # Upstream tests need root (nginx image) and hostPath volumes.
 # Grant privileged SCC to the test namespace service account.
-oc adm policy add-scc-to-user privileged -z default -n kata-containers-k8s-tests 2>/dev/null || true
+if ! oc adm policy who-can use scc/privileged -n kata-containers-k8s-tests 2>/dev/null | grep -q "system:serviceaccount:kata-containers-k8s-tests:default"; then
+    oc adm policy add-scc-to-user privileged -z default -n kata-containers-k8s-tests || {
+        echo "ERROR: failed to grant privileged SCC" >&2; exit 1
+    }
+    SCC_ADDED=true
+fi
 
 kubectl config set-context --current --namespace=kata-containers-k8s-tests
 
@@ -151,7 +172,6 @@ kubectl config set-context --current --namespace=kata-containers-k8s-tests
 mkdir -p "$RESULTS_DIR"
 passed=0
 failed=0
-skipped=0
 errors=""
 
 echo ""
@@ -163,8 +183,9 @@ echo ""
 for test_file in "${TESTS[@]}"; do
     filepath="${KATA_TESTS_DIR}/${test_file}"
     if [[ ! -f "$filepath" ]]; then
-        echo "SKIP: $test_file (not found)"
-        ((skipped++))
+        echo "ERROR: $test_file (not found in $KATA_TESTS_DIR)"
+        ((failed++))
+        errors="${errors}\n  - ${test_file} (not found)"
         continue
     fi
 
@@ -182,16 +203,13 @@ for test_file in "${TESTS[@]}"; do
     echo ""
 done
 
-# --- Restore namespace ---
-kubectl config set-context --current --namespace=default 2>/dev/null || true
-
 # --- Summary ---
 echo "=============================="
-echo "Results: ${passed} passed, ${failed} failed, ${skipped} skipped (of ${#TESTS[@]} files)"
+echo "Results: ${passed} passed, ${failed} failed (of ${#TESTS[@]} files)"
 echo "JUnit XML: ${RESULTS_DIR}/"
 if [[ -n "$errors" ]]; then
     echo -e "Failed tests:${errors}"
 fi
 echo "=============================="
 
-exit $failed
+exit $(( failed > 0 ? 1 : 0 ))

--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -30,8 +30,8 @@ PODS=(
     k8s-copy-file.bats
     k8s-sysctls.bats
     # k8s-graceful-termination.bats — pod deleted before finalizer check, timing race on OpenShift
-    k8s-empty-image.bats
-    k8s-privileged.bats
+    # k8s-empty-image.bats — not present in openshift/kata-containers tree
+    # k8s-privileged.bats — not present in openshift/kata-containers tree
     # k8s-footloose.bats — setup fails: requires sudo on host to create SSH keys
     # k8s-ip6tables.bats — OSC guest kernel lacks iptables module (upstream has it)
 )
@@ -40,19 +40,19 @@ WORKLOADS=(
     k8s-job.bats
     k8s-cron-job.bats
     k8s-parallel.bats
-    k8s-replication.bats
-    k8s-scale-nginx.bats
-    k8s-liveness-probes.bats
+    # k8s-replication.bats — CrashLoopBackOff, test hangs waiting for Ready condition
+    # k8s-scale-nginx.bats — flaky: intermittent timeout failures
+    # k8s-liveness-probes.bats — greps "Started container" but OpenShift uses "Container started"
 )
 
 RESOURCES=(
     k8s-limit-range.bats
     k8s-memory.bats
     k8s-oom.bats
-    k8s-pod-quota.bats
+    # k8s-pod-quota.bats — flaky: intermittent failures
     k8s-qos-pods.bats
-    k8s-sandbox-cgroup.bats
-    k8s-sandbox-vcpus-allocation.bats
+    # k8s-sandbox-cgroup.bats — not present in openshift/kata-containers tree
+    # k8s-sandbox-vcpus-allocation.bats — flaky: intermittent failures
     k8s-number-cpus.bats
     k8s-cpu-ns.bats
 )
@@ -66,7 +66,7 @@ VOLUMES=(
     k8s-shared-volume.bats
     # k8s-volume.bats — hostPath blocked by SELinux on RHCOS: virtiofsd can't access host-created files
     # k8s-file-volume.bats — hostPath blocked by SELinux on RHCOS: virtiofsd can't access host-created files
-    k8s-block-volume.bats
+    # k8s-block-volume.bats — setup precondition fails, 0 tests executed
     k8s-projected-volume.bats
     k8s-nested-configmap-secret.bats
     k8s-inotify.bats
@@ -81,7 +81,7 @@ NETWORKING=(
 
 SANITY=(
     k8s-env.bats
-    k8s-liveness-probes.bats
+    k8s-exec.bats
     k8s-memory.bats
     k8s-configmap.bats
     k8s-nginx-connectivity.bats

--- a/test/e2e/run_upstream_tests.sh
+++ b/test/e2e/run_upstream_tests.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # Run upstream kata-containers BATS tests on OpenShift.
-# Requires: bats, yq, jq, kubectl, envsubst, oc
+# Requires: bats, yq, jq, kubectl, envsubst, oc, git
 set -o pipefail
 
-KATA_TESTS_DIR="${KATA_TESTS_DIR:?KATA_TESTS_DIR must be set to kata-containers/tests/integration/kubernetes}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESULTS_DIR="${RESULTS_DIR:-${SCRIPT_DIR}/results}"
 
@@ -20,19 +19,29 @@ Run upstream kata-containers BATS tests on an OpenShift cluster.
 Requires: bats, yq, jq, kubectl, envsubst, oc
 
 Options:
-  -t, --test PROFILE     Test profile or .bats file to run (default: full)
-                         Profiles: sanity, pods, workloads, resources, volumes, networking, full
-                         Or a single .bats file, e.g. k8s-env.bats
-  -h, --help             Show this help
+  -t, --test PROFILE        Test profile or .bats file to run (default: full)
+                            Profiles: sanity, pods, workloads, resources, volumes, networking, full
+                            Or a single .bats file, e.g. k8s-env.bats
+  --tests-repo URL|DIR      Kata tests repo URL or local directory
+                            (default: https://github.com/openshift/kata-containers)
+  --tests-repo-ref REF      Git ref to checkout — branch or tag (default: main)
+  --preserve-tests-repo     Do not delete the cloned test repo after execution
+  -h, --help                Show this help
 EOF
     exit "${1:-1}"
 }
 
 PROFILE="full"
+TESTS_REPO="https://github.com/openshift/kata-containers"
+TESTS_REPO_REF="main"
+PRESERVE_TESTS_REPO=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -t|--test) PROFILE="$2"; shift 2;;
+        --tests-repo) TESTS_REPO="$2"; shift 2;;
+        --tests-repo-ref) TESTS_REPO_REF="$2"; shift 2;;
+        --preserve-tests-repo) PRESERVE_TESTS_REPO=true; shift;;
         -h|--help) usage 0;;
         *) echo "Unknown argument: $1"; usage;;
     esac
@@ -124,29 +133,54 @@ case "$PROFILE" in
 esac
 
 # --- Prereq checks ---
-for cmd in bats yq jq kubectl envsubst oc; do
+for cmd in bats yq jq kubectl envsubst oc git; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "ERROR: $cmd is required but not found in PATH"
         exit 1
     fi
 done
 
-if [[ ! -d "$KATA_TESTS_DIR" ]]; then
-    echo "ERROR: kata-containers test dir not found: $KATA_TESTS_DIR"
-    exit 1
-fi
-
 # --- Cleanup ---
 ORIG_NAMESPACE="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}' 2>/dev/null)"
 ORIG_NAMESPACE="${ORIG_NAMESPACE:-default}"
+CLONE_DIR=""
 SCC_ADDED=false
 cleanup() {
     kubectl config set-context --current --namespace="$ORIG_NAMESPACE" 2>/dev/null || true
     if [[ "$SCC_ADDED" == "true" ]]; then
         oc adm policy remove-scc-from-user privileged -z default -n kata-containers-k8s-tests 2>/dev/null || true
     fi
+    if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then
+        if [[ "$PRESERVE_TESTS_REPO" == "true" ]]; then
+            echo "Test repo preserved at: $CLONE_DIR"
+        else
+            rm -rf "$CLONE_DIR"
+        fi
+    fi
 }
 trap cleanup EXIT
+
+# --- Resolve test repo ---
+# Strip credentials from URL for logging
+safe_url="${TESTS_REPO/\/\/*@/\/\/}"
+if [[ -d "$TESTS_REPO" ]]; then
+    TESTS_REPO="$(realpath "$TESTS_REPO")"
+    KATA_TESTS_DIR="${TESTS_REPO}/tests/integration/kubernetes"
+    echo "Using local test repo: $TESTS_REPO"
+else
+    CLONE_DIR=$(mktemp -d /tmp/kata-tests-XXXXXX)
+    echo "Cloning $safe_url (ref: $TESTS_REPO_REF) to $CLONE_DIR..."
+    git clone --depth 1 --branch "$TESTS_REPO_REF" "$TESTS_REPO" "$CLONE_DIR" || {
+        echo "ERROR: failed to clone $safe_url at ref $TESTS_REPO_REF" >&2
+        exit 1
+    }
+    KATA_TESTS_DIR="${CLONE_DIR}/tests/integration/kubernetes"
+fi
+
+if [[ ! -d "$KATA_TESTS_DIR" ]]; then
+    echo "ERROR: test directory not found: $KATA_TESTS_DIR"
+    exit 1
+fi
 
 # --- Ensure kata node label ---
 # Upstream tests look for katacontainers.io/kata-runtime=true


### PR DESCRIPTION
While testing https://github.com/openshift/sandboxed-containers-operator/pull/2518 I had some tests failing, others flaky and some where not even present on the kata-containers tree I was working one. Then I tried to use the latest kata-containers/kata-containers tree and all tests failed completely. I realized that @vvoronko was using a tree, I was using another tree, and we needed to actually be looking at the same code. This PR address that problem by:
* leverage the downstream fork of kata-containers  (openshift/kata-containers). In CI it must not use upstream trees directly due supply chain security concern mainly
* disabling the tests that are not passing or are flaky

Then because I was running the suites many times in my environment I noticed that I needed some improvements (e.g. skip the pre-testing setup) and other developers would appreciate as well, so I am sending a couple of misc changes in this PR as well.

 