### PR TITLE
tests: update KATA_RPM_VERSION to version 4.1.0-1 

### DIFF
--- a/tests/osc-test-fbc-integration.yaml
+++ b/tests/osc-test-fbc-integration.yaml
@@ -24,8 +24,8 @@ spec:
       type: string
       description: >-
         Which prowjobs to run. Options: "sanity" (default, runs only sanity checks),
-        "all" (runs all prowjobs), or specific job names like "ocp419 ocp420"
-        (runs only those OCP version jobs, space-separated). Available job names: ocp419, ocp420, ocp421, ocp422
+        "all" (runs all prowjobs), or specific job names like "ocp420 ocp421"
+        (runs only those OCP version jobs, space-separated). Available job names: ocp420, ocp421, ocp422
       default: "sanity"
   tasks:
     - name: get-catalog-image
@@ -63,8 +63,6 @@ spec:
         results:
           - name: run_sanity
             description: "Whether to run sanity check prowjobs"
-          - name: run_ocp419
-            description: "Whether to run OCP 4.19 prowjobs"
           - name: run_ocp420
             description: "Whether to run OCP 4.20 prowjobs"
           - name: run_ocp421
@@ -82,7 +80,7 @@ spec:
               set -e
 
               # Supported OCP versions
-              OCP_VERSIONS="419 420 421 422"
+              OCP_VERSIONS="420 421 422"
 
               # Function to check if a value is in the space-separated list
               contains() {
@@ -158,51 +156,13 @@ spec:
         - name: VARIANT
           value: downstream-candidate420
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=4.1.0-1.rhaos4.20.el9"
       matrix:
         params:
           - name: PROWJOB_NAME
             value:
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-azure-ipi-kata
               - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate420-aws-ipi-peerpods
-    - name: prowjob-ocp419
-      displayName: "Running prow job $(params.PROWJOB_NAME)"
-      onError: continue
-      timeout: "8h"
-      when:
-        - input: "$(tasks.determine-prowjobs.results.run_ocp419)"
-          operator: in
-          values: ["true"]
-      runAfter:
-        - prowjob-ocp421
-        - prowjob-ocp420
-      taskRef:
-        resolver: git
-        params:
-        - name: url
-          value: https://github.com/openshift/konflux-tasks
-        - name: revision
-          value: 4826f365057d22d0189fa0db00d953c151f90c77
-        - name: pathInRepo
-          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
-        - name: VARIANT
-          value: downstream-candidate419
-        - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
-        - name: RETRY_DELAY
-          value: "60"
-        - name: MAX_RETRIES
-          value: "5"
-      matrix:
-        params:
-          - name: PROWJOB_NAME
-            value:
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate419-azure-ipi-kata
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate419-azure-ipi-peerpods
-              - periodic-ci-openshift-sandboxed-containers-operator-devel-downstream-candidate419-aws-ipi-peerpods
     - name: prowjob-ocp420
       displayName: "Running prow job $(params.PROWJOB_NAME)"
       onError: continue
@@ -228,7 +188,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate420
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=4.1.0-1.rhaos4.20.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -263,7 +223,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate421
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.19.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=4.1.0-1.rhaos4.20.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -299,7 +259,7 @@ spec:
         - name: VARIANT
           value: downstream-candidate422
         - name: ENVS
-          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=3.31.0-5.rhaos4.22.el9"
+          value: "CATALOG_SOURCE_IMAGE=$(tasks.get-catalog-image.results.CATALOG_IMAGE),FORCE_SUCCESS_EXIT=no,INSTALL_KATA_RPM=true,KATA_RPM_VERSION=4.1.0-1.rhaos4.22.el9"
         - name: RETRY_DELAY
           value: "60"
         - name: MAX_RETRIES
@@ -317,8 +277,6 @@ spec:
       params:
         - name: SANITY_STATUS
           value: $(tasks.prowjob-sanity.status)
-        - name: OCP419_STATUS
-          value: $(tasks.prowjob-ocp419.status)
         - name: OCP420_STATUS
           value: $(tasks.prowjob-ocp420.status)
         - name: OCP421_STATUS
@@ -328,7 +286,6 @@ spec:
       taskSpec:
         params:
           - name: SANITY_STATUS
-          - name: OCP419_STATUS
           - name: OCP420_STATUS
           - name: OCP421_STATUS
           - name: OCP422_STATUS
@@ -342,10 +299,6 @@ spec:
               failed_count=0
               if [ "$(params.SANITY_STATUS)" == "Failed" ]; then
                 echo "Some sanity jobs failed"
-                failed_count=$((failed_count+1))
-              fi
-              if [ "$(params.OCP419_STATUS)" == "Failed" ]; then
-                echo "Some OCP 4.19 jobs failed"
                 failed_count=$((failed_count+1))
               fi
               if [ "$(params.OCP420_STATUS)" == "Failed" ]; then


### PR DESCRIPTION

kata-containers-4.1.0-1 RPMs are available in Brew.

For OCP 4.20 and 4.21:

https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4103612

For OCP 4.22 RHEL 9:

https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4103642

OCP 4.19 is removed since it won't be supported by upcoming OSC 1.14.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>

This was also introducing a new scenario for OCP 5.0 RHEL10 that
CI isn't ready to support yet. The related changes were removed.

Signed-off-by: Greg Kurz <gkurz@redhat.com>
