### PR TITLE
Bump to 1.14

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -58,6 +58,10 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
+  - default: "1.13" # OSC_VERSION
+    description: Version string passed as VERSION build-arg to all image builds
+    name: version
+    type: string
   - default: 'false'
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
@@ -198,6 +202,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
+      - VERSION=$(params.version)
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED
@@ -422,6 +427,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
+      - VERSION=$(params.version)
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -58,7 +58,7 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "1.13" # OSC_VERSION
+  - default: "1.14" # OSC_VERSION
     description: Version string passed as VERSION build-arg to all image builds
     name: version
     type: string

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -263,7 +263,7 @@ spec:
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: ADDITIONAL_TAGS
-      value: ["latest", "1.13.1-$(tasks.clone-repository.results.commit-timestamp)"]
+      value: ["latest", "1.14.0-$(tasks.clone-repository.results.commit-timestamp)"]
     runAfter:
     - build-image-index
     taskRef:

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -30,7 +30,7 @@ spec:
     value: bundle.Dockerfile
   - name: build-args
     value:
-    - VERSION=1.13 # OSC_VERSION
+    - VERSION=1.14 # OSC_VERSION
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/osc-operator-bundle-pull-request.yaml
+++ b/.tekton/osc-operator-bundle-pull-request.yaml
@@ -28,6 +28,9 @@ spec:
     value: 5d
   - name: dockerfile
     value: bundle.Dockerfile
+  - name: build-args
+    value:
+    - VERSION=1.13 # OSC_VERSION
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -26,6 +26,9 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-operator-bundle:{{revision}}
   - name: dockerfile
     value: bundle.Dockerfile
+  - name: build-args
+    value:
+    - VERSION=1.13 # OSC_VERSION
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/osc-operator-bundle-push.yaml
+++ b/.tekton/osc-operator-bundle-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: bundle.Dockerfile
   - name: build-args
     value:
-    - VERSION=1.13 # OSC_VERSION
+    - VERSION=1.14 # OSC_VERSION
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/osc-test-fbc-push.yaml
+++ b/.tekton/osc-test-fbc-push.yaml
@@ -277,7 +277,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: ["latest", "1.13.1-$(tasks.clone-repository.results.commit-timestamp)"]
+        value: ["latest", "1.14.0-$(tasks.clone-repository.results.commit-timestamp)"]
       runAfter:
       - build-image-index
       taskRef:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,12 @@ COPY --from=builder /workspace/config/peerpods /config/peerpods
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot
 
+ARG VERSION
+
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-rhel9-operator" \
 cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
-version="1.13" \
+version="$VERSION" \
 com.redhat.component="osc-operator-container" \
 summary="This operator manages the Openshift Sandboxed Containers runtime installation" \
 maintainer="redhat@redhat.com" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.13.1  ## OSC_VERSION
+VERSION ?= 1.14.0  ## OSC_VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+ARG VERSION
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -30,7 +31,7 @@ LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9"
 LABEL com.redhat.component="osc-operator-bundle-container"
 LABEL io.openshift.maintainer.product='OpenShift Container Platform'
 LABEL io.openshift.maintainer.component='Sandboxed Containers'
-LABEL version="1.13"
+LABEL version="$VERSION"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions=v4.15
 LABEL summary="This operator manages the sandboxed-containers runtime"

--- a/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-08-18T07:36:02Z"
+    createdAt: "2026-09-04T15:26:12Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -24,7 +24,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.1.0 <1.13.1'
+    olm.skipRange: '>=1.1.0 <1.14.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.13.1
+  name: sandboxed-containers-operator.v1.14.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -571,8 +571,8 @@ spec:
     name: must-gather
   - image: registry.redhat.io/openshift-sandboxed-containers/osc-storage-helper@sha256:4e5c66f890b68532eaa48180ce3e16c95f330a76264f5aa9716100dc0e7bf68a
     name: storage-helper
-  replaces: sandboxed-containers-operator.v1.13.0
-  version: 1.13.1
+  replaces: sandboxed-containers-operator.v1.13.1
+  version: 1.14.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator
-  newTag: v1.13.1
+  newTag: v1.14.0

--- a/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sandboxed-containers-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.1.0 <1.13.1'
+    olm.skipRange: '>=1.1.0 <1.14.0'
     operatorframework.io/suggested-namespace: openshift-sandboxed-containers-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: sandboxed-containers-operator.v1.13.1  ## OSC_VERSION
+  name: sandboxed-containers-operator.v1.14.0  ## OSC_VERSION
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -372,8 +372,8 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  replaces: sandboxed-containers-operator.v1.13.0
-  version: 1.13.1  ## OSC_VERSION
+  replaces: sandboxed-containers-operator.v1.13.1
+  version: 1.14.0  ## OSC_VERSION
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/peerpods/podvm/Dockerfile.podvm-builder
+++ b/config/peerpods/podvm/Dockerfile.podvm-builder
@@ -78,10 +78,12 @@ COPY cloud-api-adaptor /src/cloud-api-adaptor
 
 ADD podvm-builder.sh /podvm-builder.sh
 
