### PR TITLE
test: unify peer-pods-cm validation with auto-patch

### DIFF
--- a/test/e2e/kata_helpers.go
+++ b/test/e2e/kata_helpers.go
@@ -23,6 +23,7 @@ const (
 	opNamespace          = "openshift-sandboxed-containers-operator"
 	testrunConfigmapNs   = "default"
 	testrunConfigmapName = "osc-config"
+	caaDaemonsetName     = "osc-caa-ds"
 )
 
 var (

--- a/test/e2e/kata_peerpod_helpers.go
+++ b/test/e2e/kata_peerpod_helpers.go
@@ -1,11 +1,15 @@
 package kata
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/tidwall/gjson"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -13,75 +17,87 @@ const (
 	ppRuntimeClass  = "kata-remote"
 )
 
-// checkPodVMImageID verifies the cloud-specific podvm image ID field exists
-// and is non-empty in the peer-pods-cm configmap.
-func checkPodVMImageID(oc *exutil.CLI, cloudPlatform string) (string, error) {
-	imageIDParam := map[string]string{
-		"aws":   "PODVM_AMI_ID",
-		"azure": "AZURE_IMAGE_ID",
-		"gcp":   "PODVM_IMAGE_NAME",
-	}
+// peerPodRequiredFields must exist and be non-empty on all cloud platforms.
+var peerPodRequiredFields = []string{"CLOUD_PROVIDER", "VXLAN_PORT"}
 
-	param, ok := imageIDParam[cloudPlatform]
-	if !ok {
-		return "", fmt.Errorf("unsupported cloud platform %q for image ID check", cloudPlatform)
-	}
-
-	imageID, err := getConfigmapParamValue(oc, param)
-	if err != nil {
-		return "", err
-	}
-	if imageID == "" {
-		return "", fmt.Errorf("%s has empty value for %s", ppConfigMapName, param)
-	}
-	return imageID, nil
+// peerPodCloudConfig defines cloud-specific peer-pods-cm requirements.
+// Empty value: field must exist and be non-empty (fail setup if missing).
+// Non-empty value: field must have this value (patch configmap if missing or different).
+var peerPodCloudConfig = map[string]map[string]string{
+	"azure": {
+		"AZURE_REGION":         "",
+		"AZURE_NSG_ID":         "",
+		"AZURE_SUBNET_ID":      "",
+		"AZURE_RESOURCE_GROUP": "",
+		"AZURE_IMAGE_ID":       "",
+		"AZURE_INSTANCE_SIZES": "Standard_B2als_v2,Standard_B2as_v2,Standard_D2as_v5,Standard_B4als_v2,Standard_D4as_v5,Standard_D8as_v5",
+		"TAGS":                 "key1=value1,key2=value2",
+	},
+	"aws": {
+		"AWS_REGION":           "",
+		"AWS_SG_IDS":           "",
+		"AWS_SUBNET_ID":        "",
+		"AWS_VPC_ID":           "",
+		"PODVM_AMI_ID":         "",
+		"PODVM_INSTANCE_TYPES": "t3.small,t3.medium,t3.xlarge",
+	},
+	"gcp": {
+		"GCP_ZONE":         "",
+		"GCP_PROJECT_ID":   "",
+		"GCP_NETWORK":      "",
+		"PODVM_IMAGE_NAME": "",
+	},
+	"libvirt": {},
 }
 
-// getConfigmapParamValue reads a single field from the peer-pods-cm configmap.
-// Note: jsonpath={.data} works with gjson because oc outputs JSON-encoded data
-// for configmaps with simple key=value pairs. If a future configmap value
-// contains special characters, switch to -o=json and query data.<param>.
-func getConfigmapParamValue(oc *exutil.CLI, param string) (string, error) {
-	cmData, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-		"configmap", ppConfigMapName, "-n", opNamespace, "-o=jsonpath={.data}",
-	).Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get %s: %w", ppConfigMapName, err)
-	}
-
-	if !gjson.Get(cmData, param).Exists() {
-		return "", fmt.Errorf("%s does not have field %s", ppConfigMapName, param)
-	}
-
-	return gjson.Get(cmData, param).String(), nil
+// imageIDField maps cloud platform to the configmap field holding the podvm image ID.
+var imageIDField = map[string]string{
+	"aws":   "PODVM_AMI_ID",
+	"azure": "AZURE_IMAGE_ID",
+	"gcp":   "PODVM_IMAGE_NAME",
 }
 
