### PR TITLE
configs: add configs to support olm v1

### DIFF
--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-08-18T07:36:02Z"
+    createdAt: "2026-08-31T09:40:10Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -539,7 +539,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - sandboxed-containers

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -357,7 +357,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - sandboxed-containers

--- a/config/olmv1/00-namespace.yaml
+++ b/config/olmv1/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sandboxed-containers-operator

--- a/config/olmv1/01-serviceaccount.yaml
+++ b/config/olmv1/01-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandboxed-containers-installer
+  namespace: openshift-sandboxed-containers-operator

--- a/config/olmv1/02-clusterrole.yaml
+++ b/config/olmv1/02-clusterrole.yaml
@@ -1,0 +1,160 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sandboxed-containers-installer-role
+rules:
+  # OLM v1: manage this ClusterExtension
+  - apiGroups: [olm.operatorframework.io]
+    resources: [clusterextensions/finalizers]
+    verbs: [update]
+    resourceNames: [sandboxed-containers]
+
+  # OLM v1: manage ClusterObjectSets created for this extension (names are generated)
+  - apiGroups: [olm.operatorframework.io]
+    resources: [clusterobjectsets/finalizers]
+    verbs: [update]
+
+  # OLM v1: metrics endpoint
+  - nonResourceURLs: [/metrics]
+    verbs: [get]
+
+  # CRDs owned by the operator
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [create, list, watch]
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, update, patch, delete]
+    resourceNames:
+      - kataconfigs.kataconfiguration.openshift.io
+      - peerpods.confidentialcontainers.org
+
+  # RBAC resources the operator creates for its own controllers
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [clusterroles, clusterrolebindings, roles, rolebindings]
+    verbs: [create, list, watch]
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [clusterroles, clusterrolebindings, roles, rolebindings]
+    verbs: [get, update, patch, delete]
+
+  # Core resources (from CSV clusterPermissions)
+  - apiGroups: [""]
+    resources: [pods, pods/finalizers]
+    verbs: [get, create, patch, update, list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, update, list, watch]
+  - apiGroups: [""]
+    resources: [nodes/status]
+    verbs: [patch]
+  - apiGroups: [""]
+    resources: [secrets, secrets/finalizers, secrets/status]
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [""]
+    resources: [serviceaccounts]
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: ["", machineconfiguration.openshift.io]
+    resources:
+      - configmaps
+      - containerruntimeconfigs
+      - endpoints
+      - events
+      - machineconfigpools
+      - machineconfigs
+      - nodes
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - services
+      - services/finalizers
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # Leader election
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # Webhook configurations (both validating and mutating)
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, delete, get, list, update, watch, patch]
+
+  # Network policies
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies]
+    verbs: [create, delete, update]
+
+  # Workload resources
+  - apiGroups: [apps]
+    resources: [daemonsets, deployments, replicasets, statefulsets]
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [apps]
+    resources: [daemonsets/finalizers]
+    verbs: [update]
+    resourceNames: [manager-role]
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, delete, get, list, watch]
+
+  # Monitoring resources
+  - apiGroups: [monitoring.coreos.com]
+    resources: [prometheusrules, servicemonitors]
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # Cloud credential requests (peer-pods)
+  - apiGroups: [cloudcredential.openshift.io]
+    resources: [credentialsrequests]
+    verbs: [create, delete, get, list]
+
+  # Confidential containers / peer-pods CRs
+  - apiGroups: [confidentialcontainers.org]
+    resources:
+      - peerpodconfigs
+      - peerpods
+      - pods
+      - peerpodconfigs/finalizers
+      - peerpods/finalizers
+      - peerpodconfigs/status
+      - peerpods/status
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # Cluster info
+  - apiGroups: [config.openshift.io]
+    resources: [apiservers, clusterversions, infrastructures]
+    verbs: [get, list, watch]
+
+  # Kata CRs
+  - apiGroups: [kataconfiguration.openshift.io]
+    resources: [kataconfigs, kataconfigs/finalizers, kataconfigs/status]
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # RuntimeClass — created by operator after KataConfig install
+  - apiGroups: [node.k8s.io]
+    resources: [runtimeclasses]
+    verbs: [create, delete, get, list, patch, update, watch]
+
+  # SCCs — installer creates the operator-managed SCCs during bundle deployment
+  - apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    verbs: [create]
+
+  # SCCs — installer manages only the operator-owned SCCs
+  - apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    resourceNames:
+      - sandboxed-containers-operator-scc
+      - kata-install-scc
+    verbs: [delete, patch, update, use, watch]
+
+  # SCCs — installer can read all SCCs to validate cluster state
+  - apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    verbs: [get, list]
+
+  # Token and access reviews for metrics auth
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]