+ARG VERSION
+
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-podvm-builder-rhel9" \
 cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
-version="1.13" \
+version="$VERSION" \
 com.redhat.component="osc-podvm-builder-container" \
 summary="Container image containing artefacts that is required for creating Pod VM images" \
 maintainer="redhat@redhat.com" \

--- a/config/peerpods/podvm/bootc/Containerfile.rhel
+++ b/config/peerpods/podvm/bootc/Containerfile.rhel
@@ -1,5 +1,5 @@
 # Get payload
-FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.13.1 as payload  ## OSC_VERSION
+FROM registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.14.0 as payload  ## OSC_VERSION
 
 # Build bootc rhel podvm
 FROM registry.redhat.io/rhel9/rhel-bootc:9.8-1788386886 as podvm-bootc

--- a/config/peerpods/podvm/osc-podvm-create-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-create-job.yaml
@@ -15,7 +15,7 @@ spec:
       # /podvm-binaries.tar.gz /payload/podvm-binaries.tar.gz
       initContainers:
         - name: copy
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.13.1  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-payload-rhel9:1.14.0  ## OSC_VERSION
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -29,7 +29,7 @@ spec:
         - name: create
           # Binaries like kubectl, packer and yq are expected to be under /usr/local/bin
           # podvm binaries are expected to be under /payload/podvm-binaries.tar.gz
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.13.1  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.14.0  ## OSC_VERSION
           # This image contains the following
           # azure-podvm-image-handler.sh script under /scripts/azure-podvm-image-handler.sh
           # aws-podvm-image-handler.sh script under /scripts/aws-podvm-image-handler.sh

--- a/config/peerpods/podvm/osc-podvm-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-delete-job.yaml
@@ -21,7 +21,7 @@ spec:
           # ibmcloud-podvm-image-handler.sh script under /scripts/ibmcloud-podvm-image-handler.sh
           # sources for cloud-api-adaptor under /src/cloud-api-adaptor
           # Binaries like kubectl, packer and yq under /usr/local/bin
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.13.1  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.14.0  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           env:

--- a/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
+++ b/config/peerpods/podvm/osc-podvm-gallery-delete-job.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: delete-gallery
-          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.13.1  ## OSC_VERSION
+          image: registry.redhat.io/openshift-sandboxed-containers/osc-podvm-builder-rhel9:1.14.0  ## OSC_VERSION
           securityContext:
             runAsUser: 0 # needed for container mode dnf access
           envFrom:

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
  DisplayName: My Operator Catalog
  sourceType: grpc
- image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.13.1  ## OSC_VERSION
+ image:  quay.io/openshift_sandboxed_containers/openshift-sandboxed-containers-operator-catalog:v1.14.0  ## OSC_VERSION
  updateStrategy:
    registryPoll:
       interval: 5m
@@ -36,4 +36,4 @@ spec:
   name: sandboxed-containers-operator
   source: my-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.13.1  ## OSC_VERSION
+  startingCSV: sandboxed-containers-operator.v1.14.0  ## OSC_VERSION

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -113,7 +113,7 @@ When adding a new container definition in some pod yaml, make sure to tag the `i
 field with `  ## OSC_VERSION`, e.g.
 
 ```
-image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.13.1  ## OSC_VERSION
+image: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.14.0  ## OSC_VERSION
 ```
 
 Do the same when adding new `RELATED_IMAGE` entries in the environment of the controller
@@ -121,7 +121,7 @@ in `config/manager/manager.yaml`, e.g.
 
 ```
             - name: RELATED_IMAGE_KATA_MONITOR
-              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.13.1  ## OSC_VERSION
+              value: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel9:1.14.0  ## OSC_VERSION
 ```
 
 This is a best effort to track locations where OSC version bumps should happen.

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -23,10 +23,12 @@ COPY collection-scripts/* /usr/bin/
 COPY node-gather/node-gather-crd.yaml /etc/
 COPY node-gather/node-gather-ds.yaml /etc/
 
+ARG VERSION
+
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-must-gather-rhel9" \
 cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
-version="1.13" \
+version="$VERSION" \
 com.redhat.component="osc-must-gather-container" \
 summary="osc-must-gather collects information about the sandboxed containers operator and the kata runtime" \
 maintainer="support@redhat.com" \


### PR DESCRIPTION
Doing the bump to make sure the builds we generate can be identified as "next release".

Also cleaning up the label management for the images: passing the version as a parameter, so that we have just one place to edit to bump the version there.