### PR TITLE
Fix shellcheck

### DIFF
--- a/.tekton/osc-must-gather-pull-request.yaml
+++ b/.tekton/osc-must-gather-pull-request.yaml
@@ -45,6 +45,8 @@ spec:
     value:
     - pr-{{pull_request_number}}
     - pullreq-{{pull_request_number}}-{{revision}}
+  - name: sast-target-dirs
+    value: must-gather
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-must-gather-push.yaml
+++ b/.tekton/osc-must-gather-push.yaml
@@ -38,6 +38,8 @@ spec:
     value: must-gather
   - name: prefetch-input
     value: '{"type": "rpm", "path": "./must-gather/"}'
+  - name: sast-target-dirs
+    value: must-gather
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -94,7 +94,7 @@ spec:
       type: string
     - name: sast-target-dirs
       type: string
-      default: .
+      default: bundle
       description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
     - name: source-date-epoch
       type: string

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -92,7 +92,7 @@ spec:
       type: string
     - name: sast-target-dirs
       type: string
-      default: .
+      default: bundle
       description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
     - name: source-date-epoch
       type: string

--- a/.tekton/osc-operator-pull-request.yaml
+++ b/.tekton/osc-operator-pull-request.yaml
@@ -45,6 +45,8 @@ spec:
     value:
     - pr-{{pull_request_number}}
     - pullreq-{{pull_request_number}}-{{revision}}
+  - name: sast-target-dirs
+    value: fbc,hack,scripts,testbin,.claude/skills
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-operator-push.yaml
+++ b/.tekton/osc-operator-push.yaml
@@ -38,6 +38,8 @@ spec:
     value: Dockerfile
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: sast-target-dirs
+    value: fbc,hack,scripts,testbin,.claude/skills
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-podvm-builder-pull-request.yaml
+++ b/.tekton/osc-podvm-builder-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value:
     - pr-{{pull_request_number}}
     - pullreq-{{pull_request_number}}-{{revision}}
+  - name: sast-target-dirs
+    value: config/peerpods/podvm
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-podvm-builder-push.yaml
+++ b/.tekton/osc-podvm-builder-push.yaml
@@ -45,6 +45,8 @@ spec:
         {"type": "pip", "path": "./config/peerpods/podvm/", "requirements_files": ["azure-cli-pip.txt"]},
         {"type": "rpm", "path": "./config/peerpods/podvm/"}
       ]
+  - name: sast-target-dirs
+    value: config/peerpods/podvm
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/must-gather/collection-scripts/gather_sandboxed_containers_logs
+++ b/must-gather/collection-scripts/gather_sandboxed_containers_logs
@@ -55,9 +55,9 @@ MCP_PATH=${OSC_PATH}/mcps
 mkdir -p ${MCP_PATH}
 
 for mcp in "${mcps[@]}"; do
-    if $(oc get mcp $mcp &>/dev/null); then
-        oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
-    fi	    
+    if oc get mcp "${mcp}" &>/dev/null; then
+        oc describe mcp "${mcp}" > "${MCP_PATH}/${mcp}_description"
+    fi
 done
 
 # installplans

--- a/scripts/cm-helpers/pp-cm-helper.sh
+++ b/scripts/cm-helpers/pp-cm-helper.sh
@@ -215,7 +215,7 @@ function applyCM() {
     [[ -n $YES ]] || (read -r -p "Apply the Changes to the peer-pods-cm ConfigMap? [y/N] " && [[ "$REPLY" =~ ^[Yy]$ ]]) || exit 0
     ${CLI} delete cm peer-pods-cm -n openshift-sandboxed-containers-operator > /dev/null 2>&1
     ${CLI} create cm peer-pods-cm --from-env-file=${ENV_FILE} -n openshift-sandboxed-containers-operator
-    until ${CLI} get cm peer-pods-cm -n openshift-sandboxed-containers-operator >/dev/null 2>&1 >/dev/null ; do
+    until ${CLI} get cm peer-pods-cm -n openshift-sandboxed-containers-operator >/dev/null 2>&1 ; do
        echo "Waiting for ConfigMap to be created..."
        sleep 1
     done


### PR DESCRIPTION
Shelcheck is run on every pipeline, for the whole repository.
Since we build 4 images (plus the catalogs) from this repo, this is a lot of duplicated efforts.

This commit tries to reduce the scan for each pipeline: each one will scan their relevant code.
The operator will keep checking everything not covered by the others, to make sure we don't miss anything.

Also fixing one error found during a previous scan.