--- a/config/olmv1/03-clusterrolebinding.yaml
+++ b/config/olmv1/03-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sandboxed-containers-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sandboxed-containers-installer-role
+subjects:
+  - kind: ServiceAccount
+    name: sandboxed-containers-installer
+    namespace: openshift-sandboxed-containers-operator

--- a/config/olmv1/04-clusterextension.yaml
+++ b/config/olmv1/04-clusterextension.yaml
@@ -1,0 +1,21 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: sandboxed-containers
+spec:
+  namespace: openshift-sandboxed-containers-operator
+  # config.inline.watchNamespace is required for OSC versions before AllNamespaces support
+  # (i.e., OSC < 1.14.x). Uncomment only if targeting an older OSC version on a TechPreview cluster.
+  # config:
+  #   configType: Inline
+  #   inline:
+  #     watchNamespace: openshift-sandboxed-containers-operator
+  serviceAccount:
+    name: sandboxed-containers-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: sandboxed-containers-operator
+      channels:
+        - stable
+      upgradeConstraintPolicy: CatalogProvided

--- a/docs/olm/MIGRATION.md
+++ b/docs/olm/MIGRATION.md
@@ -1,0 +1,75 @@
+# OLM v0 → OLM v1 Migration Strategy
+
+OSC cannot make a hard cutover to OLM v1 because `config.inline.watchNamespace`
+(which maps OwnNamespace/SingleNamespace semantics into OLM v1) is backed by the
+`SingleOwnNamespaceInstallSupport` feature gate — Alpha upstream, TechPreview-only on OCP.
+The migration is therefore phased across operator versions.
+
+## Phase overview
+
+| Phase | OSC version | OLM v0 | OLM v1 | TechPreview required |
+|---|---|---|---|---|
+| 1 — Parallel, opt-in | 1.13.x | Default, fully supported | Supported via `config/olmv1/` | Yes |
+| 2 — AllNamespaces support | 1.14.x (current) | Supported | Supported without TechPreview | No |
+| 3 — Full support | TBD | Legacy | Recommended | No |
+
+---
+
+## Phase 1 — Parallel support, TechPreview only (current: v1.13.x)
+
+OLM v0 is the default and fully supported install path. OLM v1 is usable on clusters
+with `TechPreviewNoUpgrade` enabled via the `config/olmv1/` manifests in this repo.
+
+**OLM v0 users:** no action required.
+
+**OLM v1 early adopters (TechPreview clusters only):**
+```bash
+oc apply -f config/olmv1/
+```
+
+No in-place migration from OLM v0 → OLM v1 is supported or required in this phase.
+
+---
+
+## Phase 2 — Optional opt-in, no TechPreview required
+
+**Prerequisite (one of):**
+
+**Option A — `SingleOwnNamespaceInstallSupport` graduates to GA upstream**
+
+Track [operator-controller#2268](https://github.com/operator-framework/operator-controller/pull/2268).
+Once GA, `config.inline.watchNamespace` works on production OCP without TechPreview.
+No CSV changes required; `config/olmv1/` manifests become production-supported.
+
+**Option B — Add `AllNamespaces` install mode support to OSC** ✅ In progress (v1.14.x)
+
+The operator's controllers are already architecturally cluster-scoped — no code changes
+are needed. The only change is flipping `AllNamespaces: true` in the CSV installModes.
+`config.inline.watchNamespace` is no longer needed in the ClusterExtension.
+
+**OLM v0 users in Phase 2:** no action required; OLM v0 continues to work.
+
+---
+
+## Phase 3 — Full OLM v1 support (TBD)
+
+Phase 3 is still under refinement and depends on how Phase 2 is resolved.
+
+**OCP's OLM v0 → OLM v1 migration tool (OCPSTRAT-2692)**
+
+OCP is building a CLI migration tool for bulk OLM v0 → OLM v1 migration. It only supports
+operators with `AllNamespaces` install mode. OSC is currently ineligible:
+
+> "OwnNamespace and SingleNamespace install modes are out of scope for the migration tool."
+
+**Impact of Phase 2 choice on Phase 3:**
+
+| Phase 2 path | Phase 3 migration tool eligibility |
+|---|---|
+| Option A — `SingleOwnNamespaceInstallSupport` GA | OSC remains ineligible; manual migration needed |
+| Option B — Add `AllNamespaces` support to OSC | OSC becomes eligible; platform migration tool applies |
+
+If Option B is chosen in Phase 2, the platform migration tool (OCPSTRAT-2692) can handle
+the OLM v0 → OLM v1 transition for existing installs automatically.
+
+This section will be updated once Phase 2 direction and OCPSTRAT-2692 are finalized.

--- a/docs/olm/README.md
+++ b/docs/olm/README.md
@@ -1,0 +1,81 @@
+# Installing OSC via OLM v1
+
+This guide covers installing the OpenShift Sandboxed Containers operator using OLM v1
+(`ClusterExtension`) on OCP 4.22+.
+
+> **Note:** OSC 1.14.x+ supports `AllNamespaces` install mode, enabling OLM v1 without requiring
+> `TechPreviewNoUpgrade`. For OSC < 1.14.x, see the note below about the `config.inline.watchNamespace`
+> workaround.
+
+## Prerequisites
+
+- OCP 4.22+ cluster
+- `oc` CLI with cluster-admin access
+
+## Install
+
+Apply all OLM v1 manifests from the repo:
+
+```bash
+oc apply -f config/olmv1/
+```
+
+This creates:
+- `openshift-sandboxed-containers-operator` namespace
+- `sandboxed-containers-installer` ServiceAccount with required RBAC
+- `sandboxed-containers` ClusterExtension targeting the `stable` channel
+
+> **Note for OSC < 1.14.x:** If you are installing an older version that only supports
+> `OwnNamespace`/`SingleNamespace` modes, uncomment the `config.inline.watchNamespace`
+> section in `config/olmv1/04-clusterextension.yaml`. This requires the
+> `TechPreviewNoUpgrade` feature gate to be enabled on your cluster.
+
+## Verify installation
+
+```bash
+oc get clusterextension sandboxed-containers -o jsonpath='{.status.conditions}' | jq .
+```
+
+Expected output shows:
+- `Installed: True, reason: Succeeded`
+- `Available: True, reason: ProbesSucceeded`
+
+## Verify webhook CA
+
+```bash
+oc get validatingwebhookconfiguration vkataconfig.kb.io \
+  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d | openssl x509 -noout -issuer
+```
+
+The CA bundle should be issued by the OpenShift Service CA.
+
+## Create a KataConfig
+
+Once the operator is installed, create a KataConfig CR to enable the kata runtime:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: kataconfiguration.openshift.io/v1
+kind: KataConfig
+metadata:
+  name: example-kataconfig
+spec:
+  enablePeerPods: true
+EOF
+```
+
+Monitor installation progress:
+
+```bash
+oc get kataconfig example-kataconfig -o jsonpath='{.status}'
+```
+
+## Uninstall
+
+```bash
+oc delete -f config/olmv1/
+```
+
+## Further reading
+
+- [MIGRATION.md](MIGRATION.md) — Phased migration strategy from OLM v0 to OLM v1


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or


Please provide the following information:
-->

Closes: [KATA-5833](https://redhat.atlassian.net/browse/KATA-5833)

**- Description of the problem which is fixed/What is the use case**
OSC operator currently requires TechPreview feature gate (`SingleOwnNamespaceInstallSupport`,
Alpha upstream) to support OLM v1 via `config.inline.watchNamespace`. This blocks
production OLM v1 deployments. Additionally, the operator is ineligible for OCP's
platform OLM v0→v1 migration tool (still in planning, mostly for 5.x).

This PR removes the `TechPreview` blocker by adding `AllNamespaces` support (Phase 2 of
migration strategy), enabling production-safe OLM v1 deployments without Alpha features.

**- How to verify it**
1. Apply `config/olmv1/` manifests to cluster with OLM v1
2. Verify `ClusterExtension` installs without `TechPreview` gate
3. Confirm operator pod running and KataConfig reconciliation works

**- Description for the changelog**
TBD
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