-// checkPeerPodConfigMap verifies that the peer-pods-cm configmap contains all
-// required cloud-specific fields for the given provider.
-func checkPeerPodConfigMap(oc *exutil.CLI, cloudPlatform string) error {
-	requiredFields := map[string][]string{
-		"aws":     {"CLOUD_PROVIDER", "AWS_REGION", "AWS_SG_IDS", "AWS_SUBNET_ID", "AWS_VPC_ID", "VXLAN_PORT"},
-		"azure":   {"CLOUD_PROVIDER", "AZURE_REGION", "AZURE_NSG_ID", "AZURE_SUBNET_ID", "AZURE_RESOURCE_GROUP", "VXLAN_PORT"},
-		"gcp":     {"CLOUD_PROVIDER", "GCP_ZONE", "GCP_PROJECT_ID", "GCP_NETWORK", "VXLAN_PORT"},
-		"libvirt": {"CLOUD_PROVIDER"},
-	}
-
-	fields, ok := requiredFields[cloudPlatform]
-	if !ok {
-		return fmt.Errorf("unsupported cloud platform %q", cloudPlatform)
-	}
-
-	cmData, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-		"configmap", ppConfigMapName, "-n", opNamespace, "-o=jsonpath={.data}",
+// ensurePeerPodConfig validates peer-pods-cm and patches missing values.
+// Required fields (empty value in config) must exist — setup fails if missing.
+// Default fields (non-empty value in config) are patched if missing or different,
+// followed by a CAA daemonset restart.
+func ensurePeerPodConfig(oc *exutil.CLI, cloudPlatform string) error {
+	cmJSON, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"configmap", ppConfigMapName, "-n", opNamespace, "-o", "json",
 	).Output()
 	if err != nil {
 		return fmt.Errorf("failed to get %s: %w", ppConfigMapName, err)
 	}
 
 	var missing []string
-	for _, f := range fields {
-		if !gjson.Get(cmData, f).Exists() || gjson.Get(cmData, f).String() == "" {
-			missing = append(missing, f)
+
+	for _, field := range peerPodRequiredFields {
+		val := gjson.Get(cmJSON, "data."+field)
+		if !val.Exists() || val.String() == "" {
+			missing = append(missing, field)
+		}
+	}
+
+	cloudFields, ok := peerPodCloudConfig[cloudPlatform]
+	if !ok {
+		return fmt.Errorf("unsupported cloud platform %q", cloudPlatform)
+	}
+
+	var patchFields []string
+	patchData := make(map[string]string)
+
+	for field, requiredValue := range cloudFields {
+		val := gjson.Get(cmJSON, "data."+field)
+		if requiredValue == "" {
+			if !val.Exists() || val.String() == "" {
+				missing = append(missing, field)
+			}
+			continue
+		}
+		merged := mergeCommaSeparated(val.String(), requiredValue)
+		if merged != val.String() {
+			patchData[field] = merged
+			patchFields = append(patchFields, field)
 		}
 	}
 
@@ -89,7 +105,99 @@ func checkPeerPodConfigMap(oc *exutil.CLI, cloudPlatform string) error {
 		return fmt.Errorf("%s is missing required fields: %v", ppConfigMapName, missing)
 	}
 
+	if len(patchData) > 0 {
+		Logf("Patching %s fields: %v", ppConfigMapName, patchFields)
+
+		dataJSON, err := json.Marshal(map[string]interface{}{"data": patchData})
+		if err != nil {
+			return fmt.Errorf("failed to marshal patch: %w", err)
+		}
+
+		_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+			"configmap", ppConfigMapName, "-n", opNamespace,
+			"--type", "merge", "-p", string(dataJSON),
+		).Output()
+		if err != nil {
+			return fmt.Errorf("failed to patch %s: %w", ppConfigMapName, err)
+		}
+
+		if err := rebootCaaDaemonset(oc); err != nil {
+			return fmt.Errorf("failed to restart CAA after config patch: %w", err)
+		}
+	} else {
+		Logf("%s validated, no changes needed", ppConfigMapName)
+	}
+
 	return nil
+}
+
+// mergeCommaSeparated returns the current value extended with any entries
+// from required that are not already present. If current is empty, returns
+// required as-is. Preserves all existing entries.
+func mergeCommaSeparated(current, required string) string {
+	if current == "" {
+		return required
+	}
+	existing := make(map[string]bool)
+	for _, v := range strings.Split(current, ",") {
+		existing[strings.TrimSpace(v)] = true
+	}
+	result := current
+	for _, v := range strings.Split(required, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" && !existing[v] {
+			result += "," + v
+		}
+	}
+	return result
+}
+
+// rebootCaaDaemonset triggers a rolling restart of the CAA daemonset by
+// injecting a REBOOT env var, then waits for all pods to become ready.
+func rebootCaaDaemonset(oc *exutil.CLI) error {
+	Logf("Restarting %s daemonset", caaDaemonsetName)
+	_, err := oc.AsAdmin().WithoutNamespace().Run("set").Args(
+		"env", "-n", opNamespace, "ds", caaDaemonsetName,
+		"REBOOT="+getRandomString(),
+	).Output()
+	if err != nil {
+		return fmt.Errorf("failed to trigger restart of %s: %w", caaDaemonsetName, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
+		status, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"ds", caaDaemonsetName, "-n", opNamespace,
+			"-o=jsonpath={.status.desiredNumberScheduled},{.status.numberReady}",
+		).Output()
+		if err != nil {
+			return false, nil
+		}
+		parts := strings.SplitN(status, ",", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[0] == parts[1] {
+			Logf("%s ready: %s/%s pods", caaDaemonsetName, parts[1], parts[0])
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// getConfigmapParamValue reads a single field from the peer-pods-cm configmap.
+func getConfigmapParamValue(oc *exutil.CLI, param string) (string, error) {
+	cmJSON, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"configmap", ppConfigMapName, "-n", opNamespace, "-o", "json",
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get %s: %w", ppConfigMapName, err)
+	}
+
+	val := gjson.Get(cmJSON, "data."+param)
+	if !val.Exists() {
+		return "", fmt.Errorf("%s does not have field %s", ppConfigMapName, param)
+	}
+
+	return val.String(), nil
 }
 
 // checkKataconfigPeerPods verifies that the kataconfig has enablePeerPods=true.
@@ -122,11 +230,7 @@ func checkRuntimeClass(oc *exutil.CLI) error {
 func validatePeerPodsSetup(oc *exutil.CLI, kcName, cloudPlatform string) error {
 	var failures []string
 
-	if err := checkPeerPodConfigMap(oc, cloudPlatform); err != nil {
-		failures = append(failures, err.Error())
-	}
-
-	if _, err := checkPodVMImageID(oc, cloudPlatform); err != nil {
+	if err := ensurePeerPodConfig(oc, cloudPlatform); err != nil {
 		failures = append(failures, err.Error())
 	}
 
@@ -147,16 +251,11 @@ func validatePeerPodsSetup(oc *exutil.CLI, kcName, cloudPlatform string) error {
 }
 
 // getPeerPodMetadataInstanceType queries the cloud metadata service from inside
-// the pod to retrieve the instance type. Requires the pod to have network
-// access to the cloud metadata endpoint (169.254.169.254). Peer-pod VMs always
-// have this access — it is how cloud-api-adaptor itself discovers instance
-// identity.
+// the pod to retrieve the instance type.
 func getPeerPodMetadataInstanceType(oc *exutil.CLI, namespace, podName, cloudPlatform string) (string, error) {
 	metadataCurl := map[string][]string{
 		"aws":   {"http://169.254.169.254/latest/meta-data/instance-type"},
 		"azure": {"-H", "Metadata:true", "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2023-07-01&format=text"},
-		// TODO: GCP metadata returns full resource path, needs parsing before comparison
-		// "gcp":   {"-H", "Metadata-Flavor: Google", "http://metadata.google.internal/computeMetadata/v1/instance/machine-type"},
 	}
 
 	args, ok := metadataCurl[cloudPlatform]

--- a/test/e2e/kata_peerpod_helpers.go
+++ b/test/e2e/kata_peerpod_helpers.go
@@ -1,15 +1,12 @@
 package kata
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/tidwall/gjson"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -152,35 +149,25 @@ func mergeCommaSeparated(current, required string) string {
 	return result
 }
 
-// rebootCaaDaemonset triggers a rolling restart of the CAA daemonset by
-// injecting a REBOOT env var, then waits for all pods to become ready.
+// rebootCaaDaemonset triggers a rolling restart of the CAA daemonset
+// and waits for the new generation to roll out.
 func rebootCaaDaemonset(oc *exutil.CLI) error {
 	Logf("Restarting %s daemonset", caaDaemonsetName)
-	_, err := oc.AsAdmin().WithoutNamespace().Run("set").Args(
-		"env", "-n", opNamespace, "ds", caaDaemonsetName,
-		"REBOOT="+getRandomString(),
+	_, err := oc.AsAdmin().WithoutNamespace().Run("rollout").Args(
+		"restart", "ds/"+caaDaemonsetName, "-n", opNamespace,
 	).Output()
 	if err != nil {
 		return fmt.Errorf("failed to trigger restart of %s: %w", caaDaemonsetName, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
-		status, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-			"ds", caaDaemonsetName, "-n", opNamespace,
-			"-o=jsonpath={.status.desiredNumberScheduled},{.status.numberReady}",
-		).Output()
-		if err != nil {
-			return false, nil
-		}
-		parts := strings.SplitN(status, ",", 2)
-		if len(parts) == 2 && parts[0] != "" && parts[0] == parts[1] {
-			Logf("%s ready: %s/%s pods", caaDaemonsetName, parts[1], parts[0])
-			return true, nil
-		}
-		return false, nil
-	})
+	output, err := oc.AsAdmin().WithoutNamespace().Run("rollout").Args(
+		"status", "ds/"+caaDaemonsetName, "-n", opNamespace, "--timeout=2m",
+	).Output()
+	if err != nil {
+		return fmt.Errorf("%s did not become ready after restart: %w (output: %s)", caaDaemonsetName, err, output)
+	}
+	Logf("%s rollout complete", caaDaemonsetName)
+	return nil
 }
 
 // getConfigmapParamValue reads a single field from the peer-pods-cm configmap.

--- a/test/e2e/kata_test.go
+++ b/test/e2e/kata_test.go
@@ -546,9 +546,12 @@ var _ = ginkgo.Describe("[sig-kata] Kata", ginkgo.Serial, func() {
 			ginkgo.Skip(fmt.Sprintf("C00347 image metadata verification not supported on %s", cloudPlatform))
 		}
 
-		imageID, err := checkPodVMImageID(oc, cloudPlatform)
-		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get image ID from peer-pods-cm")
-		Logf("Image ID from configmap: %v", imageID)
+		field, ok := imageIDField[cloudPlatform]
+		if !ok {
+			ginkgo.Skip(fmt.Sprintf("C00347 no image ID field mapping for platform %s", cloudPlatform))
+		}
+		imageID, err := getConfigmapParamValue(oc, field)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to get %s from peer-pods-cm", field))
 
 		ginkgo.By("Deploying peerpod with image annotation")
 		pod := NewPodDescription(&testrun, "example-347")


### PR DESCRIPTION
## Description

Replace `checkPeerPodConfigMap()` and `checkPodVMImageID()` with a single `ensurePeerPodConfig()` that validates all required configmap fields and patches missing defaults (instance types, tags) before tests run.

**Problem**: Peer-pod tests C00099, C00131, C00320, C00347 fail when `peer-pods-cm` is missing required values (e.g. `AZURE_INSTANCE_SIZES` doesn't contain the instance type the test needs).

**Solution**: A declarative config map per cloud platform where:
- Empty value = field must exist and be non-empty (fail setup if missing)
- Non-empty value = field is patched if missing or extended if incomplete

When any field is patched, the CAA daemonset is restarted and verified healthy before tests proceed. Comma-separated values are merged order-insensitively to avoid unnecessary restarts.

## What was done

- Unified `checkPeerPodConfigMap()` + `checkPodVMImageID()` into `ensurePeerPodConfig()`
- Added `mergeCommaSeparated()` for order-insensitive list extension
- Added `rebootCaaDaemonset()` for CAA restart with readiness polling
- Switched `getConfigmapParamValue()` from `-o=jsonpath={.data}` to `-o json` + gjson for reliability
- Updated C00347 to use `getConfigmapParamValue()` with `imageIDField` map

## How to verify

```bash
cd test/e2e
go build ./...
go vet ./...
```

Validated on live Azure cluster — C00099, C00131, C00320, C00347 all pass.

## Changelog description

Unify peer-pods configmap validation: auto-patch missing instance types and tags, restart CAA only when needed.